### PR TITLE
Terse Probably output for Claude Code, silent runs in CI

### DIFF
--- a/lib/probably/src/core/probably.Ci.scala
+++ b/lib/probably/src/core/probably.Ci.scala
@@ -58,3 +58,4 @@ object Ci:
   def drone: Boolean = safely(Environment.drone[Text]) == t"true"
   def semaphore: Boolean = safely(Environment.semaphore[Text]) == t"true"
   def buddy: Boolean = safely(Environment.buddyWorkspaceId[Text]).present
+  def claudeCode: Boolean = safely(Environment.claudecode[Text]).present

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -207,6 +207,99 @@ class Report(using Environment)(using palette: TestPalette):
     def iterations: Teletype = if count == 0 then e"" else count.teletype
 
   def complete(coverage: Option[Coverage])(using Stdio): Unit =
+    if Ci.claudeCode then terseComplete() else humanComplete(coverage)
+
+  private def terseComplete()(using Stdio): Unit =
+    import tableStyles.minimal
+
+    val summaryLines = lines.summaries
+    val totals = summaryLines.groupBy(_.status).view.mapValues(_.size).to(Map) - Status.Suite
+    val passed: Int = totals.getOrElse(Status.Pass, 0) + totals.getOrElse(Status.Bench, 0)
+    val total: Int = totals.values.sum
+    val failed: Int = total - passed
+    if total == passed && failure.absent then pass = true
+
+    if total == 0 then Out.println(t"No tests were run.")
+    else Out.println(t"$passed passed, $failed failed, $total total")
+
+    def truncate(text: Text, max: Int = 800): Text =
+      if text.length <= max then text else t"${text.keep(max)}…"
+
+    def statusWord(status: Status): Text = status match
+      case Status.Pass        => t"pass"
+      case Status.Fail        => t"fail"
+      case Status.Throws      => t"throws"
+      case Status.CheckThrows => t"check-throws"
+      case Status.Mixed       => t"mixed"
+      case Status.Suite       => t"suite"
+      case Status.Bench       => t"bench"
+
+    def formatFrame(frame: StackTrace.Frame): Text =
+      val ln = frame.line.let(_.toString.tt).or(t"?")
+      t"  at ${frame.method.cls}.${frame.method.method} (${frame.file}:$ln)"
+
+    val failureStatuses: Set[Status] =
+      Set(Status.Fail, Status.Throws, Status.CheckThrows, Status.Mixed)
+
+    val failures = summaryLines.filter(s => failureStatuses.contains(s.status))
+
+    if failures.nonEmpty then
+      val columns: Int = safely(Environment.columns.decode[Int]).or(120)
+      Out.println(t"")
+
+      Scaffold[Summary]
+        ( Column(e"Hash"): s =>
+            e"${s.id.id}",
+          Column(e"Test"): s =>
+            val depth = s.id.suite.let(_.id.depth).or(0)
+            e"${t"  "*depth}${s.id.name}",
+          Column(e"Status"): s =>
+            e"${statusWord(s.status)}" )
+
+      . tabulate(failures).grid(columns).render.each(Out.println(_))
+
+      Out.println(t"")
+
+      failures.each: summary =>
+        val location = t"${summary.id.codepoint.source}:${summary.id.codepoint.line}"
+        Out.println(t"${summary.id.id}  ${summary.id.name.text} @ $location")
+
+        details(summary.id).each: detail =>
+          detail match
+            case Verdict.Detail.Throws(err) =>
+              Out.println:
+                t"  threw ${err.component}.${err.className}: ${truncate(err.message.text)}"
+              err.crop(t"probably.Runner", t"run()").frames.take(3).each: frame =>
+                Out.println(formatFrame(frame))
+
+            case Verdict.Detail.CheckThrows(err) =>
+              Out.println:
+                t"  check threw ${err.component}.${err.className}: ${truncate(err.message.text)}"
+              err.crop(t"probably.Verdict#", t"apply()").frames.take(3).each: frame =>
+                Out.println(formatFrame(frame))
+
+            case Verdict.Detail.Compare(expected, observed, _) =>
+              Out.println(t"  expected: ${truncate(expected.sub(t"\n", t" "))}")
+              Out.println(t"  observed: ${truncate(observed.sub(t"\n", t" "))}")
+
+            case Verdict.Detail.Message(text) =>
+              Out.println(t"  ${truncate(text)}")
+
+            case Verdict.Detail.Captures(captures) =>
+              captures.each: (expr, value) =>
+                Out.println(t"  $expr = ${truncate(value)}")
+
+        Out.println(t"")
+
+    failure.let: (error, active) =>
+      val activeNames = active.to(List).map(_.name.text).join(t", ")
+      val errorClass = Option(error.getClass.getName).map(_.nn.tt).getOrElse(t"")
+      val msg = Option(error.getMessage).map(_.nn.tt).getOrElse(t"")
+      if active.isEmpty then Out.println(t"FATAL: $errorClass: $msg")
+      else Out.println(t"FATAL in $activeNames: $errorClass: $msg")
+      StackTrace(error).frames.take(3).each(frame => Out.println(formatFrame(frame)))
+
+  private def humanComplete(coverage: Option[Coverage])(using Stdio): Unit =
     val table =
       val showStats = !lines.summaries.all(_.count < 2)
       val timeTitle = if showStats then t"Avg" else t"Time"

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -49,6 +49,7 @@ object Runner:
 
 class Runner[report]()(using reporter: Reporter[report]):
   private var active: List[TestId] = Nil
+  private val silent: Boolean = Ci.claudeCode || Ci()
 
   def skip(id: TestId): Boolean = false
 
@@ -57,7 +58,7 @@ class Runner[report]()(using reporter: Reporter[report]):
   def maybeRun[result](test: Test[result]): Optional[Trial[result]] =
     if skip(test.id) then Unset else run[result](test)
 
-  def redraw(size: Int): Unit =
+  def redraw(size: Int): Unit = if !silent then
     if size > 0 then Out.print(e"\e[${size}A\r\e[2K")
 
     active.reverse.each: test =>


### PR DESCRIPTION
## Summary

- Detect Claude Code (`CLAUDECODE` env var) in Probably's reporter and emit a terse, failure-focused report instead of the full ASCII-art / thick-bordered output. Uses `tableStyles.minimal` and reuses existing detail rendering for `Verdict.Detail.{Throws,CheckThrows,Compare,Message,Captures}`.
- Suppress the live in-place progress redraw (`> hash  test name` lines) under both Claude Code and any detected CI environment — these escape sequences are pure noise in non-interactive consumers.

## Test plan

- [x] `CLAUDECODE=1 mill abacist.test.run` (passing): single line — `27 passed, 0 failed, 27 total`.
- [x] `CLAUDECODE=1 mill abacist.test.run` with one induced failure: summary + minimal table + per-failure header and `expected:` / `observed:` block. No ASCII art, no legend, no ribbons.
- [x] `GITHUB_ACTIONS=true mill abacist.test.run`: rich human report at end (still useful in CI logs), but no live progress display during the run.
- [x] `mill abacist.test.run` with no env vars: live progress display intact, full rich report unchanged.
- [x] `mill probably.core.compile` clean (warnings are pre-existing Decorum style notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)