### PR TITLE
Add an `unapply` method for `Argument`

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -46,6 +46,8 @@ object Argument:
     case Full, FlagSuffix, EqualityPrefix, EqualitySuffix
     case CharFlag(index: Ordinal)
 
+  def unapply(argument: Argument): Some[Text] = Some(argument())
+
   given inspectable: Argument is Inspectable = argument =>
     t"${argument.position}: ${argument.value.inspect} / ${argument.format} => ${argument().inspect}"
 


### PR DESCRIPTION
This should make it easier to pattern match against `Argument`s, for example when writing an `Interpretable` instance.
