### PR TITLE
Support addition and subtraction involving `Date`s and `Quanta`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -489,7 +489,7 @@ object austronesian extends SoundnessModule {
 
 object aviation extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq(quantitative.units)
+    def moduleDeps = Seq(abacist.core, quantitative.units)
   }
 
   object test extends ProbablyTestModule {

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package aviation
 
+import abacist.*
 import anticipation.*
 import contingency.*
 import denominative.*
@@ -43,6 +44,7 @@ import hypotenuse.*
 import kaleidoscope.*
 import prepositional.*
 import proscenium.*
+import quantitative.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
@@ -165,6 +167,18 @@ object Aviation:
 
     trait Format(val name: Text):
       type Issue: Communicable
+
+    given subtractable: Date is Subtractable by Date to Quanta[Mono[Days[1]]] = (end, start) =>
+      Quanta(end - start)
+
+    given subtractable2: Date is Subtractable by Quanta[Mono[Days[1]]] to Date = (end, start) =>
+      end - start[Days]
+
+    given addable: Date is Addable by Quanta[Mono[Days[1]]] to Date = (left, right) =>
+      left + right[Days]
+
+    given addable2: Quanta[Mono[Days[1]]] is Addable by Date to Date = (left, right) =>
+      left[Days] + right
 
     given showable: (Endianness, DateNumerics, DateSeparation, Years) => Date is Showable = date =>
       import DateNumerics.*, Years.*

--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -36,6 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
+import autopsies.contrastExpectations
 
 object Tests extends Suite(m"Aviation Tests"):
   def run(): Unit =
@@ -201,6 +202,22 @@ object Tests extends Suite(m"Aviation Tests"):
         given calendar: Calendar = calendars.gregorian
         2016-Apr-11
       .assert(_ == 2016-Apr-11)
+
+      test(m"Subtract dates"):
+        2018-Nov-19 - (2017-Sep-1)
+      .assert(_ == Quanta[Mono[Days[1]]](444))
+
+      test(m"Subtract days from a date"):
+        2018-Nov-19 - Quanta[Mono[Days[1]]](2)
+      .assert(_ == 2018-Nov-17)
+
+      test(m"Add days to a date"):
+        2018-Nov-19 + Quanta[Mono[Days[1]]](2)
+      .assert(_ == 2018-Nov-21)
+
+      test(m"Add days to a date, order reversed"):
+        Quanta[Mono[Days[1]]](2) + (2018-Nov-19)
+      .assert(_ == 2018-Nov-21)
 
       test(m"Get Gregorian date"):
         given calendar: Calendar = calendars.gregorian


### PR DESCRIPTION
We can now add/subtract days and `Date`s. The type that's used for days is
`Quanta[Mono[Days[1]]]`. This is a discrete number of days, rather than a
continuous quantity (i.e. `Quantity[Days[1]]`), which wouldn't make sense.
