### PR TITLE
Make most `Realm` givens private

### DIFF
--- a/lib/abacist/src/core/abacist.Abacist.scala
+++ b/lib/abacist/src/core/abacist.Abacist.scala
@@ -45,7 +45,7 @@ import rudiments.*
 import symbolism.*
 import vacuous.*
 
-given realm: Realm = realm"abacist"
+private given realm: Realm = realm"abacist"
 
 object Abacist:
   import Quantitative.*

--- a/lib/anthology/src/core/anthology-core.scala
+++ b/lib/anthology/src/core/anthology-core.scala
@@ -35,4 +35,4 @@ package anthology
 import anticipation.*
 import fulminate.*
 
-given realm: Realm = realm"anthology"
+private given realm: Realm = realm"anthology"

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -45,7 +45,7 @@ import proscenium.*
 import rudiments.*
 import wisteria.*
 
-given Realm = realm"austronesian"
+private given Realm = realm"austronesian"
 
 object Austronesian2:
   object EncodableDerivation extends Derivation[[entity] =>> entity is Encodable in Pojo]:

--- a/lib/aviation/src/core/aviation-core.scala
+++ b/lib/aviation/src/core/aviation-core.scala
@@ -51,7 +51,7 @@ export Aviation2.{Instant, Duration}
 export Aviation.{Date, Year, Day, Anniversary, WorkingDays}
 export Month.{Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec}
 
-given realm: Realm = realm"aviation"
+private given realm: Realm = realm"aviation"
 
 package timestampDecoders:
   given iso8601: Tactic[TimeError] => Instant is Decodable in Text = Iso8601.parse(_)

--- a/lib/cardinality/src/core/cardinality.Cardinality.scala
+++ b/lib/cardinality/src/core/cardinality.Cardinality.scala
@@ -54,7 +54,7 @@ object Cardinality:
      [Value1Type <: Double, Value2Type <: Double, Value3Type <: Double, Value4Type <: Double] =
     Max[Max[Value1Type, Value2Type], Max[Value3Type, Value4Type]]
 
-  given realm: Realm = realm"cardinality"
+  private given realm: Realm = realm"cardinality"
 
 
   def apply[left <: Double: Type, right <: Double: Type](digits: Expr[String])

--- a/lib/cataclysm/src/core/cataclysm-core.scala
+++ b/lib/cataclysm/src/core/cataclysm-core.scala
@@ -39,7 +39,7 @@ import proscenium.*
 import rudiments.*
 import spectacular.*
 
-given realm: Realm = realm"cataclysm"
+private given realm: Realm = realm"cataclysm"
 
 private[cataclysm] type Label = String & Singleton
 

--- a/lib/cellulose/src/test/cellulose.Tests.scala
+++ b/lib/cellulose/src/test/cellulose.Tests.scala
@@ -62,7 +62,7 @@ case class Privilege(name: Text, grant: Boolean)
 
 object Tests extends Suite(m"Cellulose tests (Part 1)"):
 
-  given Realm = realm"tests"
+  private given Realm = realm"tests"
 
   def run(): Unit = supervise:
     import CodlToken.*
@@ -1054,7 +1054,7 @@ object Tests extends Suite(m"Cellulose tests (Part 1)"):
 
 object Tests2 extends Suite(m"Cellulose tests (Part 2)"):
 
-  given Realm = realm"tests"
+  private given Realm = realm"tests"
 
   def run(): Unit = supervise:
     def roundtrip[T: {Encodable in Codl, Decodable in Codl, CodlSchematic}](value: T): T = value.codl.as[T]

--- a/lib/contextual/src/core/contextual.Interpolator.scala
+++ b/lib/contextual/src/core/contextual.Interpolator.scala
@@ -43,7 +43,7 @@ import vacuous.*
 
 trait Interpolator[input, state, result]:
   given canThrow: CanThrow[InterpolationError] = !!
