### PR TITLE
Make subtypes of `Text` such as `Name[x]` digestible

### DIFF
--- a/lib/gastronomy/src/core/gastronomy.Digestible.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestible.scala
@@ -97,7 +97,7 @@ object Digestible extends Derivable[Digestible]:
   given char: Char is Digestible =
     (digestion, char) => digestion.append(IArray((char >> 8).toByte, char.toByte))
 
-  given text: Text is Digestible =
+  given text: [text <: Text] => text is Digestible =
     (digestion, text) => digestion.append(text.bytes(using charEncoders.utf8))
 
   given bytes: Bytes is Digestible = _.append(_)


### PR DESCRIPTION
Due to insufficient variance, `Name[x]`s, which are subtypes of `Text`, were not digestible. This makes them so.