### PR TITLE
Use modular style for `SystemProperty` typeclass

### DIFF
--- a/lib/ambience/src/core/ambience.Architecture.scala
+++ b/lib/ambience/src/core/ambience.Architecture.scala
@@ -42,6 +42,7 @@ object Architecture:
     case t"x86" | t"i386"     => X86(32)
     case t"x86_64" | t"amd64" => X86(64)
     case t"arm"               => Arm(32)
+    case t"aarch64"           => Arm(64)
     case t"ppc"               => Ppc(32)
     case t"ppc64"             => Ppc(64)
     case t"ppc64le"           => Ppc(64, true)

--- a/lib/ambience/src/core/ambience.EnvironmentVariable2.scala
+++ b/lib/ambience/src/core/ambience.EnvironmentVariable2.scala
@@ -40,10 +40,10 @@ import prepositional.*
 import proscenium.*
 
 trait EnvironmentVariable2:
-  given generic: [unknown <: Label] => EnvironmentVariable[unknown, Text] = identity(_)
+  given generic: [label <: Label] => EnvironmentVariable[label, Text] = identity(_)
 
 
-  given decoder: [unknown <: Label, variable: Decodable in Text]
-        =>  EnvironmentVariable[unknown, variable] =
+  given decoder: [label <: Label, variable: Decodable in Text]
+        =>  EnvironmentVariable[label, variable] =
 
       variable.decoded(_)

--- a/lib/ambience/src/core/ambience.Properties.scala
+++ b/lib/ambience/src/core/ambience.Properties.scala
@@ -36,11 +36,12 @@ import language.dynamics
 
 import anticipation.*
 import contingency.*
+import prepositional.*
 import vacuous.*
 
 object Properties extends Dynamic:
   def apply[property](property: Text)
-       (using properties: SystemProperties, reader: SystemProperty[String, property])
+       (using properties: SystemProperties, reader: String is SystemProperty of property)
   : property =
 
       reader.read(properties(property), property)

--- a/lib/ambience/src/core/ambience.PropertyAccess.scala
+++ b/lib/ambience/src/core/ambience.PropertyAccess.scala
@@ -38,6 +38,7 @@ import scala.compiletime.ops.string.*
 
 import anticipation.*
 import contingency.*
+import prepositional.*
 import proscenium.*
 import vacuous.*
 
@@ -47,7 +48,7 @@ case class PropertyAccess[name <: String](property: String) extends Dynamic:
 
 
   def applyDynamic[property](key: String)()
-       (using properties: SystemProperties, reader: SystemProperty[name+"."+key.type, property])
+    (using properties: SystemProperties, reader: (name+"."+key.type) is SystemProperty of property)
   : property =
 
       val name = property+"."+key
@@ -55,7 +56,7 @@ case class PropertyAccess[name <: String](property: String) extends Dynamic:
 
 
   inline def apply[property]()
-              (using properties: SystemProperties, reader: SystemProperty[name, property])
+              (using properties: SystemProperties, reader: name is SystemProperty of property)
   : property =
 
       val name = valueOf[name]


### PR DESCRIPTION
We now use the style `"my.system.property" is SystemProperty of PropertyType` as the typeclass type
for accessing system properties.
