### PR TITLE
Fix Decorum SN-de/16 expression-boundary tracking

### DIFF
--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -1085,6 +1085,21 @@ object Checker:
       "transparent", "infix", "open", "opaque", "erased", "tracked",
       "is", "of", "in", "by", "to", "under", "on", "raises", "until" )
 
+  // Control-flow keywords that separate sub-expressions: encountering one
+  // closes the current operator frame and opens a fresh one at the same
+  // nesting depth, just like `,` does. `case` is excluded when used as a
+  // modifier (`case class`, `case object`).
+  private val BoundaryWords: Set[String] = Set
+    ( "if", "then", "else", "match", "case", "do", "while", "for", "yield",
+      "return", "throw", "try", "catch", "finally" )
+
+  private def caseIsModifier(arr: Array[Token], i: Int): Boolean =
+    var j = i + 1
+    while j < arr.length && (arr(j).kind == Kind.Space || arr(j).kind == Kind.Comment) do
+      j += 1
+    j < arr.length && arr(j).kind == Kind.Code
+      && (arr(j).text == "class" || arr(j).text == "object")
+
   private def isBinaryContext(arr: Array[Token], i: Int): Boolean =
     val left =
       var j = i - 1
@@ -1144,6 +1159,14 @@ object Checker:
           // operator frame and open a fresh one at the same nesting level.
           checkOpFrame(frames.pop(), emit)
           frames.push(mutable.ArrayBuffer.empty)
+        else if BoundaryWords.contains(text)
+          && !(text == "case" && caseIsModifier(arr, i))
+        then
+          // Control-flow keywords cut the expression into sub-expressions:
+          // `if` predicates, `then`/`else` clauses, `match` scrutinee and
+          // `case` patterns/bodies, etc. should each be checked independently.
+          checkOpFrame(frames.pop(), emit)
+          frames.push(mutable.ArrayBuffer.empty)
         else if CheckedOps.contains(text) then
           val isAtStart  = i == firstSemantic
           val isAtEnd    = i == lastSemantic
@@ -1166,6 +1189,13 @@ object Checker:
                 ( cols(i), "16",
                   s"multi-character `$text` requires one space on each side" )
             frames.top += OpHit(text, i, cols(i), leftSpace, rightSpace)
+            // `=>` and `?=>` separate a pattern/parameter list from the body
+            // it produces, so they too cut the expression. Flush *after* the
+            // OpHit append so the arrow itself participates in the left-side
+            // frame's classification.
+            if text == "=>" || text == "?=>" then
+              checkOpFrame(frames.pop(), emit)
+              frames.push(mutable.ArrayBuffer.empty)
       i += 1
 
     while frames.nonEmpty do checkOpFrame(frames.pop(), emit)
@@ -1176,38 +1206,38 @@ object Checker:
 
     if ops.isEmpty then ()
     else
-      val withSpacing = ops.map: op =>
-        val s = if op.leftSpace || op.rightSpace then 1 else 0
-        (op, s)
-      val byPrec = withSpacing.groupBy((op, _) => operatorPrecedence(op.text))
-
-      // Same-precedence consistency
-      byPrec.values.foreach: opPairs =>
-        val spacings = opPairs.map(_._2).distinct
-        if spacings.length > 1 then
-          opPairs.foreach: (op, _) =>
+      // Same-precedence consistency: every operator at a given precedence
+      // must use the same spacing within this frame.
+      ops.groupBy(op => operatorPrecedence(op.text)).foreach: (_, group) =>
+        val mixed = group.exists(op => op.leftSpace || op.rightSpace)
+          && group.exists(op => !(op.leftSpace || op.rightSpace))
+        if mixed then
+          group.foreach: op =>
             emit
               ( op.col, "16",
                 s"`${op.text}` has inconsistent spacing with same-precedence operators" )
 
