### PR TITLE
Simplify the Mill build

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -794,7 +794,7 @@ object superlunary extends Library:
       mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
     )
 
-  object test extends Component(jvm):
+  object test extends Tests(jvm):
     override def finalMainClass: Task.Simple[String] = "superlunary.run"
 
 object surveillance extends Library:


### PR DESCRIPTION
This removes every explicit dependency on the `probability.cli` module in every test module. Since they all use Probably, it is added implicitly into the `Test` modules, and is no longer explicitly included for every single module.
