### PR TITLE
Rename `Vector` to `Tensor` everywhere

### DIFF
--- a/lib/mosquito/src/core/mosquito-core.scala
+++ b/lib/mosquito/src/core/mosquito-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package mosquito
 
-export Mosquito.Vector
+export Mosquito.Tensor

--- a/lib/mosquito/src/core/soundness+mosquito-core.scala
+++ b/lib/mosquito/src/core/soundness+mosquito-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export mosquito.{Vector, Matrix, slide}
+export mosquito.{Tensor, Matrix, slide}

--- a/lib/mosquito/src/test/mosquito.Tests.scala
+++ b/lib/mosquito/src/test/mosquito.Tests.scala
@@ -49,62 +49,62 @@ given Decimalizer(4)
 
 object Tests extends Suite(m"Mosquito tests"):
   def run(): Unit =
-    test(m"Create a Vector of Ints"):
-      Vector(1, 2, 3)
-    .assert(_ == Vector(1, 2, 3))
+    test(m"Create a Tensor of Ints"):
+      Tensor(1, 2, 3)
+    .assert(_ == Tensor(1, 2, 3))
 
-    test(m"A Vector of Ints infers the correct size"):
+    test(m"A Tensor of Ints infers the correct size"):
       demilitarize:
-        val vector: Vector[Int, 3] = Vector(1, 3, 4)
+        val tensor: Tensor[Int, 3] = Tensor(1, 3, 4)
       .map(_.message)
     .assert(_ == Nil)
 
     test(m"Type error if size is incorrect"):
       demilitarize:
-        val vector: Vector[Int, 2] = Vector(1, 3, 4)
+        val tensor: Tensor[Int, 2] = Tensor(1, 3, 4)
     .assert(_.nonEmpty)
 
     test(m"Type error if type is incorrect"):
       demilitarize:
-        val vector: Vector[String, 3] = Vector(1, 3, 4)
+        val tensor: Tensor[String, 3] = Tensor(1, 3, 4)
     .assert(_.nonEmpty)
 
     test(m"Calculate integer dot-product"):
-      Vector(1, 2, 3).dot(Vector(4, 3, 7))
+      Tensor(1, 2, 3).dot(Tensor(4, 3, 7))
     .assert(_ == 31)
 
     test(m"Calculate Double dot-product"):
-      Vector(0.1, 0.2, 0.3).dot(Vector(0.4, 0.3, 0.7))
+      Tensor(0.1, 0.2, 0.3).dot(Tensor(0.4, 0.3, 0.7))
     .assert(_ === 0.31 +/- 0.000001)
 
     test(m"Calculate integer cross-product"):
-      Vector(1, 2, 3).cross(Vector(4, 3, 7))
-    .assert(_ == Vector(5, 5, -5))
+      Tensor(1, 2, 3).cross(Tensor(4, 3, 7))
+    .assert(_ == Tensor(5, 5, -5))
 
     test(m"Calculate Double cross-product"):
-      Vector(1.4, 2.4, 3.8).cross(Vector(4.9, 3.6, 0.7))
-    .assert(_ == Vector(-12.0, 17.64, -6.72))
+      Tensor(1.4, 2.4, 3.8).cross(Tensor(4.9, 3.6, 0.7))
+    .assert(_ == Tensor(-12.0, 17.64, -6.72))
 
-    test(m"Show Vector 3-vector"):
-      Vector(1, 3, 6).show
+    test(m"Show Tensor 3-tensor"):
+      Tensor(1, 3, 6).show
     .assert(_ == t"\u239b 1 \u239e\n\u239c 3 \u239f\n\u239d 6 \u23a0")
 
-    test(m"Add two vectors"):
-      Vector(1, 2, 3) + Vector(3, 4, 5)
-    .assert(_ == Vector(4, 6, 8))
+    test(m"Add two tensors"):
+      Tensor(1, 2, 3) + Tensor(3, 4, 5)
+    .assert(_ == Tensor(4, 6, 8))
 
     suite(m"Quantity operations"):
