### PR TITLE
Fix classpath paths

### DIFF
--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -47,7 +47,8 @@ import serpentine.*
 import turbulence.*
 import vacuous.*
 
-object Classpath:
+object Classpath extends Root(t""):
+  type Plane = Classpath
   type Rules = MustNotContain["/"] & MustNotMatch["[0-9].*"] & MustMatch["[a-zA-Z0-9_$.]+"]
 
   erased given nominative: Classpath is Nominative under Rules = !!
@@ -68,13 +69,6 @@ object Classpath:
 
   given substantiable: (classloader: Classloader) => (Path on Classpath) is Substantiable =
     path => classloader.java.getResourceAsStream(path.encode.s) != null
-
-  @targetName("child")
-  infix def / (child: String)
-  : Path on Classpath of Mono[child.type] under Classpath raises NameError =
-
-      Path.of[Classpath, Classpath, Mono[child.type]](t"", child)
-
 
   def apply(classloader: jn.URLClassLoader): Classpath =
     val entries = classloader.getURLs.nn.to(List).map(_.nn).flatMap(ClasspathEntry(_).option)

--- a/lib/serpentine/src/core/serpentine.Admissible.scala
+++ b/lib/serpentine/src/core/serpentine.Admissible.scala
@@ -54,7 +54,8 @@ object Admissible:
 
       case _ => provide[Tactic[NameError]](Name[system](_))
 
-  inline given admissible: [string <: Label, system] => (nominative: system is Nominative) => string is Admissible on system =
+  inline given admissible: [string <: Label, system] => (nominative: system is Nominative)
+         =>  string is Admissible on system =
     Admissible[string, system]({ void => Name.verify[string, system] })
 
 


### PR DESCRIPTION
The Serpentine changes weren't fully integrated into Hellenism, and `Classpath`-based paths weren't working correctly: they required error handling, even for statically-known paths.

That issue is now fixed.