### PR TITLE
Avoid warning with HTML attributes

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -89,8 +89,8 @@ object Honeycomb:
 
             '{  $expr.convert($value) match
                   case Attribute.NotShown => Unset
-                  case Unset              => ($expr.rename.or($key.tt).s, Unset)
                   case attribute: Text    => ($expr.rename.or($key.tt).s, attribute)
+                  case _                  => ($expr.rename.or($key.tt).s, Unset)
             } :: recur(tail)
 
           case _ =>


### PR DESCRIPTION
A macro in Honeycomb was causing a new warning every time an attribute was used. This avoids the warning in the macro definition.