### PR TITLE
Also read the imports in the compilation unit

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1423,6 +1423,9 @@ object spectacular extends SoundnessModule {
 object stenography extends SoundnessModule {
   object core extends SoundnessSubModule {
     def moduleDeps = Seq(spectacular.core, gossamer.core, turbulence.core)
+    def ivyDeps = Agg(
+      ivy"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+    )
   }
 
   object test extends ProbablyTestModule {

--- a/lib/harlequin/src/core/harlequin.ProgrammingLanguage.scala
+++ b/lib/harlequin/src/core/harlequin.ProgrammingLanguage.scala
@@ -48,9 +48,9 @@ sealed trait ProgrammingLanguage:
 
 object Scala extends ProgrammingLanguage:
   enum Context:
-   case Top
-   case Term
-   case Type
+    case Top
+    case Term
+    case Type
 
   override def preprocess(text: Text, context: Optional[Context]): Text =
     context match

--- a/lib/stenography/src/test/stenography.Tests.scala
+++ b/lib/stenography/src/test/stenography.Tests.scala
@@ -35,12 +35,11 @@ package stenography
 import language.experimental.pureFunctions
 
 import soundness.*
+import prepositional.*
 
 import autopsies.contrastExpectations
 
 object Tests extends Suite(m"Stenography Tests"):
-  import prepositional.*
-  import soundness.*
 
   def run(): Unit =
     import anticipation.*


### PR DESCRIPTION
Stenography wasn't able to read the imports at the top-level when deciding what's in scope when
rendering a type. It now can, though we had to include the compiler JARs and access the
`dotty.tools.*` package to do so.