-  given realm: Realm = realm"contextual"
+  private given realm: Realm = realm"contextual"
 
   protected def initial: state
   protected def parse(state: state, next: Text): state

--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -68,7 +68,7 @@ package strategies:
     def abort(error: Diagnostics ?=> error): Nothing = throw error
     def certify(): Unit = ()
 
-given realm: Realm = realm"contingency"
+private given realm: Realm = realm"contingency"
 
 def certify[error <: Exception: Tactic](): Unit = error.certify()
 

--- a/lib/digression/src/core/digression-core.scala
+++ b/lib/digression/src/core/digression-core.scala
@@ -41,7 +41,7 @@ extension (error: Throwable) def stackTrace: StackTrace = StackTrace(error)
 extension (inline context: StringContext)
   inline def fqcn(): Fqcn = ${Digression.fqcn('context)}
 
-given realm: Realm = realm"digression"
+private given realm: Realm = realm"digression"
 
 def idempotent(lambda: => Unit)(using codepoint: Codepoint): Unit =
   Codepoint.idempotentActions.computeIfAbsent(codepoint, void => lambda)

--- a/lib/dissonance/src/test/dissonance.Tests.scala
+++ b/lib/dissonance/src/test/dissonance.Tests.scala
@@ -47,7 +47,7 @@ import proximityMeasures.levenshteinDistance
 import strategies.throwUnsafely
 
 object Tests extends Suite(m"Dissonance tests"):
-  given Realm = realm"tests"
+  private given Realm = realm"tests"
 
   def run(): Unit =
     suite(m"Diff tests"):

--- a/lib/distillate/src/core/distillate.Distillate.scala
+++ b/lib/distillate/src/core/distillate.Distillate.scala
@@ -39,7 +39,7 @@ import fulminate.*
 import proscenium.*
 
 object Distillate:
-  given realm: Realm = realm"distillate"
+  private given realm: Realm = realm"distillate"
   def enumerable[enumeration <: reflect.Enum: Type]: Macro[enumeration is Enumerable] =
     import quotes.reflect.*
 

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -61,7 +61,7 @@ import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.enabled
 
 object Installer:
-  given realm: Realm = realm"ethereal"
+  private given realm: Realm = realm"ethereal"
 
   object Result:
     given communicable: Result is Communicable =

--- a/lib/eucalyptus/src/core/tmp-eucalyptus.scala
+++ b/lib/eucalyptus/src/core/tmp-eucalyptus.scala
@@ -41,7 +41,7 @@ package eucalyptus
 // import scala.quoted.*
 
 // object Eucalyptus:
-//   given realm: Realm = realm"eucalyptus"
+//   private given realm: Realm = realm"eucalyptus"
 
 //   def record[message: Type, text: Type]
 //        (level:          Expr[Level],

--- a/lib/exoskeleton/src/args/exoskeleton-args.scala
+++ b/lib/exoskeleton/src/args/exoskeleton-args.scala
@@ -39,7 +39,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 
-given realm: Realm = realm"exoskeleton"
+private given realm: Realm = realm"exoskeleton"
 
 package interpreters:
   given simple: Interpreter:

--- a/lib/gossamer/src/core/gossamer.Gossamer.scala
+++ b/lib/gossamer/src/core/gossamer.Gossamer.scala
@@ -44,7 +44,7 @@ import vacuous.*
 import scala.quoted.*
 
 object Gossamer:
-  given realm: Realm = realm"gossamer"
+  private given realm: Realm = realm"gossamer"
 
   object opaques:
     opaque type Ascii = anticipation.Bytes

--- a/lib/guillotine/src/core/guillotine-core.scala
+++ b/lib/guillotine/src/core/guillotine-core.scala
@@ -37,7 +37,7 @@ import language.experimental.pureFunctions
 import anticipation.*
 import fulminate.*
 
-given realm: Realm = realm"guillotine"
+private given realm: Realm = realm"guillotine"
 
 extension (inline context: StringContext)
   transparent inline def sh(inline parts: Any*): Any = ${Guillotine.sh('context, 'parts)}

--- a/lib/hieroglyph/src/core/hieroglyph.Hieroglyph.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.Hieroglyph.scala
@@ -39,7 +39,7 @@ import fulminate.*
 import proscenium.*
 
 object Hieroglyph:
-  given realm: Realm = realm"hieroglyph"
+  private given realm: Realm = realm"hieroglyph"
   opaque type CharRange = Long
 
   object CharRange:

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -41,7 +41,7 @@ import vacuous.*
 import scala.quoted.*
 
 object Honeycomb:
-  given realm: Realm = realm"honeycomb"
+  private given realm: Realm = realm"honeycomb"
 
 
   def read[name <: Label: Type, child <: Label: Type, result <: Label: Type]

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -48,7 +48,7 @@ import fulminate.*
 import symbolism.*
 
 object Hypotenuse:
-  given realm: Realm = realm"hypotenuse"
+  private given realm: Realm = realm"hypotenuse"
 
   type Bits[bits <: 8 | 16 | 32 | 64] <: B8 | B16 | B32 | B64 = bits match
     case 8  => B8

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
@@ -44,7 +44,7 @@ import proscenium.*
 import rudiments.*
 
 object Hypotenuse2:
-  given realm: Realm = realm"hypotenuse"
+  private given realm: Realm = realm"hypotenuse"
 
   def bin(expr: Expr[StringContext]): Macro[AnyVal] =
     import quotes.reflect.*

--- a/lib/inimitable/src/core/inimitable.Inimitable.scala
+++ b/lib/inimitable/src/core/inimitable.Inimitable.scala
@@ -40,7 +40,7 @@ import fulminate.*
 import proscenium.*
 
 object Inimitable:
-  given realm: Realm = realm"inimitable"
+  private given realm: Realm = realm"inimitable"
 
   def uuid(expr: Expr[StringContext]): Macro[Uuid] =
     val uuid = abortive(Uuid.parse(expr.valueOrAbort.parts.head.tt))

--- a/lib/kaleidoscope/src/core/kaleidoscope.Kaleidoscope.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Kaleidoscope.scala
@@ -45,7 +45,7 @@ import proscenium.*
 import vacuous.*
 
 object Kaleidoscope:
-  given realm: Realm = realm"kaleidoscope"
+  private given realm: Realm = realm"kaleidoscope"
 
   def glob(context: Expr[StringContext]): Macro[Any] =
     val parts = context.value.get.parts.map(Text(_)).map(Glob.parse(_).regex.s).to(List)

--- a/lib/legerdemain/src/core/legerdemain-core.scala
+++ b/lib/legerdemain/src/core/legerdemain-core.scala
@@ -42,7 +42,7 @@ import vacuous.*
 
 import html5.*
 
-given realm: Realm = realm"legerdemain"
+private given realm: Realm = realm"legerdemain"
 
 
 def elicit[value: Formulaic]

--- a/lib/mercator/src/core/mercator-core.scala
+++ b/lib/mercator/src/core/mercator-core.scala
@@ -37,7 +37,7 @@ import fulminate.*
 
 import scala.collection.BuildFrom
 
-given realm: Realm = realm"mercator"
+private given realm: Realm = realm"mercator"
 
 extension [value, functor[_]](using functor: Functor[functor])(value: functor[value])
   def map[value2](lambda: value => value2): functor[value2] =

--- a/lib/merino/src/bench/merino.Benchmarks.scala
+++ b/lib/merino/src/bench/merino.Benchmarks.scala
@@ -89,7 +89,7 @@ object Benchmarks extends Suite(m"Merino tests"):
 
       . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)
 
-given realm: Realm = Realm(t"tests")
+private given realm: Realm = Realm(t"tests")
 
 lazy val jsonExample1 = """
 

--- a/lib/merino/src/test/merino.Tests.scala
+++ b/lib/merino/src/test/merino.Tests.scala
@@ -181,4 +181,4 @@ object Tests extends Suite(m"Merino tests"):
 
 
 
-given realm: Realm = Realm(t"tests")
+private given realm: Realm = Realm(t"tests")

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -42,7 +42,7 @@ import rudiments.*
 import scala.quoted.*
 import scala.compiletime.*
 
-given realm: Realm = realm"nomenclature"
+private given realm: Realm = realm"nomenclature"
 
 object Nomenclature2:
   def build(using Quotes)(todo: List[quotes.reflect.TypeRepr]): quotes.reflect.TypeRepr =

--- a/lib/octogenarian/src/core/octogenarian-core.scala
+++ b/lib/octogenarian/src/core/octogenarian-core.scala
@@ -47,7 +47,7 @@ import serpentine.*
 
 import GitError.Reason.*
 
-given realm: Realm = realm"octogenarian"
+private given realm: Realm = realm"octogenarian"
 
 package gitCommands:
   given environmentDefault: (WorkingDirectory, GitEvent is Loggable)

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -42,7 +42,7 @@ import scala.compiletime.*
 import language.dynamics
 
 object Panopticon:
-  given realm: Realm = realm"panopticon"
+  private given realm: Realm = realm"panopticon"
   opaque type Lens[from, path <: Tuple, to] = Int
   opaque type InitLens[from] = Int
 

--- a/lib/probably/src/core/probably-core.scala
+++ b/lib/probably/src/core/probably-core.scala
@@ -45,7 +45,7 @@ import proscenium.*
 import symbolism.*
 import vacuous.*
 
-given realm: Realm = realm"probably"
+private given realm: Realm = realm"probably"
 
 given decimalizer: Decimalizer = Decimalizer(3)
 

--- a/lib/profanity/src/core/profanity-core.scala
+++ b/lib/profanity/src/core/profanity-core.scala
@@ -39,7 +39,7 @@ import parasite.*
 import proscenium.*
 import turbulence.*
 
-given realm: Realm = realm"profanity"
+private given realm: Realm = realm"profanity"
 
 given stdio: (terminal: Terminal) => Stdio = terminal.stdio
 

--- a/lib/quantitative/src/core/quantitative.Quantitative2.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative2.scala
@@ -44,7 +44,7 @@ import scala.quoted.*
 import scala.compiletime.*
 
 trait Quantitative2:
-  given realm: Realm = realm"quantitative"
+  private given realm: Realm = realm"quantitative"
 
   case class UnitPower(ref: UnitRef, power: Int)
 

--- a/lib/revolution/src/core/revolution.Revolution.scala
+++ b/lib/revolution/src/core/revolution.Revolution.scala
@@ -44,7 +44,7 @@ import proscenium.*
 import vacuous.*
 
 object Revolution:
-  given Realm(t"revolution")
+  private given Realm(t"revolution")
 
   def semver(context0: Expr[StringContext]): Macro[Semver] =
     val semver0 = context0.valueOrAbort match

--- a/lib/rudiments/src/core/rudiments.Rudiments.scala
+++ b/lib/rudiments/src/core/rudiments.Rudiments.scala
@@ -42,7 +42,7 @@ import symbolism.*
 import vacuous.*
 
 object Rudiments:
-  given realm: Realm = realm"rudiments"
+  private given realm: Realm = realm"rudiments"
   opaque type Memory = Long
   opaque type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
 

--- a/lib/scintillate/src/server/scintillate-core.scala
+++ b/lib/scintillate/src/server/scintillate-core.scala
@@ -93,7 +93,7 @@ def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.
 
 inline def request: Http.Request = infer[Http.Request]
 
-given realm: Realm = realm"scintillate"
+private given realm: Realm = realm"scintillate"
 
 extension (request: Http.Request)
   def as[body: Acceptable]: body = body.accept(request)

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -47,7 +47,7 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
-given Realm = Realm(t"serpentine")
+private given Realm = Realm(t"serpentine")
 
 object Path:
   @targetName("Root")

--- a/lib/surveillance/src/core/surveillance-core.scala
+++ b/lib/surveillance/src/core/surveillance-core.scala
@@ -53,4 +53,4 @@ extension [path: Abstractable across Paths to Text](paths: Iterable[path])
 
 export WatchEvent.{NewFile, NewDirectory, Modify, Delete}
 
-given realm: Realm = realm"surveillance"
+private given realm: Realm = realm"surveillance"

--- a/lib/tarantula/src/core/tarantula-core.scala
+++ b/lib/tarantula/src/core/tarantula-core.scala
@@ -35,6 +35,6 @@ package tarantula
 import anticipation.*
 import fulminate.*
 
-given realm: Realm = realm"tarantula"
+private given realm: Realm = realm"tarantula"
 
 def browser(using WebDriver#Session): WebDriver#Session = summon[WebDriver#Session]

--- a/lib/telekinesis/src/core/telekinesis-core.scala
+++ b/lib/telekinesis/src/core/telekinesis-core.scala
@@ -44,7 +44,7 @@ import vacuous.*
 
 import language.dynamics
 
-given realm: Realm = realm"telekinesis"
+private given realm: Realm = realm"telekinesis"
 
 package queryParameters:
   erased given arbitrary: [key <: Label, value] => key is Parametric to value = !!

--- a/lib/urticose/src/core/urticose.EmailAddress.scala
+++ b/lib/urticose/src/core/urticose.EmailAddress.scala
@@ -53,7 +53,7 @@ import scala.compiletime.*
 import EmailAddressError.Reason.*
 
 object EmailAddress:
-  given realm: Realm = realm"urticose"
+  private given realm: Realm = realm"urticose"
 
   given decodable: Tactic[EmailAddressError] => EmailAddress is Decodable in Text =
     EmailAddress.parse(_)

--- a/lib/urticose/src/core/urticose.Hostname.scala
+++ b/lib/urticose/src/core/urticose.Hostname.scala
@@ -50,7 +50,7 @@ import scala.quoted.*
 import HostnameError.Reason.*
 
 object Hostname:
-  given realm: Realm = realm"urticose"
+  private given realm: Realm = realm"urticose"
 
   given showable: Hostname is Showable = _.dnsLabels.map(_.show).join(t".")
 

--- a/lib/urticose/src/core/urticose.Urticose.scala
+++ b/lib/urticose/src/core/urticose.Urticose.scala
@@ -52,7 +52,7 @@ import scala.quoted.*
 import IpAddressError.Reason, Reason.*
 
 object Urticose:
-  given realm: Realm = realm"urticose"
+  private given realm: Realm = realm"urticose"
 
   private lazy val serviceNames: Map[(Boolean, Text), Int] =
     val stream =

--- a/lib/vacuous/src/core/vacuous-core.scala
+++ b/lib/vacuous/src/core/vacuous-core.scala
@@ -64,4 +64,4 @@ extension [value](value: value)
 extension [value](java: ju.Optional[value])
   def optional: Optional[value] = if java.isEmpty then Unset else java.get.nn
 
-given realm: Realm = realm"vacuous"
+private given realm: Realm = realm"vacuous"

--- a/lib/vicarious/src/core/vicarious-core.scala
+++ b/lib/vicarious/src/core/vicarious-core.scala
@@ -36,7 +36,7 @@ import anticipation.*
 import proscenium.*
 import fulminate.*
 
-given realm: Realm = realm"vicarious"
+private given realm: Realm = realm"vicarious"
 
 inline def catalog[key](key: key)[value](inline lambda: [field] => (field: field) => value)
    (using classTag: ClassTag[value])


### PR DESCRIPTION
Most libraries use a `Realm` at some point, though it should never be used outside of that library.

By making the `given` instances `private`, they should not leak.
