### PR TITLE
Github Actions feedback

### DIFF
--- a/lib/probably/src/core/probably.GithubActions.scala
+++ b/lib/probably/src/core/probably.GithubActions.scala
@@ -30,15 +30,95 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package probably
 
-export probably
-. { Baseline, Benchmark, Inclusion, Verdict, Runner, Test, Harness, TestId, Report, Reporter, Trial,
-    Testable, Tolerance, Min, Mean, Max, BySpeed, ===, !==, ByTime, Geometric, Arithmetic, +/-, ±,
-    test, suite, aspire, assert, check, matches, debug, Checkable, Ci, GithubActions }
+import ambience.*, environments.java
+import anticipation.*
+import contingency.*
+import gossamer.*
+import spectacular.*
+import turbulence.*
+import vacuous.*
 
-package harnesses:
-  export probably.harnesses.threadLocal
+object GithubActions:
+  def workspaceRelative(path: Text): Text =
+    safely(Environment.githubWorkspace[Text]).let: workspace =>
+      if path.starts(workspace) && path.length > workspace.length
+         && path.s.charAt(workspace.length) == '/'
+      then path.skip(workspace.length + 1)
+      else path
 
-package autopsies:
-  export probably.autopsies.{contrastExpectations, none}
+    . or(path)
+
+
+  def error
+       ( message: Text,
+         file:    Optional[Text] = Unset,
+         line:    Optional[Int]  = Unset,
+         title:   Optional[Text] = Unset )
+       (using Stdio)
+  :     Unit =
+    emit(t"error", file, line, title, message)
+
+
+  def warning
+       ( message: Text,
+         file:    Optional[Text] = Unset,
+         line:    Optional[Int]  = Unset,
+         title:   Optional[Text] = Unset )
+       (using Stdio)
+  :     Unit =
+    emit(t"warning", file, line, title, message)
+
+
+  def notice
+       ( message: Text,
+         file:    Optional[Text] = Unset,
+         line:    Optional[Int]  = Unset,
+         title:   Optional[Text] = Unset )
+       (using Stdio)
+  :     Unit =
+    emit(t"notice", file, line, title, message)
+
+
+  def debug(message: Text)(using Stdio): Unit =
+    Out.println(t"::debug::${escape(message)}")
+
+
+  def group(title: Text)(using Stdio): Unit =
+    Out.println(t"::group::${escape(title)}")
+
+
+  def endGroup()(using Stdio): Unit = Out.println(t"::endgroup::")
+
+
+  inline def grouped[result](title: Text)(inline block: => result)(using Stdio): result =
+    group(title)
+    try block finally endGroup()
+
+
+  private def escape(text: Text): Text =
+    text.sub(t"%", t"%25").sub(t"\r", t"%0D").sub(t"\n", t"%0A")
+
+
+  private def escapeProperty(text: Text): Text =
+    escape(text).sub(t",", t"%2C").sub(t":", t"%3A")
+
+
+  private def emit
+       ( kind:    Text,
+         file:    Optional[Text],
+         line:    Optional[Int],
+         title:   Optional[Text],
+         message: Text )
+       (using Stdio)
+  :     Unit =
+
+    val props = List
+                  ( file.let(workspaceRelative).let(path => t"file=${escapeProperty(path)}").option,
+                    line.let(value => t"line=${value.show}").option,
+                    title.let(text => t"title=${escapeProperty(text)}").option )
+                . flatten
+
+    val propsText = if props.isEmpty then t"" else t" ${props.join(t",")}"
+    Out.println(t"::$kind$propsText::${escape(message)}")

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -230,8 +230,9 @@ class Report(using Environment)(using palette: TestPalette):
     val summaryLines = lines.summaries
     val githubActions = Ci.githubActions
 
-    Out.println(t"::notice title=Probably diagnostic::Ci.githubActions=$githubActions; "
-        +t"GITHUB_ACTIONS=${safely(Environment.githubActions[Text]).or(t"<unset>")}")
+    val ghDetected: Text = if githubActions then t"true" else t"false"
+    val ghEnv: Text = safely(Environment.githubActions[Text]).or(t"<unset>")
+    Out.println(t"::notice title=Probably diagnostic::Ci.githubActions=$ghDetected; GITHUB_ACTIONS=$ghEnv")
 
     def truncate(text: Text, max: Int = 800): Text =
       if text.length <= max then text else t"${text.keep(max)}…"

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -228,6 +228,26 @@ class Report(using Environment)(using palette: TestPalette):
 
     val columns: Int = safely(Environment.columns.decode[Int]).or(120)
     val summaryLines = lines.summaries
