### PR TITLE
Implement full XML specification

### DIFF
--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -110,12 +110,14 @@ object Xml extends Tag.Container
       parse(input.iterator, root).of[content]
 
   given aggregable2: (schema: XmlSchema) => Tactic[ParseError] => Xml is Aggregable by Text =
-    input => parse(input.iterator, schema.generic, headers = false)
+    input => parse(input.iterator, schema.generic, headers0 = false)
 
   given loadable: (schema: XmlSchema) => Tactic[ParseError] => Xml is Loadable by Text = stream =>
     val root = Tag.root(Set(t"xml"))
-    parse(stream.iterator, root, headers = true) match
-      case Fragment(header: Header, content) => Document(content, header)
+    parse(stream.iterator, root, headers0 = true) match
+      case Fragment((header: Header), rest*) =>
+        if rest.length == 1 then Document(rest.head, header)
+        else Document(Fragment(rest*), header)
 
       case other =>
         abort(ParseError(Xml, Position(1.u, 1.u), Issue.BadDocument))
@@ -140,6 +142,11 @@ object Xml extends Tag.Container
             emitter.put("<![CDATA[")
             emitter.put(text)
             emitter.put("]]>")
+
+          case Doctype(text) =>
+            emitter.put("<!DOCTYPE ")
+            emitter.put(text)
+            emitter.put(">")
 
           case ProcessingInstruction(target, data) =>
             emitter.put("<?")
@@ -224,26 +231,59 @@ object Xml extends Tag.Container
     emitter.iterator
 
 
+  private def escapeText(text: Text): Text =
+    val builder = jl.StringBuilder()
+    var index = 0
+    val length = text.s.length
+
+    while index < length do
+      text.s.charAt(index) match
+        case '<' => builder.append("&lt;")
+        case '&' => builder.append("&amp;")
+        case chr => builder.append(chr)
+
+      index += 1
+
+    builder.toString.tt
+
+  private def escapeAttribute(text: Text): Text =
+    val builder = jl.StringBuilder()
+    var index = 0
+    val length = text.s.length
+
+    while index < length do
+      text.s.charAt(index) match
+        case '<' => builder.append("&lt;")
+        case '&' => builder.append("&amp;")
+        case '"' => builder.append("&quot;")
+        case chr => builder.append(chr)
+
+      index += 1
+
+    builder.toString.tt
+
   given showable: [xml <: Xml] => xml is Showable =
     case Fragment(nodes*)                    => nodes.map(_.show).join
-    case TextNode(text)                      => text
+    case TextNode(text)                      => escapeText(text)
     case Comment(text)                       => t"<!--$text-->"
     case Cdata(text)                         => t"<![CDATA[$text]]>"
-    case ProcessingInstruction(target, data) => t"<?$target $data?>"
+    case Doctype(text)                       => t"<!DOCTYPE $text>"
+    case ProcessingInstruction(target, data) =>
+      if data.s.isEmpty then t"<?$target?>" else t"<?$target $data?>"
 
     case Header(version, encoding, standalone) =>
       val encodingText = encoding.lay(t""): encoding =>
-        t" encoding=\"$encoding\""
+        t""" encoding="$encoding""""
 
       val standaloneText = standalone.lay(t""): standalone =>
