### PR TITLE
Provide `idempotent` blocks that only execute on the first evaluation

### DIFF
--- a/lib/digression/src/core/digression-core.scala
+++ b/lib/digression/src/core/digression-core.scala
@@ -34,6 +34,7 @@ package digression
 
 import anticipation.*
 import fulminate.*
+import rudiments.*
 
 extension (error: Throwable) def stackTrace: StackTrace = StackTrace(error)
 
@@ -41,3 +42,6 @@ extension (inline context: StringContext)
   inline def fqcn(): Fqcn = ${Digression.fqcn('context)}
 
 given realm: Realm = realm"digression"
+
+def idempotent(lambda: => Unit)(using codepoint: Codepoint): Unit =
+  Codepoint.idempotentActions.computeIfAbsent(codepoint, void => lambda)

--- a/lib/digression/src/core/digression.Codepoint.scala
+++ b/lib/digression/src/core/digression.Codepoint.scala
@@ -34,10 +34,15 @@ package digression
 
 import language.experimental.pureFunctions
 
+import java.util.concurrent as juc
+
 import anticipation.*
 
 object Codepoint:
   inline given default: Codepoint = ${Digression.location}
+
+  private[digression] val idempotentActions: juc.ConcurrentHashMap[Codepoint, Unit] =
+    juc.ConcurrentHashMap()
 
 case class Codepoint(source: Text, line: Int):
   def text: Text = Text(s"${source.s.split("/").nn.last.nn}:$line")

--- a/lib/digression/src/core/digression.Digression.scala
+++ b/lib/digression/src/core/digression.Digression.scala
@@ -32,13 +32,13 @@
                                                                                                   */
 package digression
 
-import anticipation.*
-import contingency.*
-import proscenium.*
+import language.experimental.pureFunctions
 
 import scala.quoted.*
 
-import language.experimental.pureFunctions
+import anticipation.*
+import contingency.*
+import proscenium.*
 
 object Digression:
   def location: Macro[Codepoint] =

--- a/lib/digression/src/core/soundness+digression-core.scala
+++ b/lib/digression/src/core/soundness+digression-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export digression.{Codepoint, Fqcn, FqcnError, StackTrace, fqcn, stackTrace}
+export digression.{Codepoint, Fqcn, FqcnError, StackTrace, fqcn, stackTrace, idempotent}


### PR DESCRIPTION
Sometimes we want to run some code exactly once per the number of times it appears in the code (regardless of the context in which it runs). Here is an `idempotent` block that makes that possible:

```scala
def run(): Unit =
  idempotent:
    println("runs only the first time")

run()
run()
run()
```

This is particularly useful when we require global idempotency, but also require some additional context to perform the computation that's not global.