### PR TITLE
Allow `Lexicon` to store values

### DIFF
--- a/lib/gossamer/src/test/gossamer.Tests.scala
+++ b/lib/gossamer/src/test/gossamer.Tests.scala
@@ -855,6 +855,7 @@ object Tests extends Suite(m"Gossamer Tests"):
 
     suite(m"BK-Tree tests"):
       import proximityMeasures.levenshteinDistance
+
       val words: List[Text] = List("ba", "baa", "baal", "baar", "baba", "babe", "babu",
         "baby", "bac", "bach", "back", "bad", "bade", "bae", "baff", "baft",
         "bag", "baga", "bago", "bah", "baho", "baht", "bail", "bain", "bait",


### PR DESCRIPTION
It's now possible to associate values with the keys in a lexicon. Furthermore, it's possible to create a (not-particularly-useful) `Lexicon` that's empty.
