### PR TITLE
Rename `Rfc3986` to `UrlSpace`

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
@@ -166,15 +166,15 @@ object HtmlAttribute:
   given href2: [url: Abstractable across Urls to Text] => ("href" is HtmlAttribute[url]) =
     _.generic
 
-  inline given href3: [topic, path <: Path of topic under %.type] => Rfc3986 is System
+  inline given href3: [topic, path <: Path of topic under %.type] => UrlSpace is System
          => ("href" is HtmlAttribute[path]) =
-    _.on[Rfc3986].encode
+    _.on[UrlSpace].encode
 
-  inline given href4: [topic, path <: Path of topic] => Rfc3986 is System
+  inline given href4: [topic, path <: Path of topic] => UrlSpace is System
          => ("href" is HtmlAttribute[path]) =
-    _.on[Rfc3986].encode
+    _.on[UrlSpace].encode
 
-  inline given href4: [path <: Path on Rfc3986] => ("href" is HtmlAttribute[path]) = _.encode
+  inline given href4: [path <: Path on UrlSpace] => ("href" is HtmlAttribute[path]) = _.encode
 
   // Needs to be provided by Cosmopolite
   given hreflang: ("hreflang" is HtmlAttribute[Text]) = identity(_)
@@ -249,13 +249,13 @@ object HtmlAttribute:
 
   given src3: [url: Abstractable across Urls to Text] => ("src" is HtmlAttribute[url]) = _.generic
 
-  inline given src4: [topic, path <: Path of topic under %.type] => Rfc3986 is System
+  inline given src4: [topic, path <: Path of topic under %.type] => UrlSpace is System
          => ("src" is HtmlAttribute[path]) =
-    _.on[Rfc3986].encode
+    _.on[UrlSpace].encode
 
-  inline given src5: [topic, path <: Path of topic] => Rfc3986 is System
+  inline given src5: [topic, path <: Path of topic] => UrlSpace is System
          => ("src" is HtmlAttribute[path]) =
-    _.on[Rfc3986].encode
+    _.on[UrlSpace].encode
 
 
   given srcdoc: ("srcdoc" is HtmlAttribute[Html[?]]) = _.show

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -261,7 +261,7 @@ object Http:
 
     inline def request: this.type = this
 
-    lazy val path: Relative on Rfc3986 = location.decode[Relative on Rfc3986]
+    lazy val path: Relative on UrlSpace = location.decode[Relative on UrlSpace]
 
     def on[scheme <: "http" | "https"](origin: Origin[scheme]): HttpUrl =
       Url[scheme](origin, target)

--- a/lib/urticose/src/url/soundness+urticose-url.scala
+++ b/lib/urticose/src/url/soundness+urticose-url.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export urticose
-. { url, email, host, Authority, Scheme, Url, UrlError, HttpUrl, UrlFragment, Origin, Rfc3986 }
+. { url, email, host, Authority, Scheme, Url, UrlError, HttpUrl, UrlFragment, Origin, UrlSpace }

--- a/lib/urticose/src/url/urticose.Rfc3986.scala
+++ b/lib/urticose/src/url/urticose.Rfc3986.scala
@@ -39,14 +39,14 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 
-erased trait Rfc3986
+erased trait UrlSpace
 
-object Rfc3986:
-  given submissible: (%.type is Submissible on Rfc3986) = void => ()
-  given admissible: [text <: Text] => (text is Admissible on Rfc3986) = void => ()
-  given admissible2: [string <: String] => (string is Admissible on Rfc3986) = void => ()
+object UrlSpace:
+  given submissible: (%.type is Submissible on UrlSpace) = void => ()
+  given admissible: [text <: Text] => (text is Admissible on UrlSpace) = void => ()
+  given admissible2: [string <: String] => (string is Admissible on UrlSpace) = void => ()
 
-  given system: Rfc3986 is System:
+  given system: UrlSpace is System:
     type UniqueRoot = false
     val separator: Text = t"/"
     val self: Text = t"."

--- a/lib/urticose/src/url/urticose.Url.scala
+++ b/lib/urticose/src/url/urticose.Url.scala
@@ -58,7 +58,7 @@ class Url[+scheme <: Label]
         val fragment:  Optional[Text] = Unset)
 extends Root(t"${origin.scheme}:${origin.authority.lay(t"")(t"//"+_.show)}$location"):
 
-  type Plane = Rfc3986
+  type Plane = UrlSpace
   type Topic = Zero
 
   def scheme: Scheme[scheme] = origin.scheme


### PR DESCRIPTION
I came to strongly dislike naming the namespace of URLs after the RFC that specifies it.
