### PR TITLE
Make it possible to include `Optional` values embedded in HTML

### DIFF
--- a/lib/honeycomb/src/core/honeycomb-core.scala
+++ b/lib/honeycomb/src/core/honeycomb-core.scala
@@ -45,6 +45,6 @@ extension (context: StringContext)
   def cls(): CssClass = CssClass(context.parts.head.tt)
   def id(): DomId = DomId(context.parts.head.tt)
 
-type Html[+child <: Label] = Node[child] | Text | Int | HtmlXml
+type Html[+child <: Label] = Node[child] | Text | Unset.type | HtmlXml
 
 type Attributes = Map[String, Unset.type | Text]

--- a/lib/honeycomb/src/core/honeycomb.ClearTag.scala
+++ b/lib/honeycomb/src/core/honeycomb.ClearTag.scala
@@ -48,7 +48,7 @@ case class ClearTag[+name <: Label, child <: Label, attribute <: Label]
 extends Node[name], Dynamic:
 
   def attributes: Attributes = Map()
-  def children: Seq[Node[?] | Text | Int | HtmlXml] = Nil
+  def children: Seq[Node[?] | Text | Unset.type | HtmlXml] = Nil
   def label: Text = labelString.tt
 
 

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -35,13 +35,14 @@ package honeycomb
 import anticipation.*
 import gossamer.*
 import proscenium.*
+import vacuous.*
 
 import language.dynamics
 
 object Html extends Node["html"]:
   def label: Text = t"html"
   def attributes: Attributes = Map()
-  def children: Seq[Node[?] | Text | Int | HtmlXml] = Nil
+  def children: Seq[Node[?] | Text | Unset.type | HtmlXml] = Nil
 
   def apply(head: Node["head"], body: Node["body"]): Element["html"] =
     Element(label.s, Map(), Seq(head, body))

--- a/lib/honeycomb/src/core/honeycomb.HtmlSerializer.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlSerializer.scala
@@ -115,8 +115,8 @@ object HtmlSerializer:
 
             if text.chars.last.isWhitespace then append(t" ")
 
-      case int: Int =>
-        next(int.show, verbatim)
+      case Unset =>
+        ()
 
 
     append(t"<!DOCTYPE html>\n")

--- a/lib/honeycomb/src/core/honeycomb.Node.scala
+++ b/lib/honeycomb/src/core/honeycomb.Node.scala
@@ -41,8 +41,8 @@ import vacuous.*
 object Node:
   given html: [html <: Html[?]] => html is Showable = html => html.absolve match
     case text: Text    => text
-    case int: Int      => int.show
     case node: Node[?] => node.show
+    case Unset         => t""
 
   given seq: Seq[Html[?]] is Showable = _.map(_.show).join
 
@@ -60,13 +60,16 @@ object Node:
     else t"<${item.label}$filling>${item.children.map(_.show).join}</${item.label}>"
 
 
-  def apply(label0: Text, attributes0: Attributes, children0: Seq[Node[?] | Text | Int | HtmlXml])
+  def apply
+       (label0:      Text,
+        attributes0: Attributes,
+        children0:   Seq[Node[?] | Text | Unset.type | HtmlXml])
   : Html[?] =
 
       new Node:
         def label = label0
         def attributes = attributes0
-        def children: Seq[Node[?] | Text | Int | HtmlXml] = children0
+        def children: Seq[Node[?] | Text | Unset.type | HtmlXml] = children0
 
 
 trait Node[+name <: Label]:

--- a/lib/honeycomb/src/core/honeycomb.Renderable.scala
+++ b/lib/honeycomb/src/core/honeycomb.Renderable.scala
@@ -42,11 +42,10 @@ object Renderable:
   import html5.Phrasing
   given showable: [value: Showable] => value is Renderable into Phrasing = value => List(value.show)
 
-  given message: Message is Renderable into Phrasing = message =>
-    message.segments.flatMap:
-      case message: Message => message.html
-      case text: Text       => List(text)
-      case _                => Nil
+  given message: Message is Renderable into Phrasing = _.segments.flatMap:
+    case message: Message => message.html
+    case text: Text       => List(text)
+    case _                => Nil
 
 
   given abstractable: [value: Abstractable across HtmlContent into List[Sgml]]

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -48,7 +48,7 @@ open case class Tag[+name <: Label, child <: Label, attribute <: Label]
 extends Node[name], Dynamic:
 
   def attributes: Attributes = Map()
-  def children: Seq[Node[?] | Text | Int | HtmlXml] = Nil
+  def children: Seq[Node[?] | Text | Unset.type | HtmlXml] = Nil
   def label: Text = labelString.tt
 
   def preset(presetAttributes: (String, Text)*): Tag[name, child, attribute] =

--- a/lib/honeycomb/src/core/soundness+honeycomb-core.scala
+++ b/lib/honeycomb/src/core/soundness+honeycomb-core.scala
@@ -35,4 +35,5 @@ package soundness
 export honeycomb
 . { cls, id, Autocomplete, Capture, ClearTag, Crossorigin, CssClass, DomId, Element, HDir,
     Html, html5, HtmlAttribute, HtmlDoc, HtmlSerializer, HtmlXml, HttpEquiv, Kind, Method, Node,
-    Preload, Rel, Rev, Sandbox, Scope, Shape, StartTag, Tag, Target, Wrap, html, html4, Attributes }
+    Preload, Rel, Rev, Sandbox, Scope, Shape, StartTag, Tag, Target, Wrap, html, html4, Attributes,
+    Renderable }

--- a/lib/punctuation/src/html/punctuation.HtmlTranslator.scala
+++ b/lib/punctuation/src/html/punctuation.HtmlTranslator.scala
@@ -145,7 +145,7 @@ open class HtmlTranslator(embeddings: Embedding*) extends Translator:
       def interactive(node: Html[Phrasing]): Html[NonInteractive] = node.absolve match
         case node: Node[NonInteractive @unchecked] => node
         case text: Text                            => text
-        case int: Int                              => int
+        case Unset                                 => t""
 
       val children: Seq[Html[NonInteractive]] = nonInteractive(content).map(interactive(_))
 


### PR DESCRIPTION
`Optional` values were not permitted inside HTML before, while `Int` values were. This reverses the situation.