### PR TITLE
Eliminate warnings by removing `nn`s

### DIFF
--- a/lib/digression/src/core/digression.Codepoint.scala
+++ b/lib/digression/src/core/digression.Codepoint.scala
@@ -45,4 +45,4 @@ object Codepoint:
     juc.ConcurrentHashMap()
 
 case class Codepoint(source: Text, line: Int):
-  def text: Text = Text(s"${source.s.split("/").nn.last.nn}:$line")
+  def text: Text = Text(s"${source.s.split("/").nn.last}:$line")

--- a/lib/diuretic/src/core/diuretic.JavaIoFile.scala
+++ b/lib/diuretic/src/core/diuretic.JavaIoFile.scala
@@ -42,5 +42,5 @@ object JavaIoFile extends Abstractable, Instantiable:
   type Origin = Text
   type Result = Text
 
-  def apply(path: Text): ji.File = ji.File(path.s).nn
+  def apply(path: Text): ji.File = ji.File(path.s)
   def genericize(value: ji.File): Text = value.getAbsolutePath.nn.toString.tt

--- a/lib/diuretic/src/core/diuretic.JavaNetUrl.scala
+++ b/lib/diuretic/src/core/diuretic.JavaNetUrl.scala
@@ -43,4 +43,4 @@ object JavaNetUrl extends Abstractable, Instantiable:
   type Domain = Urls
 
   def genericize(value: jn.URL): Text = value.toString.tt
-  def apply(text: Text): jn.URL = jn.URI(text.s).nn.toURL().nn
+  def apply(text: Text): jn.URL = jn.URI(text.s).toURL().nn

--- a/lib/enigmatic/src/core/enigmatic.Rsa.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rsa.scala
@@ -58,7 +58,7 @@ class Rsa[bits <: 1024 | 2048: ValueOf]() extends Cipher, Encryption:
     keyFactory().generatePublic(spec).nn.getEncoded.nn.immutable(using Unsafe)
 
   def decrypt(bytes: Bytes, key: Bytes): Bytes =
-    val cipher = init().nn
+    val cipher = init()
 
     val privateKey =
       keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(key.mutable(using Unsafe)))
@@ -67,7 +67,7 @@ class Rsa[bits <: 1024 | 2048: ValueOf]() extends Cipher, Encryption:
     cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)
 
   def encrypt(bytes: Bytes, key: Bytes): Bytes =
-    val cipher = init().nn
+    val cipher = init()
     val publicKey = keyFactory().generatePublic(jss.X509EncodedKeySpec(key.mutable(using Unsafe)))
     cipher.init(jc.Cipher.ENCRYPT_MODE, publicKey)
     cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)

--- a/lib/fulminate/src/core/fulminate.Communicable.scala
+++ b/lib/fulminate/src/core/fulminate.Communicable.scala
@@ -61,7 +61,7 @@ object Communicable:
   given expr: [expr] => Quotes => Expr[expr] is Communicable = tpe => Message(tpe.show)
 
   given specializable: Specializable is Communicable = value =>
-    Message(value.getClass.nn.getName.nn.split("\\.").nn.last.nn.dropRight(1).toLowerCase.nn.tt)
+    Message(value.getClass.getName.nn.split("\\.").nn.last.nn.dropRight(1).toLowerCase.nn.tt)
 
   given listMessage: List[Message] is Communicable =
     messages => Message(List.fill(messages.size)("\n - ".tt) ::: List("".tt), messages)

