### PR TITLE
Rename `Attribute` to `XmlAttribute` and related changes

### DIFF
--- a/lib/xylophone/src/core/soundness+xylophone-core.scala
+++ b/lib/xylophone/src/core/soundness+xylophone-core.scala
@@ -33,9 +33,8 @@
 package soundness
 
 export xylophone
-. { Attribute, Namespace, StandardXmlPrinter, Xml, XmlError, XmlAst, xmlAttribute, XmlDecoder,
-    XmlEncoder, XmlInterpolation, xmlLabel, XmlName, XmlPrinter, x,
-    XmlPath }
+. { XmlAttribute, Namespace, StandardXmlPrinter, Xml, XmlError, XmlAst, attribute, XmlDecoder,
+    XmlEncoder, XmlInterpolation, label, XmlName, XmlPrinter, x, XmlPath }
 
 package xmlPrinters:
   export xylophone.xmlPrinters.compact

--- a/lib/xylophone/src/core/xylophone.Attribute.scala
+++ b/lib/xylophone/src/core/xylophone.Attribute.scala
@@ -32,17 +32,6 @@
                                                                                                   */
 package xylophone
 
-import anticipation.*
-import contingency.*
-import gossamer.*
-import rudiments.*
-import vacuous.*
+import proscenium.*
 
-case class Attribute(node: XmlNode, attribute: Text):
-  def as[value: XmlDecoder]: value raises XmlError =
-    val attributes = Xml.normalize(node).prim match
-      case XmlAst.Element(_, _, attributes, _) => attributes
-      case _                                   => abort(XmlError(XmlError.Reason.Read))
-
-    value.read
-     (List(XmlAst.Element(XmlName(t"empty"), List(XmlAst.Textual(attributes(XmlName(attribute)))))))
+case class attribute() extends StaticAnnotation

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -182,7 +182,7 @@ object Xml extends Format:
 case class XmlFragment(head: Text | Unit, path: XmlPath, root: XmlAst.Root)
 extends Xml, Dynamic:
   def apply(idx: Int = 0): XmlNode = XmlNode(idx, head :: path, root)
-  def attribute(key: Text): Attribute = apply(0).attribute(key)
+  def attribute(key: Text): XmlAttribute = apply(0).attribute(key)
   def pointer: XmlPath = (head :: path).reverse
   def selectDynamic(tagName: String): XmlFragment = XmlFragment(tagName.tt, head :: path, root)
   def applyDynamic(tagName: String)(idx: Int = 0): XmlNode = selectDynamic(tagName).apply(idx)
@@ -199,7 +199,7 @@ extends Xml, Dynamic:
 case class XmlNode(head: Int, path: XmlPath, root: XmlAst.Root) extends Xml, Dynamic:
   def selectDynamic(tagName: String): XmlFragment = XmlFragment(tagName.tt, head :: path, root)
   def applyDynamic(tagName: String)(idx: Int = 0): XmlNode = selectDynamic(tagName).apply(idx)
-  def attribute(attribute: Text): Attribute = Attribute(this, attribute)
+  def attribute(attribute: Text): XmlAttribute = XmlAttribute(this, attribute)
   def pointer: XmlPath = (head :: path).reverse
 
   @targetName("all")

--- a/lib/xylophone/src/core/xylophone.XmlEncoder.scala
+++ b/lib/xylophone/src/core/xylophone.XmlEncoder.scala
@@ -51,7 +51,7 @@ object XmlEncoder extends Derivation[XmlEncoder]:
   given int: XmlEncoder[Int] = int =>
     XmlAst.Element(XmlName(t"Int"), List(XmlAst.Textual(int.show)))
 
-  private val attributeAttribute = xmlAttribute()
+  private val attributeAttribute = attribute()
 
   inline def join[derivation <: Product: ProductReflection]: XmlEncoder[derivation] =
     value =>

--- a/lib/xylophone/src/core/xylophone.label.scala
+++ b/lib/xylophone/src/core/xylophone.label.scala
@@ -34,4 +34,4 @@ package xylophone
 
 import proscenium.*
 
-case class xmlLabel(name: String) extends StaticAnnotation
+case class label(name: String) extends StaticAnnotation

--- a/lib/xylophone/src/core/xylophone.xmlAttribute.scala
+++ b/lib/xylophone/src/core/xylophone.xmlAttribute.scala
@@ -32,6 +32,17 @@
                                                                                                   */
 package xylophone
 
-import proscenium.*
+import anticipation.*
+import contingency.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
 
-case class xmlAttribute() extends StaticAnnotation
+case class XmlAttribute(node: XmlNode, attribute: Text):
+  def as[value: XmlDecoder]: value raises XmlError =
+    val attributes = Xml.normalize(node).prim match
+      case XmlAst.Element(_, _, attributes, _) => attributes
+      case _                                   => abort(XmlError(XmlError.Reason.Read))
+
+    value.read
+     (List(XmlAst.Element(XmlName(t"empty"), List(XmlAst.Textual(attributes(XmlName(attribute)))))))

--- a/lib/xylophone/src/test/xylophone.Tests.scala
+++ b/lib/xylophone/src/test/xylophone.Tests.scala
@@ -48,7 +48,7 @@ import errorDiagnostics.stackTraces
 case class Worker(name: Text, age: Int)
 case class Firm(name: Text, ceo: Worker)
 
-case class Book(title: Text, @xmlAttribute isbn: Text)
+case class Book(title: Text, @attribute isbn: Text)
 case class Bibliography(author: Text, book: Book)
 
 enum ColorVal:


### PR DESCRIPTION
There was a conflict with `Attribute` in Honeycomb, so this one has been renamed to `XmlAttribute`.
Consequently the annotation, `@xmlAttribute` had to be changed to `@attribute`.
