### PR TITLE
Export `filesystemTraversal.*` values

### DIFF
--- a/lib/galilei/src/core/galilei-core.scala
+++ b/lib/galilei/src/core/galilei-core.scala
@@ -66,6 +66,9 @@ extension [target: Openable](value: target)
 
       target.open(value, lambda, options)
 
+package filesystemTraversal:
+  given preOrder: TraversalOrder = TraversalOrder.PreOrder
+  given postOrder: TraversalOrder = TraversalOrder.PostOrder
 
 extension [platform: System](path: Path on platform)
 

--- a/lib/galilei/src/core/soundness+galilei-core.scala
+++ b/lib/galilei/src/core/soundness+galilei-core.scala
@@ -32,16 +32,20 @@
                                                                                                   */
 package soundness
 
-export galilei .
-  { CopyAttributes, Makable, CreateNonexistent, CreateNonexistentParents, DeleteRecursively,
-    DereferenceSymlinks, Entry, FilesystemAttribute, Handle, IoError, IoEvent, MoveAtomically,
-    Openable, OverwritePreexisting, ReadAccess, Socket, Symlink, TraversalOrder, Volume,
-    WriteAccess, WriteSynchronously, C, D, open, javaPath, javaFile, children, descendants, size,
-    delete, wipe, volume, hardLinkTo, entry, copyTo, copyInto, /*renameTo, */moveTo, moveInto,
-    symlinkTo, symlinkInto, modified, accessed, readable, writable, hidden, touch, make, created,
-    executable, hardLinks, exists }
+export galilei
+       . { CopyAttributes, Makable, CreateNonexistent, CreateNonexistentParents, DeleteRecursively,
+           DereferenceSymlinks, Entry, FilesystemAttribute, Handle, IoError, IoEvent,
+           MoveAtomically, Openable, OverwritePreexisting, ReadAccess, Socket, Symlink,
+           TraversalOrder, Volume, WriteAccess, WriteSynchronously, C, D, open, javaPath, javaFile,
+           children, descendants, size, delete, wipe, volume, hardLinkTo, entry, copyTo, copyInto,
+           moveTo, moveInto, symlinkTo, symlinkInto, modified, accessed, readable, writable, hidden,
+           touch, make, created, executable, hardLinks, exists }
 
 package filesystemOptions:
-  export galilei.filesystemOptions.{readAccess, writeAccess, dereferenceSymlinks, moveAtomically,
-      copyAttributes, deleteRecursively, overwritePreexisting, createNonexistentParents,
-      createNonexistent, writeSynchronously}
+  export galilei.filesystemOptions
+         . { readAccess, writeAccess, dereferenceSymlinks, moveAtomically, copyAttributes,
+             deleteRecursively, overwritePreexisting, createNonexistentParents, createNonexistent,
+             writeSynchronously }
+
+package filesystemTraversal:
+  export galilei.filesystemTraversal.{preOrder, postOrder}

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -117,6 +117,10 @@ case class Relative(ascent: Int, descent: List[Text] = Nil):
         check[tail, system](path.tail).unit
 
       case EmptyTuple =>
+        ()
+
+      case _ =>
+        path.each(summonInline[Text is Admissible on system].check(_))
 
   inline def on[system]: Relative of Subject under Constraint on system =
     check[Subject, system](descent.to(List))


### PR DESCRIPTION
Provide an easy way to choose how `descendants` should traverse a filesystem.