### PR TITLE
Provide an "isolated" classloader

### DIFF
--- a/lib/hellenism/src/core/hellenism.Classloader.scala
+++ b/lib/hellenism/src/core/hellenism.Classloader.scala
@@ -52,6 +52,13 @@ class Classloader(val java: ClassLoader):
 
   def parent: Optional[Classloader] = Optional(java.getParent).let(new Classloader(_))
 
+  def use[result](block: => result): result =
+    val classloader0 = Thread.currentThread.nn.getContextClassLoader().nn
+    val thread = Thread.currentThread.nn
+
+    try thread.setContextClassLoader(java) yet block
+    finally thread.setContextClassLoader(classloader0)
+
   protected def urlClassloader: Optional[jn.URLClassLoader] = java match
     case java: jn.URLClassLoader => java
     case _                       => parent.let(_.urlClassloader)

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -33,6 +33,7 @@
 package hellenism
 
 import java.net as jn
+import java.io as ji
 
 import anticipation.*
 import contingency.*
@@ -103,3 +104,13 @@ trait Classpath:
           super.loadClass(name, resolve)
 
     new Classloader(javaClassloader)
+
+  def classloader: Classloader =
+    val urls = entries.flatMap:
+      case ClasspathEntry.Jar(jarfile)   => List(ji.File(jarfile.s).toURI.nn.toURL.nn)
+      case ClasspathEntry.Directory(dir) => List(ji.File(dir.s).toURI.nn.toURL.nn)
+      case ClasspathEntry.Url(url)       => List(jn.URI.create(url.s).nn.toURL.nn)
+      case ClasspathEntry.JavaRuntime    => Nil
+
+    new Classloader
+         (new jn.URLClassLoader(Array.from(urls), ClassLoader.getPlatformClassLoader().nn))

--- a/lib/mandible/src/core/mandible-core.scala
+++ b/lib/mandible/src/core/mandible-core.scala
@@ -69,13 +69,15 @@ import filesystemOptions.createNonexistent.disabled
 import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.disabled
 
+import interfaces.paths.pathOnLinux
+
 
 def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using TemporaryDirectory)
      (using classloader: Classloader)
 : Bytecode =
 
     val uuid = Uuid()
-    val out: Path on Linux = unsafely(temporaryDirectory[Path on Linux]/uuid)
+    val out: Path on Linux = unsafely(temporaryDirectory/uuid)
     val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))
 
     val settings: staging.Compiler.Settings =


### PR DESCRIPTION
There's now a `use` method on `Classloader`s which allows you to execute some code with that
classloader in context.