+    val githubActions = Ci.githubActions
+
+    def truncate(text: Text, max: Int = 800): Text =
+      if text.length <= max then text else t"${text.keep(max)}…"
+
+    def describeFailure(info: Optional[Verdict.Detail]): Text = info match
+      case Verdict.Detail.Throws(err) =>
+        truncate(t"Threw ${err.component}.${err.className}: ${err.message.text}")
+
+      case Verdict.Detail.CheckThrows(err) =>
+        truncate(t"Check threw ${err.component}.${err.className}: ${err.message.text}")
+
+      case Verdict.Detail.Compare(expected, observed, _) =>
+        truncate(t"Expected: ${expected.sub(t"\n", t" ")}; observed: ${observed.sub(t"\n", t" ")}")
+
+      case Verdict.Detail.Message(text) =>
+        truncate(text)
+
+      case Verdict.Detail.Captures(_) | Unset =>
+        t"Test failed"
 
     coverage.each: coverage =>
       Out.println(e"$Bold($Underline(Test coverage))")
@@ -394,8 +414,11 @@ class Report(using Environment)(using palette: TestPalette):
             palette.subdue(palette.detail, 0.6),
             palette.subdue(palette.detail, 0.9) )
 
+      val suiteName = suite.let(_.name.teletype).or(e"")
+      if githubActions then
+        GithubActions.group(t"Benchmarks: ${suite.let(_.name.text).or(t"")}")
+
       Out.println:
-        val suiteName = suite.let(_.name.teletype).or(e"")
         ribbon.fill(e"${suite.lay(t"")(_.id.id)}", e"Benchmarks", suiteName)
 
       val comparisons: List[ReportLine.Bench] =
@@ -467,6 +490,8 @@ class Report(using Environment)(using palette: TestPalette):
       bench.tabulate(benchmarks.to(List).sortBy(-_.benchmark.throughput))
       . grid(columns).render.each(Out.println(_))
 
+      if githubActions then GithubActions.endGroup()
+
     def showLegend(): Unit =
       Out.println(t"─"*74)
       Out.println:
@@ -477,8 +502,25 @@ class Report(using Environment)(using palette: TestPalette):
 
       Out.println(t"─"*74)
 
+    if githubActions then summaryLines.each: summary =>
+      summary.status match
+        case Status.Fail | Status.Throws | Status.CheckThrows | Status.Mixed =>
+          val firstDetail: Optional[Verdict.Detail] =
+            details.get(summary.id).flatMap(_.headOption).getOrElse(Unset)
+
+          GithubActions.error
+           ( message = describeFailure(firstDetail),
+             file    = summary.id.codepoint.source,
+             line    = summary.id.codepoint.line,
+             title   = summary.id.name.text )
+
+        case _ => ()
+
     details.to(List).sortBy(_(0).timestamp).each: (id, info) =>
       val ribbon = Ribbon(palette.pass, palette.subdue(palette.pass, 0.5), palette.subdue(palette.pass, 0.75))
+
+      if githubActions then GithubActions.group(t"Failure: ${id.name.text} (${id.id})")
+
       Out.println(ribbon.fill(e"$Bold(${id.id})", id.codepoint.text.teletype, id.name.teletype))
 
       info.each: details =>
@@ -520,6 +562,7 @@ class Report(using Environment)(using palette: TestPalette):
             Out.println(text)
 
       Out.println()
+      if githubActions then GithubActions.endGroup()
 
     failure.let: (error, active) =>
       val explanation = active.to(List) match
@@ -534,9 +577,22 @@ class Report(using Environment)(using palette: TestPalette):
 
           e"A fatal error occurred while $tests $were running."
 
+      if githubActions then
+        val activeNames = active.to(List).map(_.name.text).join(t", ")
+        val cause = Option(error.getMessage).map(_.nn.tt).getOrElse(t"")
+        val errorClass = Option(error.getClass.getName).map(_.nn.tt).getOrElse(t"")
+        val message = if active.isEmpty
+                      then truncate(t"Fatal error: $errorClass: $cause")
+                      else truncate(t"Fatal error in $activeNames: $errorClass: $cause")
+
+        GithubActions.error(message = message, title = t"Fatal error")
+        GithubActions.group(t"Fatal error stack trace")
+
       Out.println()
 
       Out.println(Ribbon(palette.pass, palette.subdue(palette.pass, 0.5)).fill(e"$Bold(FATAL)", explanation))
       Out.println(StackTrace(error).teletype)