--- a/lib/fulminate/src/core/fulminate.Error.scala
+++ b/lib/fulminate/src/core/fulminate.Error.scala
@@ -43,7 +43,7 @@ transparent abstract class Error(val message: Message, private val cause: Throwa
    (using val diagnostics: Diagnostics)
 extends Exception(message.text.s, cause, false, diagnostics.captureStack):
   this: Error =>
-  def fullClass: List[Text] = List(getClass.nn.getName.nn.split("\\.").nn.map(_.nn).map(Text(_))*)
+  def fullClass: List[Text] = List(getClass.getName.nn.split("\\.").nn.map(_.nn).map(Text(_))*)
   def className: Text = fullClass.last
   def component: Text = fullClass.head
 

--- a/lib/galilei/src/core/galilei.FilesystemAttribute.scala
+++ b/lib/galilei/src/core/galilei.FilesystemAttribute.scala
@@ -40,13 +40,13 @@ import spectacular.*
 
 object FilesystemAttribute:
   class Readable[plane: System](path: Path on plane):
-    def apply(): Boolean = jnf.Files.isReadable(jnf.Path.of(path.show.s).nn)
+    def apply(): Boolean = jnf.Files.isReadable(jnf.Path.of(path.show.s))
     def update(value: Boolean): Unit = path.javaFile.setReadable(value)
 
   class Writable[plane: System](path: Path on plane):
-    def apply(): Boolean = jnf.Files.isWritable(jnf.Path.of(path.show.s).nn)
+    def apply(): Boolean = jnf.Files.isWritable(jnf.Path.of(path.show.s))
     def update(value: Boolean): Unit = path.javaFile.setWritable(value)
 
   class Executable[plane <: Posix: System](path: Path on plane):
-    def apply(): Boolean = jnf.Files.isExecutable(jnf.Path.of(path.show.s).nn)
+    def apply(): Boolean = jnf.Files.isExecutable(jnf.Path.of(path.show.s))
     def update(value: Boolean): Unit = path.javaFile.setExecutable(value)

--- a/lib/hellenism/src/core/hellenism.ClasspathEntry.scala
+++ b/lib/hellenism/src/core/hellenism.ClasspathEntry.scala
@@ -42,10 +42,10 @@ import vacuous.*
 
 sealed trait ClasspathEntry:
   def javaUrl: jn.URL = this match
-    case ClasspathEntry.Directory(path) => ji.File(path.s).nn.toURI.nn.toURL.nn
-    case ClasspathEntry.Jar(path)       => ji.File(path.s).nn.toURI.nn.toURL.nn
-    case ClasspathEntry.Url(url)        => jn.URL(url.s).nn
-    case ClasspathEntry.JavaRuntime     => jn.URL("jrt:/").nn
+    case ClasspathEntry.Directory(path) => ji.File(path.s).toURI.nn.toURL.nn
+    case ClasspathEntry.Jar(path)       => ji.File(path.s).toURI.nn.toURL.nn
+    case ClasspathEntry.Url(url)        => jn.URL(url.s)
+    case ClasspathEntry.JavaRuntime     => jn.URL("jrt:/")
 
 object ClasspathEntry:
   case class Directory(path: Text) extends ClasspathEntry:
@@ -64,7 +64,7 @@ object ClasspathEntry:
       ClasspathEntry.JavaRuntime
 
     case t"file" =>
-      val path: Text = url.nn.getPath.nn.tt
+      val path: Text = url.getPath.nn.tt
       if path.ends(t"/") then ClasspathEntry.Directory(path) else ClasspathEntry.Jar(path)
 
     case t"http" | t"https" =>

--- a/lib/hypotenuse/src/core/hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse-core.scala
@@ -201,7 +201,7 @@ extension (byte: Byte)
   inline def hex: Text = JInt.toHexString(byte).nn.tt
 
   @targetName("base32Byte")
-  inline def base32: Text = JInt.toString(byte, 32).nn.tt
+  inline def base32: Text = JInt.toString(byte, 32).tt
 
   @targetName("binaryByte")
   inline def binary: Text = JInt.toBinaryString(byte).nn.tt
@@ -238,7 +238,7 @@ extension (short: Short)
   inline def hex: Text = JInt.toHexString(short).nn.tt
 
   @targetName("base32Short")
-  inline def base32: Text = JInt.toString(short, 32).nn.tt
+  inline def base32: Text = JInt.toString(short, 32).tt
 
   @targetName("binaryShort")
   inline def binary: Text = JInt.toBinaryString(short).nn.tt
@@ -275,7 +275,7 @@ extension (int: Int)
   inline def hex: Text = JInt.toHexString(int).nn.tt
 
   @targetName("base32Int")
-  inline def base32: Text = JInt.toString(int, 32).nn.tt
+  inline def base32: Text = JInt.toString(int, 32).tt
 
   @targetName("binaryInt")
   inline def binary: Text = JInt.toBinaryString(int).nn.tt
@@ -306,7 +306,7 @@ extension (long: Long)
   inline def hex: Text = JLong.toHexString(long).nn.tt
 
   @targetName("base32Long")
-  inline def base32: Text = JLong.toString(long, 32).nn.tt
+  inline def base32: Text = JLong.toString(long, 32).tt
 
   @targetName("binaryLong")
   inline def binary: Text = JLong.toBinaryString(long).nn.tt

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -360,7 +360,7 @@ object Hypotenuse:
     given fromDigits: FromDigits[U16]:
       inline def fromDigits(digits: String): U16 = ${Hypotenuse2.parseU16('digits)}
 
-    given textualizer: U16 is Textualizer = u16 => JShort.toUnsignedInt(u16).toString.nn.tt
+    given textualizer: U16 is Textualizer = u16 => JShort.toUnsignedInt(u16).toString.tt
     inline def apply(inline bits: B16): U16 = bits
 
 
@@ -422,7 +422,7 @@ object Hypotenuse:
     given fromDigits: FromDigits[U8]:
       inline def fromDigits(digits: String): U8 = ${Hypotenuse2.parseU8('digits)}
 
-    given textualizer: U8 is Textualizer = u8 => JByte.toUnsignedInt(u8).toString.nn.tt
+    given textualizer: U8 is Textualizer = u8 => JByte.toUnsignedInt(u8).toString.tt
     inline def apply(inline bits: B8): U8 = bits
 
     inline given orderable: U8 is Orderable:
@@ -565,7 +565,7 @@ object Hypotenuse:
     inline def hex: Text = JLong.toHexString(s64).nn.tt
 
     @targetName("base32S64")
-    inline def base32: Text = JLong.toString(s64, 32).nn.tt
+    inline def base32: Text = JLong.toString(s64, 32).tt
 
     @targetName("binaryS64")
     inline def binary: Text = JLong.toBinaryString(s64).nn.tt
@@ -623,7 +623,7 @@ object Hypotenuse:
     inline def hex: Text = JInt.toHexString(s32).nn.tt
 
     @targetName("base32S32")
-    inline def base32: Text = JInt.toString(s32, 32).nn.tt
+    inline def base32: Text = JInt.toString(s32, 32).tt
 
     @targetName("binaryS32")
     inline def binary: Text = JInt.toBinaryString(s32).nn.tt
@@ -681,7 +681,7 @@ object Hypotenuse:
     inline def hex: Text = JInt.toHexString(s16).nn.tt
 
     @targetName("base32S16")
-    inline def base32: Text = JInt.toString(s16, 32).nn.tt
+    inline def base32: Text = JInt.toString(s16, 32).tt
 
     @targetName("binaryS16")
     inline def binary: Text = JInt.toBinaryString(s16).nn.tt
@@ -742,7 +742,7 @@ object Hypotenuse:
     inline def hex: Text = JInt.toHexString(s8).nn.tt
 
     @targetName("base32S8")
-    inline def base32: Text = JInt.toString(s8, 32).nn.tt
+    inline def base32: Text = JInt.toString(s8, 32).tt
 
     @targetName("binaryS8")
     inline def binary: Text = JInt.toBinaryString(s8).nn.tt

--- a/lib/iridescence/src/core/iridescence.RgbHex.scala
+++ b/lib/iridescence/src/core/iridescence.RgbHex.scala
@@ -49,9 +49,9 @@ object RgbHex extends Interpolator[Nothing, Option[Rgb24], Rgb24]:
     else if next.s.length == 6 && next.s.all: char =>
       char.isDigit || ((char | 32) >= 'a' && (char | 32) <= 'f')
     then
-      val red = Integer.parseInt(next.s.substring(0, 2).nn, 16)
-      val green = Integer.parseInt(next.s.substring(2, 4).nn, 16)
-      val blue = Integer.parseInt(next.s.substring(4, 6).nn, 16)
+      val red = Integer.parseInt(next.s.substring(0, 2), 16)
+      val green = Integer.parseInt(next.s.substring(2, 4), 16)
+      val blue = Integer.parseInt(next.s.substring(4, 6), 16)
 
       Some(Rgb24(red, green, blue))
 

--- a/lib/superlunary/src/jvm/superlunary.Executor.scala
+++ b/lib/superlunary/src/jvm/superlunary.Executor.scala
@@ -40,9 +40,9 @@ object Executor:
     val cls = Class.forName("Generated$Code$From$Quoted").nn
     val instance = cls.getDeclaredConstructor().nn.newInstance().nn
     val method = cls.getMethod("apply").nn
-    val function = method.invoke(instance).nn
-    val cls2 = function.getClass.nn
-    val method2 = function.getClass.nn.getMethod("apply", classOf[Object]).nn
+    val function = method.invoke(instance)
+    val cls2 = function.getClass
+    val method2 = function.getClass.getMethod("apply", classOf[Object]).nn
     method2.setAccessible(true)
     method2.invoke(function, input).asInstanceOf[String]
 


### PR DESCRIPTION
The compiler seems to have got better at identifying when `.nn` is not necessary, and has started issuing warnings. This PR heeds those warnings and removes the `.nn`s
