### PR TITLE
Make physical quantities comparable

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -131,6 +131,8 @@ trait ProbablyTestModule extends BaseScalaModule {
     "-Xplugin",
     (larceny.plugin.assembly().path).toString()
   )
+
+  def consoleScalacOptions = scalacOptions()
 }
 
 trait SoundnessGroupModule extends BaseScalaModule with PublishModule {
@@ -1309,7 +1311,7 @@ object punctuation extends SoundnessModule {
 
 object quantitative extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq(hypotenuse.core, gossamer.core, anticipation.opaque, anticipation.time)
+    def moduleDeps = Seq(hypotenuse.core, gossamer.core, anticipation.opaque, anticipation.time, probably.core)
   }
   object units extends SoundnessSubModule {
     def moduleDeps = Seq(core)

--- a/lib/probably/src/core/probably.Checkable.scala
+++ b/lib/probably/src/core/probably.Checkable.scala
@@ -44,5 +44,16 @@ object Checkable:
   inline given commensurable: [value: Commensurable by value] => value is Checkable against value =
     (left, right) => left <= right && right <= left
 
+
+  def apply[self, contrast](lambda: (self, contrast) => Boolean)
+  : self is Checkable against contrast =
+
+      new Checkable:
+        type Self = self
+        type Contrast = contrast
+
+        def check(self: Self, contrast: Contrast): Boolean = lambda(self, contrast)
+
+
 trait Checkable extends Typeclass, Contrastive:
   def check(left: Self, right: Contrast): Boolean

--- a/lib/quantitative/src/core/quantitative.Quantitative.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import gossamer.*
 import hypotenuse.*
 import prepositional.*
+import probably.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
@@ -93,6 +94,13 @@ object Quantitative extends Quantitative2:
                                        quantity2 <: Quantity[right]]
                              =>  quantity is Addable by quantity2 =
       ${Quantitative.addTypeclass[left, quantity, right, quantity2]}
+
+    inline given checkable: [left <: Measure,
+                             quantity <: Quantity[left],
+                             right <: Measure,
+                             quantity2 <: Quantity[right]]
+                 =>  quantity is Checkable against quantity2 =
+      ${Quantitative.checkable[left, quantity, right, quantity2]}
 
     transparent inline given subtractable: [left <: Measure,
                                             quantity <: Quantity[left],

--- a/lib/quantitative/src/test/quantitative.Tests.scala
+++ b/lib/quantitative/src/test/quantitative.Tests.scala
@@ -133,6 +133,23 @@ object Tests extends Suite(m"Quantitative Tests"):
         .map(_.message)
       .assert(_ == List("quantitative: the left operand represents distance, but the right operand represents area; these are incompatible physical quantities"))
 
+      test(m"Units of the same dimension can be checked for equivalence (and found equal)"):
+        Mile === 1760*Yard
+
+      . assert(_ == true)
+
+      test(m"Units of the same dimension can be checked for equivalence (and found unequal)"):
+        Mile === Inch
+
+      . assert(_ == false)
+
+      test(m"Units of different measures cannot be compared"):
+        demilitarize:
+          Mile === Joule
+
+        . map(_.message)
+      . assert(_ == List("quantitative: the left operand represents distance, but the right operand represents energy; these are incompatible physical quantities"))
+
     suite(m"Automatic conversions"):
       test(m"Conversions are applied automatically to RHS in multiplication"):
         val x = 2*Metre


### PR DESCRIPTION
While we can add and subtract different quantities, provided they have the same dimensions, we
can't check them for equality, unless they happen to have the same units. This provides a
`Checkable` instance which makes _equivalence_ checking possible.
