### PR TITLE
Report terminal errors during tests

### DIFF
--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -69,7 +69,7 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       jl.System.exit(2)
     finally try
       runner.complete()
-      if runner.report.pass then jl.System.exit(0) else jl.System.exit(1)
+      if runner.report.passed then jl.System.exit(0) else jl.System.exit(1)
     catch case err: EnvironmentError =>
       jl.System.out.nn.println(StackTrace(err).teletype)
       jl.System.exit(3)

--- a/lib/probably/src/core/probably.Reporter.scala
+++ b/lib/probably/src/core/probably.Reporter.scala
@@ -38,16 +38,15 @@ import turbulence.*
 trait Reporter[report]:
   def make(): report
   def fail(report: report, error: Throwable, active: Set[TestId]): Unit
-  def declareSuite(report: report, suite: Testable): Unit
+  def declare(report: report, suite: Testable): Unit
   def complete(report: report): Unit
 
 object Reporter:
   given report: (Stdio, Environment) => Reporter[Report]:
     def make(): Report = Report()
-    def declareSuite(report: Report, suite: Testable): Unit = report.declareSuite(suite)
+    def declare(report: Report, suite: Testable): Unit = report.declare(suite)
 
     def fail(report: Report, error: Throwable, active: Set[TestId]): Unit =
       report.fail(error, active)
 
-    def complete(report: Report): Unit =
-      report.complete(Coverage())
+    def complete(report: Report): Unit = report.complete(Coverage())

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -74,7 +74,7 @@ class Runner[report]()(using reporter: Reporter[report]):
 
   def suite(suite: Testable, block: Testable ?=> Unit): Unit =
     if !skip(suite.id) then
-      reporter.declareSuite(report, suite)
+      reporter.declare(report, suite)
       block(using suite)
 
   def terminate(error: Throwable): Unit = synchronized:


### PR DESCRIPTION
Sometimes there's an unrecoverable error while running the tests. Previously, this wasn't reported.
Now, it is, and the (partial) report is printed.

- **If an unhandled exception occurs during tests, print it out**
- **Don't pass if there's an error**