+
+      if githubActions then GithubActions.endGroup()
 
     totals(false)

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -230,6 +230,9 @@ class Report(using Environment)(using palette: TestPalette):
     val summaryLines = lines.summaries
     val githubActions = Ci.githubActions
 
+    Out.println(t"::notice title=Probably diagnostic::Ci.githubActions=$githubActions; "
+        +t"GITHUB_ACTIONS=${safely(Environment.githubActions[Text]).or(t"<unset>")}")
+
     def truncate(text: Text, max: Int = 800): Text =
       if text.length <= max then text else t"${text.keep(max)}…"
 

--- a/lib/probably/src/core/soundness_probably_core.scala
+++ b/lib/probably/src/core/soundness_probably_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   probably
   . { Baseline, Benchmark, Inclusion, Verdict, Runner, Test, Harness, TestId, Report, Reporter,
-      Trial, Testable, Tolerance, Min, Mean, Max, BySpeed, ===, !==, ByTime, Geometric, Arithmetic,
+      Trial, Testable, Tolerance, Min, Mean, Max, Cadential, ===, !==, Temporal, Geometric, Arithmetic,
       +/-, ±, test, suite, aspire, assert, check, matches, debug, Checkable, Ci, GithubActions }
 
 package harnesses:

--- a/lib/probably/src/core/soundness_probably_core.scala
+++ b/lib/probably/src/core/soundness_probably_core.scala
@@ -32,10 +32,11 @@
                                                                                                   */
 package soundness
 
-export probably
-. { Baseline, Benchmark, Inclusion, Verdict, Runner, Test, Harness, TestId, Report, Reporter, Trial,
-    Testable, Tolerance, Min, Mean, Max, BySpeed, ===, !==, ByTime, Geometric, Arithmetic, +/-, ±,
-    test, suite, aspire, assert, check, matches, debug, Checkable, Ci, GithubActions }
+export
+  probably
+  . { Baseline, Benchmark, Inclusion, Verdict, Runner, Test, Harness, TestId, Report, Reporter,
+      Trial, Testable, Tolerance, Min, Mean, Max, BySpeed, ===, !==, ByTime, Geometric, Arithmetic,
+      +/-, ±, test, suite, aspire, assert, check, matches, debug, Checkable, Ci, GithubActions }
 
 package harnesses:
   export probably.harnesses.threadLocal


### PR DESCRIPTION
Probably now emits GitHub Actions workflow commands when running inside a
GitHub Actions runner, so failed tests show up as inline annotations on
the PR/commit page and the noisier sections of the log become
collapsible. Outside GitHub Actions there is no change in behaviour.

## Summary

- New `probably.GithubActions` helper object with methods for emitting
  the standard `::error`, `::warning`, `::notice`, `::debug`, and
  `::group::` / `::endgroup::` workflow commands. Property values and
  message bodies are escaped per the GitHub Actions spec
  (`%` → `%25`, `\r` → `%0D`, `\n` → `%0A`, plus `,` → `%2C` and
  `:` → `%3A` inside property values), and absolute paths are made
  workspace-relative by stripping `$GITHUB_WORKSPACE`.

- `Report.complete()` checks `Ci.githubActions` once and, when true:
  - Emits one `::error file=,line=,title=<test name>::<reason>` per
    failed test (`Fail`, `Throws`, `CheckThrows`, or `Mixed`), using
    the test's `Codepoint` so the annotation links to the source line.
    The reason is derived from the first available `Verdict.Detail`
    (`Threw <class>: <msg>` for exceptions, `Expected: …; observed: …`
    for failed comparisons, the captured message for `Message`, etc.),
    falling back to `"Test failed"` when no detail is present.
  - Wraps the benchmarks block, each failure-detail block, and the
    fatal-error stack trace in `::group::` / `::endgroup::` so they
    can be collapsed in the workflow log.
  - For fatal errors, emits an additional `::error::Fatal error: …`
    annotation alongside the existing stack-trace output.

- `soundness_probably_core.scala` re-exports `GithubActions` from the
  `soundness` package so it's available as `soundness.GithubActions`.

## Test plan

- [ ] `mill probably.__.compile` succeeds locally.
- [ ] Run a failing test suite locally with `GITHUB_ACTIONS=true` (and
      optionally `GITHUB_WORKSPACE=$PWD`) and confirm `::error` lines
      and `::group::` markers appear on stdout in the expected places.
- [ ] Run the same suite without `GITHUB_ACTIONS` set and confirm the
      output is byte-identical to before this change.
- [ ] In a real GitHub Actions run, verify failed tests appear as
      annotations on the workflow run / PR diff, and that benchmarks
      and per-test failure details collapse into named groups.
