### PR TITLE
Make it easier to serve HTML and other types

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -46,6 +46,7 @@ import contextual.*
 import contingency.*
 import denominative.*
 import fulminate.*
+import gesticulate.*
 import gossamer.*
 import hellenism.*
 import hieroglyph.*
@@ -80,6 +81,8 @@ object Html extends Tag.Container
   erased trait Integral
   erased trait Decimal
   erased trait Id
+
+  given media: Document[Html] is Media = _ => media"text/html"
 
   def doctype: Doctype = Doctype(t"html")
 

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -305,6 +305,7 @@ object Http:
 
         ${Telekinesis.response('headers)}
 
+    given conversion: [servable: Servable] => Conversion[servable, Response] = servable.serve(_)
 
     transparent inline def applyDynamic(id: "apply")(inline headers: Any*): Prototype | Response =
       ${Telekinesis.response('headers)}
@@ -409,11 +410,11 @@ object Http:
 
       Response(version, status, headers.reverse, body)
 
-  case class Response private
-              (version:     Http.Version,
-               status:      Http.Status,
-               textHeaders: List[Http.Header],
-               body:        Stream[Data]):
+  into case class Response private
+                   (version:     Http.Version,
+                    status:      Http.Status,
+                    textHeaders: List[Http.Header],
+                    body:        Stream[Data]):
 
     def successBody: Optional[Stream[Data]] =
       body.unless(status.category != Http.Status.Category.Successful)


### PR DESCRIPTION
Most notably, from an application's perspective, it's no longer necessary to wrap each result in `Http.Response`. Instead, this can be inferred with an implicit conversion that's enabled by making `Http.Response` an `into` type.
