### PR TITLE
Fix for reading a classpath resource

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -961,7 +961,7 @@ object hellenism extends SoundnessModule {
   }
 
   object test extends ProbablyTestModule {
-    def moduleDeps = Seq(probably.cli, core)
+    def moduleDeps = Seq(probably.cli, core, turbulence.core)
   }
 }
 

--- a/lib/gesticulate/src/core/gesticulate-core.scala
+++ b/lib/gesticulate/src/core/gesticulate-core.scala
@@ -32,6 +32,12 @@
                                                                                                   */
 package gesticulate
 
+import anticipation.*
+import turbulence.*
+
 extension (inline ctx: StringContext)
   transparent inline def media(inline parts: String*): MediaType =
     ${Media.Prefix.expand('ctx, 'parts)}
+
+extension [media](value: media)
+  inline def ascribe(media: MediaType): Content = Content(media, value.stream[Bytes])

--- a/lib/gesticulate/src/core/soundness+gesticulate-core.scala
+++ b/lib/gesticulate/src/core/soundness+gesticulate-core.scala
@@ -34,4 +34,4 @@ package soundness
 
 export gesticulate
 . { Extensions, Media, MediaType, MediaTypeError, media, Multipart, MultipartError, Part, Content,
-    Asset }
+    Asset, ascribe }

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -61,7 +61,7 @@ object Classpath extends Root(t""):
     def decode(text: Text): Classpath.type =
       if text.starts(t"/") then Classpath else raise(PathError(_.InvalidRoot)) yet Classpath
 
-    def encode(root: Classpath.type): Text = t"/"
+    def encode(root: Classpath.type): Text = t""
 
 
   object Directory:

--- a/lib/hellenism/src/test/hellenism.Tests.scala
+++ b/lib/hellenism/src/test/hellenism.Tests.scala
@@ -35,12 +35,22 @@ package hellenism
 import soundness.*
 
 import autopsies.contrastExpectations
+import classloaders.threadContext
 
 object Tests extends Suite(m"Proscenium Tests"):
   def run(): Unit =
     test(m"check that a classpath file is accessible"):
       cp"/scala/Option.class"
     . assert()
+
+    test(m"Decode a classpath"):
+      unsafely:
+        t"/scala/Option.class".decode[Path on Classpath]
+    . assert(_ == Classpath / "scala" / "Option.class")
+
+    test(m"check that a classpath file is readable"):
+      cp"/scala/Option.class".read[Bytes]
+    . assert(_.length > 0)
 
     test(m"check that a nonexistent classpath file is an error"):
       demilitarize(cp"/missing.txt").map(_.message)


### PR DESCRIPTION
Conventionally, in the `Path` representation of a classpath path, the root should be encoded as
the empty string. This wasn't the case, so it was failing.