-      // Cross-precedence ordering: higher precedence should have ≤ spacing
-      val precSpacings = byPrec.toList.map: (p, pairs) =>
-        (p, pairs.head._2)
-      val sortedPrecs = precSpacings.sortBy(_._1)
-      var i = 0
-      while i < sortedPrecs.length do
-        val (pLow, sLow) = sortedPrecs(i)
-        var j = i + 1
-        while j < sortedPrecs.length do
-          val (pHigh, sHigh) = sortedPrecs(j)
-          if sHigh > sLow then
-            byPrec(pHigh).foreach: (op, _) =>
-              emit
-                ( op.col, "16",
-                  s"`${op.text}` cannot have more spacing than lower-precedence "
-                    +"operators in the same expression" )
-          j += 1
-        i += 1
+      // Cross-precedence ordering: every spaced operator must have *strictly*
+      // lower precedence than every unspaced operator.  Equivalently: the
+      // highest-precedence spaced operator must be lower than the
+      // lowest-precedence unspaced one.
+      var maxSpacedPrec   = Int.MinValue
+      var minUnspacedPrec = Int.MaxValue
+      ops.foreach: op =>
+        val prec   = operatorPrecedence(op.text)
+        val spaced = op.leftSpace || op.rightSpace
+        if spaced && prec > maxSpacedPrec then maxSpacedPrec = prec
+        if !spaced && prec < minUnspacedPrec then minUnspacedPrec = prec
+
+      if maxSpacedPrec > minUnspacedPrec then
+        ops.foreach: op =>
+          val prec   = operatorPrecedence(op.text)
+          val spaced = op.leftSpace || op.rightSpace
+          if spaced && prec > minUnspacedPrec then
+            emit
+              ( op.col, "16",
+                s"`${op.text}` cannot have more spacing than lower-precedence "
+                  +"operators in the same expression" )
 
   private def isSymbolicOperator(text: String): Boolean =
     text.nonEmpty && text.forall: c =>

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -176,6 +176,26 @@ object Tests extends Suite(m"Decorum Tests"):
         rules("infix def + (right: Int): Int = right\n")
       . assert(!_.contains("18"))
 
+      test(m"`if/then/else` does not pool predicate ops with else-clause ops"):
+        rules("def f(x: Int, y: Int, a: Int, b: Int): Int = if x == y then a else a^b\n")
+      . assert(!_.contains("16"))
+
+      test(m"`else if` chain does not pool ops across branches"):
+        rules("def f(x: Boolean, a: Int, b: Int): Int = if x then 1 else if a == b then 2 else a^b\n")
+      . assert(!_.contains("16"))
+
+      test(m"Parenthesised `if/then/else` followed by an operator is accepted"):
+        rules("def f(x: Int, a: Int, b: Int): Int = (if x == 0 then a else b) + 1\n")
+      . assert(!_.contains("16"))
+
+      test(m"`case class` modifier does not flush operator frames spuriously"):
+        rules("case class Foo(x: Int, y: Int)\n")
+      . assert(!_.contains("16"))
+
+      test(m"Cross-precedence violation is still rejected"):
+        rules("def f(a: Int, b: Int, c: Int): Int = a+b * c\n")
+      . assert(_.contains("16"))
+
     suite(m"Phase 3: Continuations and shape"):
 
       test(m"`=>` continuation with wrong space count is rejected"):


### PR DESCRIPTION
## Summary

- Decorum's SN-de/16 was pooling operators from different sub-expressions of a single-line `if/then/else` into one frame, producing false positives such as the `==` in the predicate being compared against the `^` in the else-clause of `if left == right then !strict else (left < right)^greaterThan`.
- Extend `checkOperatorSpacing`'s frame-stack to flush-and-reopen on control-flow keywords (`if`, `then`, `else`, `match`, `case`, `do`, `while`, `for`, `yield`, `return`, `throw`, `try`, `catch`, `finally`) and on `=>` / `?=>`, the same way `,` already does. `case` is excluded when used as a modifier (`case class` / `case object`) via a one-token lookahead.
- Rewrite `checkOpFrame` around `maxSpacedPrec` / `minUnspacedPrec`. Equivalent for correct inputs; also fixes a latent bug where the old `pairs.head._2` reduction non-deterministically misclassified same-precedence groups with mixed spacing.

Across `lib/`, rule-16 violations dropped from 2 → 0 (the two false positives in `aviation.internal.scala:127` and `:242`); all other rule counts are unchanged.

## Test plan

- [x] Existing 47 decorum tests still pass
- [x] Five new regression tests cover: `if/then/else`, `else if` chain, parenthesised `if/then/else` followed by an operator, `case class` modifier (negative — `case` must not flush), and the cross-precedence violation still firing
- [x] `mill -i decorum.plugin.runMain decorum.ScanAll lib 16` — 0 violations after fix (was 2)
- [x] `mill -i decorum.plugin.runMain decorum.ScanAll lib` per-rule breakdown — only the rule-16 count moved (2 → 0); 56 [30], 36 [2], 15 [3], 10 [25], 8 [28], 3 [27], 2 [21], 2 [12], 1 [9.2], 1 [26.1] are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)