### PR TITLE
Add Outlet, Playback and OutletError for audio output

### DIFF
--- a/lib/cacophony/src/core/cacophony.Outlet.scala
+++ b/lib/cacophony/src/core/cacophony.Outlet.scala
@@ -30,9 +30,117 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package cacophony
 
-export cacophony
-. { Audio, Audible, AudioError, Wave, Aiff, Aifc, Au, Snd, ChannelLayout, Monaural, Stereo,
-    Surround, Encoding, Configuration, Feed, FeedError, Recording, Outlet, OutletError,
-    Playback }
+import javax.sound.sampled as jss
+
+import anticipation.*
+import contingency.*
+import quantitative.*
+import symbolism.*
+import vacuous.*
+
+object Outlet:
+  def list: List[Outlet] =
+    jss.AudioSystem.getMixerInfo.nn.toList.flatMap: info0 =>
+      val info = info0.nn
+      val mixer = jss.AudioSystem.getMixer(info).nn
+
+      val canPlay = mixer.getSourceLineInfo.nn.exists:
+        case dli: jss.DataLine.Info => dli.getLineClass == classOf[jss.SourceDataLine]
+        case _                      => false
+
+      if canPlay then List(Outlet(info)) else Nil
+
+case class Outlet(private[cacophony] val mixerInfo: jss.Mixer.Info):
+  def name:        Text = mixerInfo.getName.nn.tt
+  def vendor:      Text = mixerInfo.getVendor.nn.tt
+  def description: Text = mixerInfo.getDescription.nn.tt
+
+  def configurations: List[Configuration] =
+    val mixer = jss.AudioSystem.getMixer(mixerInfo).nn
+
+    mixer.getSourceLineInfo.nn.toList.flatMap:
+      case dli: jss.DataLine.Info if dli.getLineClass == classOf[jss.SourceDataLine] =>
+        dli.getFormats.nn.toList.map: f0 =>
+          val f = f0.nn
+
+          val encoding =
+            if f.getEncoding == jss.AudioFormat.Encoding.PCM_UNSIGNED then Encoding.PcmUnsigned
+            else Encoding.PcmSigned
+
+          val rate: Optional[Quantity[Seconds[-1]]] =
+            if f.getSampleRate < 0 then Unset else f.getSampleRate.toDouble*Hertz
+
+          Configuration(f.getChannels, rate, f.getSampleSizeInBits, encoding, f.isBigEndian)
+
+      case _ => Nil
+
+  def supports[layout: ChannelLayout as cl]
+                (rate: Quantity[Seconds[-1]], bits: Int)
+              : Boolean =
+    val sampleRate = rate.value.toFloat
+    val bytesPerFrame = cl.channels*(bits/8)
+
+    val format = jss.AudioFormat
+                  (jss.AudioFormat.Encoding.PCM_SIGNED,
+                   sampleRate,
+                   bits,
+                   cl.channels,
+                   bytesPerFrame,
+                   sampleRate,
+                   false)
+
+    val mixer = jss.AudioSystem.getMixer(mixerInfo).nn
+    mixer.isLineSupported(jss.DataLine.Info(classOf[jss.SourceDataLine], format))
+
+  def play(audio: Audio, chunkBytes: Int = 65536): Playback raises OutletError =
+    val mixer = jss.AudioSystem.getMixer(mixerInfo).nn
+    val info = jss.DataLine.Info(classOf[jss.SourceDataLine], audio.format)
+
+    if !mixer.isLineSupported(info)
+    then abort(OutletError(name, OutletError.Reason.UnsupportedConfiguration))
+
+    val line: jss.SourceDataLine =
+      try mixer.getLine(info).nn.asInstanceOf[jss.SourceDataLine]
+      catch case _: jss.LineUnavailableException =>
+        abort(OutletError(name, OutletError.Reason.Unavailable))
+
+    try line.open(audio.format)
+    catch case _: jss.LineUnavailableException =>
+      abort(OutletError(name, OutletError.Reason.Unavailable))
+
+    line.start()
+
+    new Playback:
+      private var stopped = false
+      private val data    = audio.data
+
+      private val worker: Thread =
+        val task: Runnable = () =>
+          try
+            var offset = 0
+            while !stopped && offset < data.length do
+              val len     = math.min(chunkBytes, data.length - offset)
+              val written = line.write(data, offset, len)
+              if written <= 0 then offset = data.length else offset += written
+
+            if !stopped then line.drain()
+          finally
+            if !stopped then
+              stopped = true
+              line.stop()
+              line.close()
+
+        Thread.ofVirtual.nn.start(task).nn
+
+      def active: Boolean = !stopped
+
+      def stop(): Unit =
+        if !stopped then
+          stopped = true
+          line.stop()
+          line.flush()
+          line.close()
+
+      def await(): Unit = worker.join()

--- a/lib/cacophony/src/core/cacophony.OutletError.scala
+++ b/lib/cacophony/src/core/cacophony.OutletError.scala
@@ -30,9 +30,21 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package cacophony
 
-export cacophony
-. { Audio, Audible, AudioError, Wave, Aiff, Aifc, Au, Snd, ChannelLayout, Monaural, Stereo,
-    Surround, Encoding, Configuration, Feed, FeedError, Recording, Outlet, OutletError,
-    Playback }
+import anticipation.*
+import fulminate.*
+
+object OutletError:
+  enum Reason(val number: Int) extends Clarification:
+    case Unavailable              extends Reason(1)
+    case UnsupportedConfiguration extends Reason(2)
+    case Closed                   extends Reason(3)
+
+  given Reason is Communicable =
+    case Reason.Unavailable              => m"the audio line could not be opened"
+    case Reason.UnsupportedConfiguration => m"the requested configuration is not supported"
+    case Reason.Closed                   => m"the playback has already been stopped"
+
+case class OutletError(outlet: Text, reason: OutletError.Reason)(using Diagnostics)
+extends Error(realm"ca", 2, reason.number)(m"could not play to outlet $outlet because $reason")

--- a/lib/cacophony/src/core/cacophony.Playback.scala
+++ b/lib/cacophony/src/core/cacophony.Playback.scala
@@ -30,9 +30,9 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package cacophony
 
-export cacophony
-. { Audio, Audible, AudioError, Wave, Aiff, Aifc, Au, Snd, ChannelLayout, Monaural, Stereo,
-    Surround, Encoding, Configuration, Feed, FeedError, Recording, Outlet, OutletError,
-    Playback }
+trait Playback:
+  def active: Boolean
+  def stop(): Unit
+  def await(): Unit


### PR DESCRIPTION
## Summary
- Adds `Outlet` (mirror of `Feed`) for enumerating audio output devices via `Outlet.list` and playing an `Audio` to one of them via `outlet.play(audio)`
- Adds a `Playback` handle (mirror of `Recording`) with `active`, `stop()` and `await()` for controlling in-progress playback
- Adds `OutletError` (mirror of `FeedError`) with reason codes for unavailable lines, unsupported configurations, and already-stopped playback

## Test plan
- [x] `mill cacophony.core.compile` succeeds
- [x] `mill cacophony.test.run` — all 18 existing tests still pass
- [ ] Manual smoke test: enumerate `Outlet.list` and play a small WAV through one, then verify `stop()` halts mid-stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)