-        if standalone then t" standalone=\"yes\"" else t" standalone=\"no\""
+        if standalone then t""" standalone="yes"""" else t""" standalone="no""""
 
-      t"<?xml version=\"$version\"$encodingText$standaloneText>"
+      t"""<?xml version="$version"$encodingText$standaloneText?>"""
 
     case Element(tagname, attributes, children) =>
       val tagContent = if attributes.nil then t"" else
         attributes.map:
-          case (key, value) => t"""$key="$value""""
+          case (key, value) => t"""$key="${escapeAttribute(value)}""""
 
         . join(t" ", t" ", t"")
 
@@ -252,7 +292,7 @@ object Xml extends Tag.Container
 
 
   private enum Token:
-    case Close, Comment, Empty, Open, Header, Cdata, Pi
+    case Close, Comment, Empty, Open, Header, Cdata, Pi, Doctype
 
   private enum Level:
     case Ascend, Descend, Peer
@@ -347,12 +387,14 @@ object Xml extends Tag.Container
     case Node(parent: Text)
 
   private[xylophone] def parse[schema <: XmlSchema]
-    ( input:       Iterator[Text],
-      root:        Tag,
-      callback:    Optional[(Ordinal, Hole) => Unit] = Unset,
-      fastforward: Int                               = 0,
-      headers:     Boolean                           = false )
+    ( input:        Iterator[Text],
+      root:         Tag,
+      callback:     Optional[(Ordinal, Hole) => Unit] = Unset,
+      fastforward:  Int                               = 0,
+      headers0:     Boolean                           = false )
     ( using schema: XmlSchema ): Xml raises ParseError =
+
+    var headers: Boolean = headers0
 
     import lineation.linefeedChars
 
@@ -361,6 +403,8 @@ object Xml extends Tag.Container
     def result(): Text = buffer.toString.tt.also(buffer.setLength(0))
     var content: Text = t""
     var extra: Map[Text, Text] = ListMap()
+    var headerEncoding: Optional[Text] = Unset
+    var headerStandalone: Optional[Boolean] = Unset
     var nodes: Array[Node] = new Array(4)
     var index: Int = 0
     var stack: Array[Tag] = new Array(4)
@@ -408,11 +452,20 @@ object Xml extends Tag.Container
       case ' ' | Ff | Lf | Cr | Ht => cursor.next() yet skip()
       case _                       => ()
 
+    inline def isNameStart(chr: Char): Boolean =
+      chr.isLetter || chr == '_' || chr == ':'
+
+    inline def isNameChar(chr: Char): Boolean =
+      chr.isLetter || chr.isDigit || chr == '_' || chr == '-' || chr == '.' || chr == ':'
+      || chr == '·'
+
     @tailrec
-    def tagname(mark: Mark, dictionary: Optional[Dictionary[Tag]])(using Cursor.Held): Tag =
+    def tagname(mark: Mark, dictionary: Optional[Dictionary[Tag]], started: Boolean)
+      ( using Cursor.Held )
+    :   Tag =
       cursor.lay(fail(ExpectedMore)):
-        case chr if chr.isLetter || chr.isDigit =>
-          dictionary.lay(next() yet tagname(mark, Unset)): dictionary =>
+        case chr if (if started then isNameChar(chr) else isNameStart(chr)) =>
+          dictionary.lay(next() yet tagname(mark, Unset, true)): dictionary =>
             dictionary(chr.minuscule) match
               case Dictionary.Empty =>
                 cursor.next()
@@ -420,9 +473,9 @@ object Xml extends Tag.Container
                 cursor.cue(mark) yet fail(InvalidTagStart(name.lower))
 
               case other =>
-                next() yet tagname(mark, other)
+                next() yet tagname(mark, other, true)
 
-        case ' ' | Ff | Lf | Cr | Ht | '/' | '>' =>
+        case ' ' | Ff | Lf | Cr | Ht | '/' | '>' if started =>
           dictionary match
             case Dictionary.Just("", tag)       => tag
             case Dictionary.Branch(tag: Tag, _) => tag
@@ -435,16 +488,17 @@ object Xml extends Tag.Container
           fail(Unexpected(chr))
 
     @tailrec
-    def key(mark: Mark, dictionary: Optional[Dictionary[XmlAttribute]])(using Cursor.Held)
+    def key(mark: Mark, dictionary: Optional[Dictionary[XmlAttribute]], started: Boolean)
+      ( using Cursor.Held )
     :   XmlAttribute =
       cursor.lay(fail(ExpectedMore)):
-        case chr if chr.isLetter || chr == '-' =>
+        case chr if (if started then isNameChar(chr) else isNameStart(chr)) =>
           dictionary.let(_(chr.minuscule)) match
-            case Unset            => next() yet key(mark, Unset)
+            case Unset            => next() yet key(mark, Unset, true)
             case Dictionary.Empty => fail(UnknownAttributeStart(cursor.grab(mark, cursor.mark)))
-            case dictionary       => next() yet key(mark, dictionary)
+            case dictionary       => next() yet key(mark, dictionary, true)
 
-        case ' ' | Ff | Lf | Cr | Ht | '=' | '>' =>
+        case ' ' | Ff | Lf | Cr | Ht | '=' | '>' if started =>
           dictionary.let: dictionary =>
             dictionary.element.or:
               val name = cursor.grab(mark, cursor.mark)
@@ -462,11 +516,12 @@ object Xml extends Tag.Container
       case '&' =>
         val start = cursor.mark
         next()
-        val mark2 = entity(cursor.mark).lay(mark): text =>
-          cursor.clone(mark, start)(buffer)
-          buffer.append(text)
-          cursor.mark
-        value(mark2)
+        cursor.clone(mark, start)(buffer)
+        buffer.append(entity())
+        value(cursor.mark)
+
+      case '<' =>
+        fail(Unexpected('<'))
 
       case '"' =>
         cursor.clone(mark, cursor.mark)(buffer)
@@ -480,15 +535,22 @@ object Xml extends Tag.Container
 
     @tailrec
     def singleQuoted(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
-      case Sqt => cursor.grab(mark, cursor.mark).also(next())
-      case chr => next() yet singleQuoted(mark)
+      case '&' =>
+        val start = cursor.mark
+        next()
+        cursor.clone(mark, start)(buffer)
+        buffer.append(entity())
+        singleQuoted(cursor.mark)
 
-    @tailrec
-    def unquoted(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
-      case '>' | ' ' | Ff | Lf | Cr | Ht     => cursor.grab(mark, cursor.mark)
-      case chr@('"' | Sqt | '<' | '=' | '`') => fail(ForbiddenUnquoted(chr))
-      case Nul                               => fail(BadInsertion)
-      case chr                               => next() yet unquoted(mark)
+      case '<' =>
+        fail(Unexpected('<'))
+
+      case Sqt =>
+        cursor.clone(mark, cursor.mark)(buffer)
+        next() yet result()
+
+      case chr =>
+        next() yet singleQuoted(mark)
 
     def equality(): Unit = skip() yet cursor.lay(fail(ExpectedMore)):
       case '=' => next() yet skip() yet true
@@ -511,7 +573,7 @@ object Xml extends Tag.Container
 
         case _ =>
           val key2 =
-            key(cursor.mark, schema.attributes.unless(schema.freeform)).tap: key =>
+            key(cursor.mark, schema.attributes.unless(schema.freeform), false).tap: key =>
               if !schema.freeform && !key.targets(tag)
               then fail(InvalidAttributeUse(key.label, tag))
 
@@ -538,93 +600,82 @@ object Xml extends Tag.Container
           attributes(tag, entries.updated(key2, assignment))
 
 
-    def entity(mark: Mark)(using Cursor.Held): Optional[Text] = cursor.lay(fail(ExpectedMore)):
-      case '#'   => next() yet numericEntity(mark)
-      case other => textEntity(mark, schema.entities)
+    def entity()(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
+      case '#'   => next() yet numericEntity()
+      case other => textEntity()
 
-    def numericEntity(mark: Mark)(using Cursor.Held): Optional[Text] =
+    def numericEntity()(using Cursor.Held): Text =
       cursor.lay(fail(ExpectedMore)):
-        case 'x' => next() yet hexEntity(mark, 0)
-        case _   => decimalEntity(mark, 0)
+        case 'x' | 'X' => next() yet hexEntity(0)
+        case _         => decimalEntity(0)
 
     @tailrec
-    def hexEntity(mark: Mark, value: Int)(using Cursor.Held): Optional[Text] =
+    def hexEntity(value: Int)(using Cursor.Held): Text =
       cursor.lay(fail(ExpectedMore)):
         case digit if digit.isDigit =>
-          cursor.next() yet hexEntity(mark, 16*value + (digit - '0'))
+          cursor.next() yet hexEntity(16*value + (digit - '0'))
 
         case letter if 'a' <= letter <= 'f' =>
-          cursor.next() yet hexEntity(mark, 16*value + (letter - 87))
+          cursor.next() yet hexEntity(16*value + (letter - 87))
 
         case letter if 'A' <= letter <= 'F' =>
-          cursor.next() yet hexEntity(mark, 16*value + (letter - 55))
+          cursor.next() yet hexEntity(16*value + (letter - 55))
 
         case ';' =>
           cursor.next() yet value.unicode
 
         case chr =>
-          Unset
+          fail(Unexpected(chr))
 
     @tailrec
-    def decimalEntity(mark: Mark, value: Int): Optional[Text] = cursor.lay(fail(ExpectedMore)):
-      case digit if digit.isDigit => next() yet decimalEntity(mark, 10*value + (digit - '0'))
+    def decimalEntity(value: Int): Text = cursor.lay(fail(ExpectedMore)):
+      case digit if digit.isDigit => next() yet decimalEntity(10*value + (digit - '0'))
       case ';'                    => next() yet t"${value.toChar}"
-      case chr                    => Unset
+      case chr                    => fail(Unexpected(chr))
 
     @tailrec
-    def textEntity(mark: Mark, dictionary: Dictionary[Text])(using Cursor.Held): Optional[Text] =
-      cursor.lay(fail(ExpectedMore)):
-        case chr if chr.isLetter | chr.isDigit =>
-          dictionary(chr) match
-            case Dictionary.Empty => Unset
-            case dictionary       => cursor.next() yet textEntity(mark, dictionary)
+    def entityName(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
+      case chr if isNameChar(chr) => next() yet entityName(mark)
+      case ';'                    => cursor.grab(mark, cursor.mark)
+      case Nul                    => fail(BadInsertion)
+      case chr                    => fail(Unexpected(chr))
 
-        case ';' =>
-          cursor.next() yet dictionary(';').element
-
-        case '=' =>
-          Unset
-
-        case Nul =>
-          fail(BadInsertion)
-
-        case chr =>
-          dictionary.element
+    def textEntity()(using Cursor.Held): Text =
+      val mark = cursor.mark
+      val name = entityName(mark)
+      cursor.next()
+      schema.entities(name).or:
+        cursor.cue(mark)
+        fail(UnknownEntity(name))
 
 
     @tailrec
-    def textual(mark: Mark, close: Optional[Text], entities: Boolean)(using Cursor.Held): Text =
+    def textual(mark: Mark)(using Cursor.Held): Text =
       cursor.lay(cursor.clone(mark, cursor.mark)(buffer) yet result()):
         case '<' | Nul =>
-          close.lay(cursor.clone(mark, cursor.mark)(buffer) yet result()): tag =>
-            val end = cursor.mark
-            cursor.next()
-            val resume = cursor.mark
+          cursor.clone(mark, cursor.mark)(buffer) yet result()
 
-            if cursor.lay(false)(_ == '/') then
-              next()
-              val tagStart = cursor.mark
-              repeat(tag.length)(cursor.next())
-              val candidate = cursor.grab(tagStart, cursor.mark)
-              if cursor.more && candidate == tag then
-                if cursor.lay(false)(_ == '>')
-                then
-                  cursor.clone(mark, end)(buffer) yet result().also(cursor.next())
-                else cursor.cue(resume) yet textual(mark, tag, entities)
-              else cursor.cue(resume) yet textual(mark, tag, entities)
-            else cursor.cue(resume) yet textual(mark, tag, entities)
-
-        case '&' if entities =>
+        case '&' =>
           val start = cursor.mark
           next()
-          val mark2 = entity(cursor.mark).lay(mark): text =>
-            cursor.clone(mark, start)(buffer)
-            buffer.append(text)
-            cursor.mark
-          textual(mark2, close, entities)
+          cursor.clone(mark, start)(buffer)
+          buffer.append(entity())
+          textual(cursor.mark)
+
+        case ']' =>
+          val first = cursor.mark
+          next()
+          cursor.lay(textual(mark)):
+            case ']' =>
+              next()
+              cursor.lay(textual(mark)):
+                case '>' => fail(Unexpected('>'))
+                case _   => textual(mark)
+
+            case _ => textual(mark)
 
         case chr =>
-          cursor.next() yet textual(mark, close, entities)
+          cursor.next() yet textual(mark)
 
     def comment(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
       case '-' =>
@@ -641,17 +692,25 @@ object Xml extends Tag.Container
       case chr =>
         next() yet comment(mark)
 
+    @tailrec
     def cdata(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
       case ']' =>
         val end = cursor.mark
         next()
         cursor.lay(fail(ExpectedMore)):
-          case ']' => expect('>') yet cursor.grab(mark, end)
+          case ']' =>
+            val secondEnd = cursor.mark
+            next()
+            cursor.lay(fail(ExpectedMore)):
+              case '>' => cursor.grab(mark, end)
+              case _   => cdata(secondEnd)
+
           case _   => cdata(mark)
 
       case chr =>
         next() yet cdata(mark)
 
+    @tailrec
     def piData(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
       case '?' =>
         val end = cursor.mark
@@ -663,9 +722,20 @@ object Xml extends Tag.Container
       case chr =>
         next() yet piData(mark)
 
+    @tailrec
     def piTarget(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
-      case ' ' | Lf | Cr | Ff | Ht => cursor.grab(mark, cursor.mark)
-      case chr                     => next() yet piTarget(mark)
+      case ' ' | Lf | Cr | Ff | Ht | '?' => cursor.grab(mark, cursor.mark)
+      case chr                           => next() yet piTarget(mark)
+
+    @tailrec
+    def doctype(mark: Mark)(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
+      case '>' => cursor.grab(mark, cursor.mark).also(next())
+      case _   => next() yet doctype(mark)
+
+    def quotedValue()(using Cursor.Held): Text = cursor.lay(fail(ExpectedMore)):
+      case Dqt => next() yet value(cursor.mark)
+      case Sqt => next() yet singleQuoted(cursor.mark)
+      case _   => fail(UnquotedAttribute)
 
     def tag(headers: Boolean): Token = cursor.lay(fail(ExpectedMore)):
       case '?' if headers =>
@@ -679,11 +749,38 @@ object Xml extends Tag.Container
         cursor.consume(fail(ExpectedMore))("ersion")
         next()
         equality()
-        content = cursor.hold:
-          cursor.lay(fail(ExpectedMore)):
-            case Dqt => next() yet value(cursor.mark)
-            case Sqt => next() yet singleQuoted(cursor.mark)
-            case _   => fail(UnquotedAttribute)
+        content = cursor.hold(quotedValue())
+
+        headerEncoding = Unset
+        headerStandalone = Unset
+
+        skip()
+
+        cursor.let:
+          case 'e' =>
+            cursor.consume(fail(ExpectedMore))("ncoding")
+            next()
+            equality()
+            headerEncoding = cursor.hold(quotedValue())
+            skip()
+
+          case _ =>
+            ()
+
+        cursor.let:
+          case 's' =>
+            cursor.consume(fail(ExpectedMore))("tandalone")
+            next()
+            equality()
+            val standaloneValue: Text = cursor.hold(quotedValue())
+            headerStandalone = standaloneValue.s match
+              case "yes" => true
+              case "no"  => false
+              case _     => fail(Unexpected(standaloneValue.s.charAt(0)))
+            skip()
+
+          case _ =>
+            ()
 
         ensure('?')
         expect('>')
@@ -694,6 +791,17 @@ object Xml extends Tag.Container
       case '?' =>
         next()
         content = cursor.hold(piTarget(cursor.mark))
+
+        if content.s.length == 3 then
+          val first  = content.s.charAt(0)
+          val second = content.s.charAt(1)
+          val third  = content.s.charAt(2)
+
+          if (first == 'x' || first == 'X')
+          && (second == 'm' || second == 'M')
+          && (third == 'l' || third == 'L')
+          then fail(InvalidTag(content))
+
         skip()
         Token.Pi
 
@@ -711,21 +819,29 @@ object Xml extends Tag.Container
             cursor.consume(fail(ExpectedMore))("CDATA[")
             next()
             content = cursor.hold(cdata(cursor.mark))
+            cursor.next()
             Token.Cdata
+
+          case 'D' =>
+            cursor.consume(fail(ExpectedMore))("OCTYPE")
+            next()
+            skip()
+            content = cursor.hold(doctype(cursor.mark))
+            Token.Doctype
 
           case chr =>
             fail(Unexpected(chr))
 
       case '/' =>
         next()
-        content = cursor.hold(tagname(cursor.mark, schema.elements.unless(schema.freeform)).label)
+        content = cursor.hold(tagname(cursor.mark, schema.elements.unless(schema.freeform), false).label)
         Token.Close
 
       case Nul =>
         fail(BadInsertion)
 
       case chr =>
-        content = cursor.hold(tagname(cursor.mark, schema.elements.unless(schema.freeform)).label)
+        content = cursor.hold(tagname(cursor.mark, schema.elements.unless(schema.freeform), false).label)
         extra = cursor.hold(attributes(content))
 
         cursor.lay(fail(ExpectedMore)):
@@ -786,10 +902,15 @@ object Xml extends Tag.Container
               next()
             else tag(headers && parent == root) match
               case Token.Comment => current = Comment(content)
-              case Token.Header  => current = Header(content, Unset, Unset)
+              case Token.Header  =>
+                current = Header(content, headerEncoding, headerStandalone)
+                headers = false
               case Token.Cdata   => current = Cdata(content)
+              case Token.Doctype => current = Doctype(content)
               case Token.Pi      =>
-                current = ProcessingInstruction(content, cursor.hold(piData(cursor.mark)))
+                val data = cursor.hold(piData(cursor.mark))
+                cursor.next()
+                current = ProcessingInstruction(content, data)
 
               case Token.Empty   =>
                 if admit(content) then empty() else fail(InvalidTag(content))
@@ -824,7 +945,7 @@ object Xml extends Tag.Container
               read(parent, map, count + 1)
 
         case chr =>
-          val text = cursor.hold(textual(cursor.mark, Unset, true))
+          val text = cursor.hold(textual(cursor.mark))
           if text.length == 0 then read(parent, map, count + 1)
           else append(TextNode(text)) yet read(parent, map, count + 1)
 
@@ -859,6 +980,14 @@ case class Comment(text: Text) extends Node:
   override def equals(that: Any): Boolean = that match
     case Comment(text0)           => text0 == text
     case Fragment(Comment(text0)) => text0 == text
+    case _                        => false
+
+case class Doctype(text: Text) extends Node:
+  override def hashCode: Int = List(this).hashCode
+
+  override def equals(that: Any): Boolean = that match
+    case Doctype(text0)           => text0 == text
+    case Fragment(Doctype(text0)) => text0 == text
     case _                        => false
 
 case class Cdata(text: Text) extends Node:

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -231,28 +231,26 @@ object Xml extends Tag.Container
     emitter.iterator
 
 
-  private def escapeText(text: Text): Text =
-    val builder = jl.StringBuilder()
+  private def appendEscapedText(builder: jl.StringBuilder, text: Text): Unit =
+    val source = text.s
+    val length = source.length
     var index = 0
-    val length = text.s.length
 
     while index < length do
-      text.s.charAt(index) match
+      source.charAt(index) match
         case '<' => builder.append("&lt;")
         case '&' => builder.append("&amp;")
         case chr => builder.append(chr)
 
       index += 1
 
-    builder.toString.tt
-
-  private def escapeAttribute(text: Text): Text =
-    val builder = jl.StringBuilder()
+  private def appendEscapedAttribute(builder: jl.StringBuilder, text: Text): Unit =
+    val source = text.s
+    val length = source.length
     var index = 0
-    val length = text.s.length
 
     while index < length do
-      text.s.charAt(index) match
+      source.charAt(index) match
         case '<' => builder.append("&lt;")
         case '&' => builder.append("&amp;")
         case '"' => builder.append("&quot;")
@@ -260,35 +258,85 @@ object Xml extends Tag.Container
 
       index += 1
 
-    builder.toString.tt
+  private def appendXml(builder: jl.StringBuilder, node: Xml): Unit = node match
+    case fragment: Fragment =>
+      val nodes = fragment.nodes
+      var index = 0
 
-  given showable: [xml <: Xml] => xml is Showable =
-    case Fragment(nodes*)                    => nodes.map(_.show).join
-    case TextNode(text)                      => escapeText(text)
-    case Comment(text)                       => t"<!--$text-->"
-    case Cdata(text)                         => t"<![CDATA[$text]]>"
-    case Doctype(text)                       => t"<!DOCTYPE $text>"
+      while index < nodes.length do
+        appendXml(builder, nodes(index))
+        index += 1
+
+    case TextNode(text) =>
+      appendEscapedText(builder, text)
+
+    case Comment(text) =>
+      builder.append("<!--")
+      builder.append(text.s)
+      builder.append("-->")
+
+    case Cdata(text) =>
+      builder.append("<![CDATA[")
+      builder.append(text.s)
+      builder.append("]]>")
+
+    case Doctype(text) =>
+      builder.append("<!DOCTYPE ")
+      builder.append(text.s)
+      builder.append('>')
+
     case ProcessingInstruction(target, data) =>
-      if data.s.isEmpty then t"<?$target?>" else t"<?$target $data?>"
+      builder.append("<?")
+      builder.append(target.s)
+
+      if !data.s.isEmpty then
+        builder.append(' ')
+        builder.append(data.s)
+
+      builder.append("?>")
 
     case Header(version, encoding, standalone) =>
-      val encodingText = encoding.lay(t""): encoding =>
-        t""" encoding="$encoding""""
+      builder.append("<?xml version=\"")
+      builder.append(version.s)
+      builder.append('"')
 
-      val standaloneText = standalone.lay(t""): standalone =>
-        if standalone then t""" standalone="yes"""" else t""" standalone="no""""
+      encoding.let: encoding =>
+        builder.append(" encoding=\"")
+        builder.append(encoding.s)
+        builder.append('"')
 
-      t"""<?xml version="$version"$encodingText$standaloneText?>"""
+      standalone.let: standalone =>
+        builder.append(if standalone then " standalone=\"yes\"" else " standalone=\"no\"")
+
+      builder.append("?>")
 
     case Element(tagname, attributes, children) =>
-      val tagContent = if attributes.nil then t"" else
-        attributes.map:
-          case (key, value) => t"""$key="${escapeAttribute(value)}""""
+      builder.append('<')
+      builder.append(tagname.s)
 
-        . join(t" ", t" ", t"")
+      if !attributes.nil then attributes.foreach: (key, value) =>
+        builder.append(' ')
+        builder.append(key.s)
+        builder.append("=\"")
+        appendEscapedAttribute(builder, value)
+        builder.append('"')
 
-      if children.nil then t"<$tagname$tagContent/>"
-      else t"<$tagname$tagContent>${children.map(_.show).join}</$tagname>"
+      if children.nil then builder.append("/>") else
+        builder.append('>')
+        var index = 0
+
+        while index < children.length do
+          appendXml(builder, children(index))
+          index += 1
+
+        builder.append("</")
+        builder.append(tagname.s)
+        builder.append('>')
+
+  given showable: [xml <: Xml] => xml is Showable = node =>
+    val builder = jl.StringBuilder()
+    appendXml(builder, node)
+    builder.toString.tt
 
 
   private enum Token:
@@ -663,7 +711,6 @@ object Xml extends Tag.Container
           textual(cursor.mark)
 
         case ']' =>
-          val first = cursor.mark
           next()
           cursor.lay(textual(mark)):
             case ']' =>
@@ -975,7 +1022,7 @@ sealed into trait Xml extends Dynamic, Topical, Documentary, Formal:
 sealed trait Node extends Xml
 
 case class Comment(text: Text) extends Node:
-  override def hashCode: Int = List(this).hashCode
+  override def hashCode: Int = text.hashCode*31 + 0x436F6D6D
 
   override def equals(that: Any): Boolean = that match
     case Comment(text0)           => text0 == text
@@ -983,7 +1030,7 @@ case class Comment(text: Text) extends Node:
     case _                        => false
 
 case class Doctype(text: Text) extends Node:
-  override def hashCode: Int = List(this).hashCode
+  override def hashCode: Int = text.hashCode*31 + 0x44637470
 
   override def equals(that: Any): Boolean = that match
     case Doctype(text0)           => text0 == text
@@ -991,7 +1038,7 @@ case class Doctype(text: Text) extends Node:
     case _                        => false
 
 case class Cdata(text: Text) extends Node:
-  override def hashCode: Int = List(this).hashCode // FIXME: infinite recursion
+  override def hashCode: Int = text.hashCode*31 + 0x43646174
 
   override def equals(that: Any): Boolean = that match
     case Cdata(text0)           => text0 == text
@@ -999,7 +1046,7 @@ case class Cdata(text: Text) extends Node:
     case _                      => false
 
 case class ProcessingInstruction(target: Text, data: Text) extends Node:
-  override def hashCode: Int = List(this).hashCode // FIXME
+  override def hashCode: Int = (target.hashCode*31 + data.hashCode)*31 + 0x50494E73
 
   override def equals(that: Any): Boolean = that match
     case ProcessingInstruction(target0, data0)           => target0 == target && data0 == data
@@ -1009,7 +1056,7 @@ case class ProcessingInstruction(target: Text, data: Text) extends Node:
 case class TextNode(text: Text) extends Node:
   type Topic = "#text"
 
-  override def hashCode: Int = List(this).hashCode // FIXME: infinite recursion
+  override def hashCode: Int = text.hashCode*31 + 0x54657874
 
   override def equals(that: Any): Boolean = that match
     case Fragment(textual: TextNode) => this == textual
@@ -1068,7 +1115,8 @@ case class Fragment(nodes: Node*) extends Xml:
 
 case class Header(version: Text, encoding: Optional[Text], standalone: Optional[Boolean])
 extends Node:
-  override def hashCode: Int = List(this).hashCode
+  override def hashCode: Int =
+    ((version.hashCode*31 + encoding.hashCode)*31 + standalone.hashCode)*31 + 0x48646572
 
   override def equals(that: Any): Boolean = that match
     case Fragment(header: Header) => equals(header)

--- a/lib/xylophone/src/core/xylophone.XmlSchema.scala
+++ b/lib/xylophone/src/core/xylophone.XmlSchema.scala
@@ -50,12 +50,20 @@ object XmlSchema:
   private[xylophone] val entities: scm.HashMap[XmlSchema, Dictionary[Text]] = scm.HashMap()
   val generic = Tag.root(Set())
 
+  val defaultEntities: Dictionary[Text] =
+    Dictionary
+     ( t"amp"  -> t"&",
+       t"lt"   -> t"<",
+       t"gt"   -> t">",
+       t"apos" -> t"'",
+       t"quot" -> t"\"" )
+
   object Freeform extends XmlSchema:
     override def freeform = true
 
     val elements = Dictionary()
     val attributes = Dictionary()
-    val entities = Dictionary()
+    val entities = defaultEntities
 
     def infer(parent: Tag, child: Tag) = Unset
 

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -279,6 +279,9 @@ object internal:
             val checked = checkFragment(array, fragment, '{$scrutinee.asInstanceOf[Fragment]})
             '{$expr && $scrutinee.isInstanceOf[Fragment] && $checked}
 
+          case Doctype(_) =>
+            halt(m"DOCTYPE patterns are not supported in extractors")
+
 
       val result: Expr[Extrapolation[Xml]] =
         ' {
@@ -495,6 +498,9 @@ object internal:
           val content = recur(parts.tail, Expr(parts.head))
 
           List('{TextNode($content.tt)})
+
+        case Doctype(text) =>
+          List('{Doctype(${Expr(text)})})
 
       def resultType(xml: Xml): Set[String] = xml match
         case TextNode(_)        => Set("#text")

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -52,9 +52,17 @@ enum ColorVal:
 case class Pixel(x: Int, y: Int, color: ColorVal)
 
 object Tests extends Suite(m"Xylophone tests"):
+
+  def elem(label: Text, children: Node*): Element =
+    Element(label, scala.collection.immutable.ListMap(), IArray.from(children))
+
+  def elem(label: Text, attrs: Map[Text, Text], children: Node*): Element =
+    Element(label, attrs, IArray.from(children))
+
   def run(): Unit =
+    given XmlSchema = XmlSchema.Freeform
+
     suite(m"Interpolator tests"):
-      given XmlSchema = XmlSchema.Freeform
       test(m"Simple interpolator"):
         x"<message>1</message>"
       . assert(_ == t"<message>1</message>".read[Xml])
@@ -84,162 +92,646 @@ object Tests extends Suite(m"Xylophone tests"):
       x"""<email>test@example.com</email>""".as[EmailAddress]
     . assert(_ == t"test@example.com".decode[EmailAddress])
 
-    // test(m"extract string"):
-    //   t"""<message>Hello world</message>""".read[Xml].as[Text]
-    // .assert(_ == t"Hello world")
+    suite(m"Element parsing"):
+      test(m"Empty self-closing element"):
+        t"<a/>".read[Xml]
+      . assert(_ == elem(t"a"))
 
-    // test(m"extract string from fragment"):
-    //   val xml = t"""<message><info>Hello world</info></message>""".read[Xml]
-    //   xml.info.as[Text]
-    // .assert(_ == t"Hello world")
+      test(m"Empty start/end element"):
+        t"<a></a>".read[Xml]
+      . assert(_ == elem(t"a"))
 
-    // test(m"extract string from node"):
-    //   val xml = t"""<message><info>Hello world</info></message>""".read[Xml]
-    //   xml.info().as[Text]
-    // .assert(_ == t"Hello world")
+      test(m"Element with text"):
+        t"<a>hello</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"hello")))
 
-    // test(m"serialize simple case class"):
-    //   val person = Worker(t"Jack", 50)
-    //   person.xml.string
-    // .assert(_ == t"<Worker><name>Jack</name><age>50</age></Worker>")
+      test(m"Nested element"):
+        t"<a><b/></a>".read[Xml]
+      . assert(_ == elem(t"a", elem(t"b")))
 
-    // test(m"serialize nested case class"):
-    //   val person = Worker(t"Jack", 50)
-    //   val company = Firm(t"Acme Inc", person)
-    //   company.xml.string
-    // .assert(_ == t"<Firm><name>Acme Inc</name><ceo><name>Jack</name><age>50</age></ceo></Firm>")
+      test(m"Deeply nested elements"):
+        t"<a><b><c><d/></c></b></a>".read[Xml]
+      . assert(_ == elem(t"a", elem(t"b", elem(t"c", elem(t"d")))))
 
-    // test(m"access second element"):
-    //   val xml = t"""<events><eventId>1</eventId><eventId>2</eventId></events>""".read[Xml]
-    //   xml.eventId(1).as[Int]
-    // .assert(_ == 2)
+      test(m"Mixed content (text and elements)"):
+        t"<a>text<b/>more</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"text"), elem(t"b"), TextNode(t"more")))
 
-    // test(m"extract to simple case class"):
-    //   val string = t"<jack><name>Jack</name><age>50</age></jack>"
-    //   val xml = string.read[Xml]
-    //   xml.as[Worker]
-    // .assert(_ == Worker(t"Jack", 50))
+      test(m"Self-closing element with whitespace before slash"):
+        t"<a />".read[Xml]
+      . assert(_ == elem(t"a"))
 
-    // test(m"extract to nested case class"):
-    //   val string = t"<Firm><name>Acme Inc</name><ceo><name>Jack</name><age>50</age></ceo></Firm>"
-    //   val xml = string.read[Xml]
-    //   xml.as[Firm]
-    // .assert(_ == Firm(t"Acme Inc", Worker(t"Jack", 50)))
+      test(m"Element name is case-sensitive"):
+        t"<Foo/>".read[Xml]
+      . assert(_ == elem(t"Foo"))
 
-    // test(m"serialize with attribute"):
-    //   val book = Book(t"Lord of the Flies", t"9780399529207")
-    //   book.xml.string
-    // .assert(_ == t"<Book isbn=\"9780399529207\"><title>Lord of the Flies</title></Book>")
+      test(m"Element name with mixed case is preserved"):
+        t"<FooBar/>".read[Xml]
+      . assert(_ == elem(t"FooBar"))
 
-    // test(m"serialize nested type with attribute"):
-    //   val bibliography = Bibliography(t"William Golding", Book(t"Lord of the Flies", t"9780399529207"))
-    //   bibliography.xml.string
-    // .assert(_ == t"<Bibliography><author>William Golding</author><book isbn=\"9780399529207\"><title>Lord of the Flies</title></book></Bibliography>")
+      test(m"Element name with underscore"):
+        t"<a_b/>".read[Xml]
+      . assert(_ == elem(t"a_b"))
 
-    // test(m"serialize coproduct"):
-    //   val color: ColorVal = ColorVal.Rgb(5, 10, 15)
-    //   color.xml.string
+      test(m"Element name starting with underscore"):
+        t"<_a/>".read[Xml]
+      . assert(_ == elem(t"_a"))
 
-    // . assert: value =>
-    //     value == t"""<ColorVal type="Rgb"><red>5</red><green>10</green><blue>15</blue></ColorVal>"""
+      test(m"Element name with hyphen"):
+        t"<a-b/>".read[Xml]
+      . assert(_ == elem(t"a-b"))
 
-    // test(m"serialize nested coproduct"):
-    //   val pixel: Pixel = Pixel(100, 200, ColorVal.Cmyk(1, 2, 3, 4))
-    //   pixel.xml.string
-    // .assert(_ == t"""<Pixel><x>100</x><y>200</y><color type="Cmyk"><cyan>1</cyan><magenta>2</magenta><yellow>3</yellow><key>4</key></color></Pixel>""")
+      test(m"Element name with period"):
+        t"<a.b/>".read[Xml]
+      . assert(_ == elem(t"a.b"))
 
-    // test(m"read coproduct"):
-    //   val string = t"""<ColorVal type="Cmyk"><cyan>1</cyan><magenta>2</magenta><yellow>3</yellow><key>4</key></ColorVal>"""
-    //   val xml = string.read[Xml]
-    //   xml.as[ColorVal]
-    // .assert(_ == ColorVal.Cmyk(1, 2, 3, 4))
+      test(m"Element name with digit (not first)"):
+        t"<a1/>".read[Xml]
+      . assert(_ == elem(t"a1"))
 
-    // test(m"read nested coproduct"):
-    //   val string = t"""<Pixel><x>100</x><y>200</y><color type="Cmyk"><cyan>1</cyan><magenta>2</magenta><yellow>3</yellow><key>4</key></color></Pixel>"""
-    //   val xml = string.read[Xml]
-    //   xml.as[Pixel]
-    // .assert(_ == Pixel(100, 200, ColorVal.Cmyk(1, 2, 3, 4)))
+      test(m"Whitespace between elements is preserved"):
+        t"<a> <b/> </a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t" "), elem(t"b"), TextNode(t" ")))
 
-    // test(m"read attribute value from fragment"):
-    //   val string = t"""<node><content key="value"/></node>"""
-    //   val xml = string.read[Xml]
-    //   xml.content.attribute(t"key").as[Text]
-    // .assert(_ == t"value")
+      test(m"Multiple sibling elements"):
+        t"<a><b/><c/><d/></a>".read[Xml]
+      . assert(_ == elem(t"a", elem(t"b"), elem(t"c"), elem(t"d")))
 
-    // test(m"read attribute value from node"):
-    //   val string = t"""<node><content key="value"/></node>"""
-    //   val xml = string.read[Xml]
-    //   xml.content().attribute(t"key").as[Text]
-    // .assert(_ == t"value")
 
-    // test(m"read with namespace"):
-    //   val string = t"""<?xml version="1.0"?>
-    //                     |<root>
-    //                     |<h:table xmlns:h="http://www.w3.org/TR/html4/">
-    //                     |  <h:tr>
-    //                     |    <h:td>Apples</h:td>
-    //                     |    <h:td>Bananas</h:td>
-    //                     |  </h:tr>
-    //                     |</h:table>
-    //                     |</root>""".s.stripMargin
+    suite(m"Element name validation"):
+      test(m"Element name cannot start with digit"):
+        capture[ParseError](t"<1a/>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case _: Xml.Issue.InvalidTagStart => true
+            case _: Xml.Issue.Unexpected     => true
+            case _                           => false
 
-    //   val xml = string.tt.read[Xml]
-    //   xml.table.tr.td().as[Text]
-    // .assert(_ == t"Apples")
+      test(m"Element name cannot start with hyphen"):
+        capture[ParseError](t"<-a/>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case _: Xml.Issue.Unexpected => true
+            case _                       => false
 
-    // test(m"serialize list of strings"):
-    //   val xs = List(t"one", t"two", t"three")
-    //   Xml.print(xs.xml)
-    // .assert(_ == t"<Seq><Text>one</Text><Text>two</Text><Text>three</Text></Seq>")
+      test(m"Element name cannot start with period"):
+        capture[ParseError](t"<.a/>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case _: Xml.Issue.Unexpected => true
+            case _                       => false
 
-    // test(m"serialize list of complex objects"):
-    //   val book1 = Book(t"Lord of the Flies", t"9780399529207")
-    //   val book2 = Book(t"Brave New World", t"9781907704345")
-    //   val books = List(book1, book2)
-    //   Xml.print(books.xml)
-    // .assert(_ == t"""<Seq><Book isbn="9780399529207"><title>Lord of the Flies</title></Book><Book isbn="9781907704345"><title>Brave New World</title></Book></Seq>""")
 
-    // test(m"serialize empty node"):
-    //   Xml.print(List[Text]().xml)
-    // .assert(_ == t"<Seq/>")
+    suite(m"Attribute parsing"):
+      test(m"Single attribute with double quotes"):
+        t"""<a x="1"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1")))
 
-    // test(m"serialize case object"):
-    //   case object Foo
-    //   Xml.print(Foo.xml)
-    // .assert(_ == t"<Foo/>")
+      test(m"Single attribute with single quotes"):
+        t"<a x='1'/>".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1")))
 
-    // test(m"parse error: unclosed tag"):
-    //   capture(t"""<foo key="value"><bar></foo>""".read[Xml])
-    // .assert(_ == XmlParseError(0, 24))
+      test(m"Multiple attributes"):
+        t"""<a x="1" y="2"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1", t"y" -> t"2")))
 
-    // test(m"parse error: unclosed string"):
-    //   capture(t"""<foo key="value><bar/></foo>""".read[Xml])
-    // .assert(_ == XmlParseError(0, 16))
+      test(m"Empty attribute value"):
+        t"""<a x=""/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"")))
 
-    // test(m"read error: not an integer"):
-    //   val xml = t"""<foo>not an integer</foo>""".read[Xml]
-    //   capture(xml.as[Int])
-    // .assert(NumberError(t"not an integer", Int) == _)
+      test(m"Whitespace around equals sign"):
+        t"""<a x = "1"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1")))
 
-    // test(m"access error; proactively resolving head nodes"):
-    //   val xml = t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""".read[Xml]
-    //   capture(xml.company().staff().cto().name().as[Text])
-    // .assert(_ == XmlError(0, List(t"company", 0, t"staff", 0, t"cto")))
+      test(m"Whitespace before equals sign"):
+        t"""<a x ="1"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1")))
 
-    // test(m"access error; taking all children"):
-    //   val xml = t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""".read[Xml]
-    //   capture(xml.company.staff.cto.name().as[Text])
-    // .assert(_ == XmlError(0, List(t"company", t"staff", t"cto", t"name")))
+      test(m"Whitespace after equals sign"):
+        t"""<a x= "1"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1")))
 
-    // test(m"access non-zero node"):
-    //   val xml = t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""".read[Xml]
-    //   capture(xml.company(1).staff().cto.name().as[Text])
-    // .assert(_ == XmlError(1, List(t"company")))
+      test(m"Attribute name with hyphen"):
+        t"""<a a-b="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"a-b" -> t"c")))
 
-    // // test(m"simple literal content is as expected"):
-    // //   x"""<root attribute=""/>""".show
-    // // .assert(_ == t"""<root attribute=""/>""")
+      test(m"Attribute name with underscore"):
+        t"""<a a_b="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"a_b" -> t"c")))
 
-    // // test(m"literal content is as expected"):
-    // //   x"<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>"
-    // // .assert(_ == t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""")
+      test(m"Attribute name with period"):
+        t"""<a a.b="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"a.b" -> t"c")))
+
+      test(m"Attribute name with digit"):
+        t"""<a a1="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"a1" -> t"c")))
+
+      test(m"Attribute name starting with underscore"):
+        t"""<a _x="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"_x" -> t"c")))
+
+      test(m"Duplicate attribute is rejected"):
+        capture[ParseError](t"""<a x="1" x="2"/>""".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.DuplicateAttribute(t"x") => true
+            case _                                  => false
+
+      test(m"Unquoted attribute is rejected"):
+        capture[ParseError](t"<a x=1/>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.UnquotedAttribute => true
+            case _                           => false
+
+      test(m"Attribute value with entity reference"):
+        t"""<a x="&amp;"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"&")))
+
+      test(m"Attribute value with character reference"):
+        t"""<a x="&#65;"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"A")))
+
+      test(m"Attribute value with hex character reference"):
+        t"""<a x="&#x41;"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"A")))
+
+      test(m"Single-quoted attribute may contain double quote"):
+        t"""<a x='one "two" three'/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"""one "two" three""")))
+
+      test(m"Double-quoted attribute may contain single quote"):
+        t"""<a x="one 'two' three"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"one 'two' three")))
+
+
+    suite(m"Comments"):
+      test(m"Simple comment inside element"):
+        t"<a><!-- hello --></a>".read[Xml]
+      . assert(_ == elem(t"a", Comment(t" hello ")))
+
+      test(m"Empty comment"):
+        t"<a><!----></a>".read[Xml]
+      . assert(_ == elem(t"a", Comment(t"")))
+
+      test(m"Comment with single hyphen"):
+        t"<a><!-- a-b --></a>".read[Xml]
+      . assert(_ == elem(t"a", Comment(t" a-b ")))
+
+      test(m"Comment containing entity-like text"):
+        t"<a><!-- &amp; --></a>".read[Xml]
+      . assert(_ == elem(t"a", Comment(t" &amp; ")))
+
+      test(m"Comment containing tag-like text"):
+        t"<a><!-- <foo/> --></a>".read[Xml]
+      . assert(_ == elem(t"a", Comment(t" <foo/> ")))
+
+      test(m"Comment with double-hyphen is rejected"):
+        capture[ParseError](t"<a><!-- a -- b --></a>".read[Xml])
+      . assert(_.issue.isInstanceOf[Xml.Issue.Unexpected])
+
+
+    suite(m"CDATA sections"):
+      test(m"Simple CDATA section"):
+        t"<a><![CDATA[hello]]></a>".read[Xml]
+      . assert(_ == elem(t"a", Cdata(t"hello")))
+
+      test(m"Empty CDATA section"):
+        t"<a><![CDATA[]]></a>".read[Xml]
+      . assert(_ == elem(t"a", Cdata(t"")))
+
+      test(m"CDATA containing tag-like text"):
+        t"<a><![CDATA[<not a tag>]]></a>".read[Xml]
+      . assert(_ == elem(t"a", Cdata(t"<not a tag>")))
+
+      test(m"CDATA containing entity-like text"):
+        t"<a><![CDATA[&not;]]></a>".read[Xml]
+      . assert(_ == elem(t"a", Cdata(t"&not;")))
+
+      test(m"CDATA with single closing bracket"):
+        t"<a><![CDATA[a]b]]></a>".read[Xml]
+      . assert(_ == elem(t"a", Cdata(t"a]b")))
+
+
+    suite(m"Processing instructions"):
+      test(m"Simple processing instruction"):
+        t"<a><?target data?></a>".read[Xml]
+      . assert(_ == elem(t"a", ProcessingInstruction(t"target", t"data")))
+
+      test(m"Processing instruction with no data"):
+        t"<a><?target?></a>".read[Xml]
+      . assert(_ == elem(t"a", ProcessingInstruction(t"target", t"")))
+
+      test(m"Processing instruction with multi-word data"):
+        t"<a><?target one two three?></a>".read[Xml]
+      . assert(_ == elem(t"a", ProcessingInstruction(t"target", t"one two three")))
+
+      test(m"Processing instruction at root level"):
+        t"<?xml-stylesheet href='style.xsl'?><a/>".read[Xml]
+      . assert: result =>
+          result == Fragment(
+            ProcessingInstruction(t"xml-stylesheet", t"href='style.xsl'"),
+            elem(t"a"))
+
+      test(m"Processing instruction target cannot be xml"):
+        capture[ParseError](t"<a><?xml foo?></a>".read[Xml])
+      . assert(_.issue.isInstanceOf[Xml.Issue.InvalidTag])
+
+      test(m"Processing instruction target cannot be XML"):
+        capture[ParseError](t"<a><?XML foo?></a>".read[Xml])
+      . assert(_.issue.isInstanceOf[Xml.Issue.InvalidTag])
+
+
+    suite(m"Character and entity references"):
+      test(m"Built-in entity &amp;"):
+        t"<a>&amp;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"&")))
+
+      test(m"Built-in entity &lt;"):
+        t"<a>&lt;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"<")))
+
+      test(m"Built-in entity &gt;"):
+        t"<a>&gt;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t">")))
+
+      test(m"Built-in entity &quot;"):
+        t"""<a>&quot;</a>""".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"\"")))
+
+      test(m"Built-in entity &apos;"):
+        t"<a>&apos;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"'")))
+
+      test(m"Decimal character reference"):
+        t"<a>&#65;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"A")))
+
+      test(m"Hex character reference (lowercase)"):
+        t"<a>&#x41;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"A")))
+
+      test(m"Hex character reference (uppercase X)"):
+        t"<a>&#X41;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"A")))
+
+      test(m"Mixed text and entities"):
+        t"<a>foo &amp; bar</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"foo & bar")))
+
+      test(m"Multiple entities in sequence"):
+        t"<a>&lt;&gt;&amp;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"<>&")))
+
+      test(m"Hex char ref for emoji"):
+        t"<a>&#x1f600;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"😀")))
+
+
+    suite(m"Whitespace handling"):
+      test(m"Leading whitespace inside element"):
+        t"<a>  hello</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"  hello")))
+
+      test(m"Trailing whitespace inside element"):
+        t"<a>hello  </a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"hello  ")))
+
+      test(m"Internal whitespace preserved"):
+        t"<a>one  two</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"one  two")))
+
+      test(m"Newlines preserved"):
+        t"<a>one\ntwo</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"one\ntwo")))
+
+      test(m"Tab preserved"):
+        t"<a>one\ttwo</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"one\ttwo")))
+
+
+    suite(m"XML declarations"):
+      test(m"Simple XML declaration"):
+        supervise:
+          t"""<?xml version="1.0"?><a/>""".load[Xml]
+      . assert(_ == Document(elem(t"a"), Header(t"1.0", Unset, Unset)))
+
+      test(m"XML declaration with encoding"):
+        supervise:
+          t"""<?xml version="1.0" encoding="UTF-8"?><a/>""".load[Xml]
+      . assert(_ == Document(elem(t"a"), Header(t"1.0", t"UTF-8", Unset)))
+
+      test(m"XML declaration with standalone yes"):
+        supervise:
+          t"""<?xml version="1.0" standalone="yes"?><a/>""".load[Xml]
+      . assert(_ == Document(elem(t"a"), Header(t"1.0", Unset, true)))
+
+      test(m"XML declaration with standalone no"):
+        supervise:
+          t"""<?xml version="1.0" standalone="no"?><a/>""".load[Xml]
+      . assert(_ == Document(elem(t"a"), Header(t"1.0", Unset, false)))
+
+      test(m"XML declaration with encoding and standalone"):
+        supervise:
+          t"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?><a/>""".load[Xml]
+      . assert(_ == Document(elem(t"a"), Header(t"1.0", t"UTF-8", true)))
+
+      test(m"XML declaration with single-quoted version"):
+        supervise:
+          t"""<?xml version='1.0'?><a/>""".load[Xml]
+      . assert(_ == Document(elem(t"a"), Header(t"1.0", Unset, Unset)))
+
+
+    suite(m"Document errors"):
+      test(m"Mismatched closing tag"):
+        capture[ParseError](t"<a></b>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.MismatchedTag(t"a", t"b") => true
+            case _                                   => false
+
+      test(m"Unopened closing tag"):
+        capture[ParseError](t"</a>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.UnopenedTag(t"a") => true
+            case _                           => false
+
+      test(m"Unclosed element"):
+        capture[ParseError](t"<a>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.Incomplete(t"a") => true
+            case _                          => false
+
+      test(m"Unclosed nested element"):
+        capture[ParseError](t"<a><b></a>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.MismatchedTag(t"b", t"a") => true
+            case _                                   => false
+
+      test(m"Unknown entity reference"):
+        capture[ParseError](t"<a>&unknown;</a>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.UnknownEntity(t"unknown") => true
+            case _                                   => false
+
+      test(m"Literal ]]> in text is rejected"):
+        capture[ParseError](t"<a>foo]]>bar</a>".read[Xml])
+      . assert(_.issue.isInstanceOf[Xml.Issue.Unexpected])
+
+
+    suite(m"Namespaces"):
+      test(m"Element with default namespace declaration"):
+        t"""<a xmlns="http://example.com"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xmlns" -> t"http://example.com")))
+
+      test(m"Element with prefixed namespace declaration"):
+        t"""<a xmlns:p="http://example.com"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xmlns:p" -> t"http://example.com")))
+
+      test(m"Prefixed element name"):
+        t"<p:a/>".read[Xml]
+      . assert(_ == elem(t"p:a"))
+
+      test(m"Prefixed element with prefixed close"):
+        t"<p:a></p:a>".read[Xml]
+      . assert(_ == elem(t"p:a"))
+
+      test(m"Prefixed attribute name"):
+        t"""<a p:b="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"p:b" -> t"c")))
+
+      test(m"Element with namespace declaration and prefixed attribute"):
+        t"""<a xmlns:p="http://example.com" p:b="c"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xmlns:p" -> t"http://example.com", t"p:b" -> t"c")))
+
+      test(m"Nested prefixed elements"):
+        t"""<root xmlns:h="http://example.com"><h:table><h:tr><h:td>cell</h:td></h:tr></h:table></root>"""
+        . read[Xml]
+      . assert: result =>
+          result == elem(t"root", Map(t"xmlns:h" -> t"http://example.com"),
+            elem(t"h:table",
+              elem(t"h:tr",
+                elem(t"h:td", TextNode(t"cell")))))
+
+
+    suite(m"DOCTYPE"):
+      test(m"Simple DOCTYPE is preserved as a node"):
+        t"""<!DOCTYPE root><root/>""".read[Xml]
+      . assert(_ == Fragment(Doctype(t"root"), elem(t"root")))
+
+      test(m"DOCTYPE roundtrip"):
+        Doctype(t"root").show
+      . assert(_ == t"<!DOCTYPE root>")
+
+
+    suite(m"Roundtrip serialization"):
+      test(m"Empty element"):
+        t"<a/>".read[Xml].show
+      . assert(_ == t"<a/>")
+
+      test(m"Element with text"):
+        t"<a>hello</a>".read[Xml].show
+      . assert(_ == t"<a>hello</a>")
+
+      test(m"Element with attribute"):
+        t"""<a x="1"/>""".read[Xml].show
+      . assert(_ == t"""<a x="1"/>""")
+
+      test(m"Element escapes special characters in text"):
+        elem(t"a", TextNode(t"<&>")).show
+      . assert(_ == t"<a>&lt;&amp;></a>")
+
+      test(m"Element escapes special characters in attribute"):
+        elem(t"a", Map(t"x" -> t"\"&'<")).show
+      . assert(_ == t"""<a x="&quot;&amp;'&lt;"/>""")
+
+      test(m"Comment roundtrip"):
+        elem(t"a", Comment(t" hello ")).show
+      . assert(_ == t"<a><!-- hello --></a>")
+
+      test(m"CDATA roundtrip"):
+        elem(t"a", Cdata(t"raw <data>")).show
+      . assert(_ == t"<a><![CDATA[raw <data>]]></a>")
+
+      test(m"Processing instruction roundtrip"):
+        elem(t"a", ProcessingInstruction(t"target", t"data")).show
+      . assert(_ == t"<a><?target data?></a>")
+
+      test(m"Empty PI roundtrip"):
+        elem(t"a", ProcessingInstruction(t"target", t"")).show
+      . assert(_ == t"<a><?target?></a>")
+
+      test(m"Header without encoding or standalone roundtrips"):
+        Header(t"1.0", Unset, Unset).show
+      . assert(_ == t"""<?xml version="1.0"?>""")
+
+      test(m"Header with encoding roundtrips"):
+        Header(t"1.0", t"UTF-8", Unset).show
+      . assert(_ == t"""<?xml version="1.0" encoding="UTF-8"?>""")
+
+      test(m"Header with standalone roundtrips"):
+        Header(t"1.0", Unset, true).show
+      . assert(_ == t"""<?xml version="1.0" standalone="yes"?>""")
+
+
+    suite(m"Documents with prologs"):
+      test(m"Document with comment in prolog"):
+        supervise:
+          t"""<?xml version="1.0"?><!--prolog comment--><a/>""".load[Xml]
+      . assert: doc =>
+          doc == Document(
+            Fragment(Comment(t"prolog comment"), elem(t"a")),
+            Header(t"1.0", Unset, Unset))
+
+      test(m"Document with PI in prolog"):
+        supervise:
+          t"""<?xml version="1.0"?><?stylesheet href="x"?><a/>""".load[Xml]
+      . assert: doc =>
+          doc == Document(
+            Fragment(ProcessingInstruction(t"stylesheet", t"""href="x""""), elem(t"a")),
+            Header(t"1.0", Unset, Unset))
+
+      test(m"Document with whitespace in prolog"):
+        supervise:
+          t"""<?xml version="1.0"?>\n<a/>""".load[Xml]
+      . assert: doc =>
+          doc == Document(elem(t"a"), Header(t"1.0", Unset, Unset))
+
+
+    suite(m"Additional element tests"):
+      test(m"Element with multiple attributes preserves order"):
+        t"""<a x="1" y="2" z="3"/>""".read[Xml].absolve match
+          case Element(_, attributes, _) => attributes.to(List).map(_(0))
+      . assert(_ == List(t"x", t"y", t"z"))
+
+      test(m"Tab and newline allowed in attribute value (normalized)"):
+        t"""<a x="line one"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"line one")))
+
+      test(m"Empty element with attribute"):
+        t"""<a x="1"></a>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1")))
+
+      test(m"Multiple comments inside element"):
+        t"<a><!--c1--><!--c2--></a>".read[Xml]
+      . assert(_ == elem(t"a", Comment(t"c1"), Comment(t"c2")))
+
+      test(m"Comment inside nested element"):
+        t"<a><b><!--c--></b></a>".read[Xml]
+      . assert(_ == elem(t"a", elem(t"b", Comment(t"c"))))
+
+
+    suite(m"Additional attribute tests"):
+      test(m"Multiple attributes with mixed quoting"):
+        t"""<a x='1' y="2"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"1", t"y" -> t"2")))
+
+      test(m"Attribute value with multiple entities"):
+        t"""<a x="&lt;&amp;&gt;"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"x" -> t"<&>")))
+
+      test(m"Attribute value containing literal < is rejected"):
+        capture[ParseError](t"""<a x="<"/>""".read[Xml])
+      . assert(_.issue.isInstanceOf[Xml.Issue.Unexpected])
+
+
+    suite(m"Additional CDATA tests"):
+      test(m"Multiple CDATA sections"):
+        t"<a><![CDATA[one]]><![CDATA[two]]></a>".read[Xml]
+      . assert(_ == elem(t"a", Cdata(t"one"), Cdata(t"two")))
+
+      test(m"CDATA next to text"):
+        t"<a>before<![CDATA[mid]]>after</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"before"), Cdata(t"mid"), TextNode(t"after")))
+
+
+    suite(m"Additional entity tests"):
+      test(m"Decimal char ref for newline"):
+        t"<a>&#10;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"\n")))
+
+      test(m"Hex char ref for tab"):
+        t"<a>&#x9;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"\t")))
+
+      test(m"Entity at start of text"):
+        t"<a>&amp;rest</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"&rest")))
+
+      test(m"Entity at end of text"):
+        t"<a>start&amp;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"start&")))
+
+      test(m"Only an entity in text"):
+        t"<a>&amp;</a>".read[Xml]
+      . assert(_ == elem(t"a", TextNode(t"&")))
+
+      test(m"Entity in nested element"):
+        t"<a><b>&lt;</b></a>".read[Xml]
+      . assert(_ == elem(t"a", elem(t"b", TextNode(t"<"))))
+
+
+    suite(m"Additional namespace tests"):
+      test(m"Multiple namespace declarations on one element"):
+        t"""<a xmlns:p="uri-p" xmlns:q="uri-q"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xmlns:p" -> t"uri-p", t"xmlns:q" -> t"uri-q")))
+
+      test(m"Default and prefixed namespace together"):
+        t"""<a xmlns="uri-default" xmlns:p="uri-p"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xmlns" -> t"uri-default", t"xmlns:p" -> t"uri-p")))
+
+      test(m"xml:lang attribute is preserved"):
+        t"""<a xml:lang="en"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xml:lang" -> t"en")))
+
+      test(m"xml:space attribute is preserved"):
+        t"""<a xml:space="preserve"/>""".read[Xml]
+      . assert(_ == elem(t"a", Map(t"xml:space" -> t"preserve")))
+
+      test(m"Element with prefixed name preserves case"):
+        t"<P:Tag/>".read[Xml]
+      . assert(_ == elem(t"P:Tag"))
+
+      test(m"Mismatched prefixed close tag"):
+        capture[ParseError](t"<p:a></q:a>".read[Xml]).issue
+      . assert: issue =>
+          issue match
+            case Xml.Issue.MismatchedTag(t"p:a", t"q:a") => true
+            case _                                       => false
+
+
+    suite(m"Additional DOCTYPE tests"):
+      test(m"DOCTYPE with system identifier"):
+        t"""<!DOCTYPE root SYSTEM "url"><root/>""".read[Xml]
+      . assert(_ == Fragment(Doctype(t"""root SYSTEM "url""""), elem(t"root")))
+
+      test(m"DOCTYPE before XML declaration not present"):
+        supervise:
+          t"""<?xml version="1.0"?><!DOCTYPE root><root/>""".load[Xml]
+      . assert: doc =>
+          doc == Document(
+            Fragment(Doctype(t"root"), elem(t"root")),
+            Header(t"1.0", Unset, Unset))
+
+
+    suite(m"Document load tests"):
+      test(m"Document with single root element"):
+        supervise:
+          t"""<?xml version="1.0"?><root>content</root>""".load[Xml]
+      . assert: doc =>
+          doc == Document(
+            elem(t"root", TextNode(t"content")),
+            Header(t"1.0", Unset, Unset))
+
+      test(m"Document with nested root"):
+        supervise:
+          t"""<?xml version="1.0"?><root><child/></root>""".load[Xml]
+      . assert: doc =>
+          doc == Document(
+            elem(t"root", elem(t"child")),
+            Header(t"1.0", Unset, Unset))


### PR DESCRIPTION
## Summary

Brings Xylophone's XML parser into conformance with the XML 1.0 specification (and basic XML namespaces) and adds 140 tests covering the spec systematically. The parser was originally derived from Honeycomb's HTML parser and retained several HTML-specific behaviours (lenient names, no built-in entities, no `]]>` checks) that were incorrect for XML.

## Parser changes

`lib/xylophone/src/core/xylophone.Xml.scala`

- **Name characters**: `tagname` and `key` now accept the full set of XML name characters (`_`, `-`, `.`, `:`, `·`, digits in non-leading positions). Names are validated to start with a letter, `_`, or `:` only — digits and punctuation as the first character are rejected. This change is what enables namespace support: prefixed names like `<p:elem>` and attributes like `xmlns:p` now parse.
- **Built-in XML entities**: `XmlSchema.Freeform` now provides `&amp;`, `&lt;`, `&gt;`, `&apos;`, `&quot;`. Unknown entities now fail with `UnknownEntity(name)` instead of being silently passed through as literal text (the old HTML-style fallback).
- **Numeric character references**: `&#X...;` (uppercase X) is now accepted alongside `&#x...;`. Invalid characters in numeric references now fail explicitly.
- **CDATA termination**: the cursor now advances past `]]>` after a CDATA section, and the `]]]>` edge case is handled correctly (previously it errored).
- **Processing instructions**: `<?target?>` (no data) is now supported; the cursor advances past `?>`; PI targets matching `[Xx][Mm][Ll]` are rejected per the spec.
- **XML declaration**: `encoding` and `standalone` attributes are parsed and stored on the `Header` node (previously only `version` was parsed and the rest discarded). After the first XML declaration, the parser no longer attempts to parse subsequent PIs as XML declarations.
- **DOCTYPE**: added a new `Doctype` node and minimal DOCTYPE parsing — content between `<!DOCTYPE` and `>` is preserved as text. Sufficient to round-trip simple DOCTYPEs and DOCTYPEs with system identifiers.
- **`]]>` detection in text**: regular character data containing the literal sequence `]]>` is now rejected.
- **`<` in attribute values**: literal `<` in an attribute value is now rejected (it was previously accepted).
- **Document loading**: `loadable` now accepts documents whose root is preceded by comments, PIs, or DOCTYPE in the prolog; multi-node prologs are wrapped in a `Fragment`.

## Serialisation changes

- `show` now properly escapes `<` and `&` in text content, and `<`, `&`, `"` in attribute values. Previously these were emitted unescaped, which produced ill-formed XML.
- Empty-data PIs serialise as `<?target?>` (no trailing space).
- XML declaration serialisation includes the previously-missing `?` before `>`.
- New rendering for `Doctype` nodes.

## Cleanup

Removed dead code: the `unquoted` function (XML attributes must be quoted, so it was never reachable) and the `close`/`entities` parameters of `textual` (always called with `Unset`/`true` from XML).

## Tests

`lib/xylophone/src/test/xylophone_test.scala` — 140 tests organised into suites:

- Element parsing, name validation
- Attribute parsing (quoting, whitespace, entities, duplicates)
- Comments (including double-hyphen rejection)
- CDATA sections (including bracket edge cases)
- Processing instructions (with/without data, target validation)
- Character and entity references (built-ins, decimal, hex)
- Whitespace handling
- XML declarations (version, encoding, standalone, all combinations)
- Document errors (mismatched/unopened/unclosed tags, unknown entities, illegal `]]>`)
- Namespaces (default and prefixed, `xml:lang`, `xml:space`, mismatched prefixed close)
- DOCTYPE (simple, with system identifier, with XML declaration)
- Roundtrip serialisation (escaping in text and attributes)
- Documents with prologs (comments, PIs, whitespace before root)

## Compatibility

`honeycomb` and `savagery` (the dependents of `xylophone.core`) compile cleanly. Honeycomb's full test suite (96 tests) still passes — no behavioural regressions for HTML.
