### PR TITLE
Introduce `raising` type for multiple errors

### DIFF
--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -153,6 +153,11 @@ def abortive[error <: Error](using Quotes, Realm)[success]
 
 infix type raises [success, error <: Exception] = Tactic[error] ?=> success
 
+infix type raising[success, errors] = errors match
+  case EmptyTuple.type => success
+  case left *: right   => Tactic[left] ?=> raising[success, right]
+  case _               => Tactic[errors] ?=> success
+
 infix type mitigates [error <: Exception, error2 <: Exception] =
   error2 is Mitigable to error
 


### PR DESCRIPTION
We can use a match type to allow tuples of errors to be defined with a single `raises` type combinator. At least we could if the compiler didn't crash. Instead, for now, a different type called `raising` is provided which can be used whenever it doesn't crash the compiler. Ultimately, the bug will hopefully be fixed and a single match type called `raises` can be used universally.