-      test(m"Add two quantity vectors"):
-        Vector(1.0*Metre, 2.0*Metre, 3.0*Metre) + Vector(3.0*Metre, 4.0*Metre, 5.0*Metre)
-      .assert(_ == Vector(4.0*Metre, 6.0*Metre, 8.0*Metre))
+      test(m"Add two quantity tensors"):
+        Tensor(1.0*Metre, 2.0*Metre, 3.0*Metre) + Tensor(3.0*Metre, 4.0*Metre, 5.0*Metre)
+      .assert(_ == Tensor(4.0*Metre, 6.0*Metre, 8.0*Metre))
 
-      test(m"Add two mixed-quantity vectors"):
-        Vector(1.0*Foot, 1.0*Foot, 1.0*Foot) + Vector(3.0*Metre, 4.0*Metre, 5.0*Metre)
-      .assert(_ == Vector(3.3048*Metre, 4.3048*Metre, 5.3048*Metre))
+      test(m"Add two mixed-quantity tensors"):
+        Tensor(1.0*Foot, 1.0*Foot, 1.0*Foot) + Tensor(3.0*Metre, 4.0*Metre, 5.0*Metre)
+      .assert(_ == Tensor(3.3048*Metre, 4.3048*Metre, 5.3048*Metre))
 
       test(m"Map from m to m²"):
-        Vector(1.0*Metre, 2.0*Metre, 3.0*Metre, 4.0*Metre).map(_*Metre)
-      .assert(_ == Vector(1.0*Metre*Metre, 2.0*Metre*Metre, 3.0*Metre*Metre, 4.0*Metre*Metre))
+        Tensor(1.0*Metre, 2.0*Metre, 3.0*Metre, 4.0*Metre).map(_*Metre)
+      .assert(_ == Tensor(1.0*Metre*Metre, 2.0*Metre*Metre, 3.0*Metre*Metre, 4.0*Metre*Metre))
 
     suite(m"Matrix tests"):
       val m1 = Matrix[2, 3]((1, 2, 3), (4, 5, 6))
@@ -135,27 +135,27 @@ object Tests extends Suite(m"Mosquito tests"):
       .assert(_ == Matrix[2, 3]((0, 1, 1), (2, 2, 3)))
 
     suite(m"Interesting types"):
-      test(m"Dot product of a vector of quantities"):
-        val v1 = Vector(5*Inch, 2*Inch, Inch)
-        val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
+      test(m"Dot product of a tensor of quantities"):
+        val v1 = Tensor(5*Inch, 2*Inch, Inch)
+        val v2 = Tensor(2*Inch, 3*Inch, 6*Inch)
         v1.dot(v2)
       .assert(_ == 22*Inch*Inch)
 
-      test(m"Cross product of a vector of quantities"):
-        val v1 = Vector(5*Inch, 2*Inch, Inch)
-        val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
+      test(m"Cross product of a tensor of quantities"):
+        val v1 = Tensor(5*Inch, 2*Inch, Inch)
+        val v2 = Tensor(2*Inch, 3*Inch, 6*Inch)
         v1.cross(v2)
-      .assert(_ == Vector(9*Inch, -28*Inch, 11*Inch))
+      .assert(_ == Tensor(9*Inch, -28*Inch, 11*Inch))
 
-      test(m"Sum of two vectors of quantities"):
-        val v1 = Vector(5*Inch, 2*Inch, Inch)
-        val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
+      test(m"Sum of two tensors of quantities"):
+        val v1 = Tensor(5*Inch, 2*Inch, Inch)
+        val v2 = Tensor(2*Inch, 3*Inch, 6*Inch)
         v1 + v2
-      .assert(_ == Vector(7*Inch, 5*Inch, 7*Inch))
+      .assert(_ == Tensor(7*Inch, 5*Inch, 7*Inch))
 
-      test(m"Sum of two vectors of different quantities"):
-        val v1 = Vector(5*Inch, 2*Inch, Inch)
-        val v2 = Vector(2*Metre, 3*Metre, 6*Metre)
+      test(m"Sum of two tensors of different quantities"):
+        val v1 = Tensor(5*Inch, 2*Inch, Inch)
+        val v2 = Tensor(2*Metre, 3*Metre, 6*Metre)
         println(v1.show)
         println(v2.show)
 


### PR DESCRIPTION
This renames `Vector` to `Tensor`.

`Tensor` is not _currently_ the ideal word because it's representing only rank-1 tensors, i.e. vectors. But since `Vector` is already widely used in Scala, we will go with it and enhance it to support higher-order tensors later.
