### PR TITLE
Resolve Decorum warnings across Cacophony source files

### DIFF
--- a/lib/cacophony/src/core/cacophony.Aifc.scala
+++ b/lib/cacophony/src/core/cacophony.Aifc.scala
@@ -35,11 +35,11 @@ package cacophony
 import anticipation.*
 import gesticulate.*
 
-sealed trait Aifc
-
 object Aifc:
   def apply(): Audible = audibility
 
   given audibility: Aifc is Audible:
     def name: Text           = "AIFC".tt
     def mediaType: MediaType = media"audio/x-aifc"
+
+sealed trait Aifc

--- a/lib/cacophony/src/core/cacophony.Aiff.scala
+++ b/lib/cacophony/src/core/cacophony.Aiff.scala
@@ -35,11 +35,11 @@ package cacophony
 import anticipation.*
 import gesticulate.*
 
-sealed trait Aiff
-
 object Aiff:
   def apply(): Audible = audibility
 
   given audibility: Aiff is Audible:
     def name: Text           = "AIFF".tt
     def mediaType: MediaType = media"audio/x-aiff"
+
+sealed trait Aiff

--- a/lib/cacophony/src/core/cacophony.Au.scala
+++ b/lib/cacophony/src/core/cacophony.Au.scala
@@ -35,11 +35,11 @@ package cacophony
 import anticipation.*
 import gesticulate.*
 
-sealed trait Au
-
 object Au:
   def apply(): Audible = audibility
 
   given audibility: Au is Audible:
     def name: Text           = "AU".tt
     def mediaType: MediaType = media"audio/basic"
+
+sealed trait Au

--- a/lib/cacophony/src/core/cacophony.Audible.scala
+++ b/lib/cacophony/src/core/cacophony.Audible.scala
@@ -74,13 +74,13 @@ trait Audible extends Typeclass:
         else
           val src = raw.getFormat.nn
           val target = jss.AudioFormat
-                        (jss.AudioFormat.Encoding.PCM_SIGNED,
-                         src.getSampleRate,
-                         16,
-                         src.getChannels,
-                         src.getChannels*2,
-                         src.getSampleRate,
-                         false)
+            ( jss.AudioFormat.Encoding.PCM_SIGNED,
+              src.getSampleRate,
+              16,
+              src.getChannels,
+              src.getChannels*2,
+              src.getSampleRate,
+              false )
 
           try jss.AudioSystem.getAudioInputStream(target, raw).nn
           catch case _: IllegalArgumentException => abort(AudioError(this))

--- a/lib/cacophony/src/core/cacophony.Configuration.scala
+++ b/lib/cacophony/src/core/cacophony.Configuration.scala
@@ -36,8 +36,8 @@ import quantitative.*
 import vacuous.*
 
 case class Configuration
-            (channels:      Int,
-             sampleRate:    Optional[Quantity[Seconds[-1]]],
-             bitsPerSample: Int,
-             encoding:      Encoding,
-             bigEndian:     Boolean)
+  ( channels:      Int,
+    sampleRate:    Optional[Quantity[Seconds[-1]]],
+    bitsPerSample: Int,
+    encoding:      Encoding,
+    bigEndian:     Boolean )

--- a/lib/cacophony/src/core/cacophony.Feed.scala
+++ b/lib/cacophony/src/core/cacophony.Feed.scala
@@ -79,39 +79,37 @@ case class Feed(private[cacophony] val mixerInfo: jss.Mixer.Info):
 
       case _ => Nil
 
-  def supports[layout: ChannelLayout as cl]
-                (rate: Quantity[Seconds[-1]], bits: Int)
-              : Boolean =
+  def supports[layout: ChannelLayout as cl](rate: Quantity[Seconds[-1]], bits: Int): Boolean =
     val sampleRate = rate.value.toFloat
     val bytesPerFrame = cl.channels*(bits/8)
 
     val format = jss.AudioFormat
-                  (jss.AudioFormat.Encoding.PCM_SIGNED,
-                   sampleRate,
-                   bits,
-                   cl.channels,
-                   bytesPerFrame,
-                   sampleRate,
-                   false)
+      ( jss.AudioFormat.Encoding.PCM_SIGNED,
+        sampleRate,
+        bits,
+        cl.channels,
+        bytesPerFrame,
+        sampleRate,
+        false )
 
     val mixer = jss.AudioSystem.getMixer(mixerInfo).nn
     mixer.isLineSupported(jss.DataLine.Info(classOf[jss.TargetDataLine], format))
 
   def record[layout: ChannelLayout as cl]
-              (rate: Quantity[Seconds[-1]], bits: Int, chunkBytes: Int = 65536)
-            : Recording across layout raises FeedError =
+    ( rate: Quantity[Seconds[-1]], bits: Int, chunkBytes: Int = 65536 )
+  :   Recording across layout raises FeedError =
 
     val sampleRate    = rate.value.toFloat
     val bytesPerFrame = cl.channels*(bits/8)
 
     val format = jss.AudioFormat
-                  (jss.AudioFormat.Encoding.PCM_SIGNED,
-                   sampleRate,
-                   bits,
-                   cl.channels,
-                   bytesPerFrame,
-                   sampleRate,
-                   false)
+      ( jss.AudioFormat.Encoding.PCM_SIGNED,
+        sampleRate,
+        bits,
+        cl.channels,
+        bytesPerFrame,
+        sampleRate,
+        false )
 
     val mixer = jss.AudioSystem.getMixer(mixerInfo).nn
     val info = jss.DataLine.Info(classOf[jss.TargetDataLine], format)

--- a/lib/cacophony/src/core/cacophony.Monaural.scala
+++ b/lib/cacophony/src/core/cacophony.Monaural.scala
@@ -32,8 +32,8 @@
                                                                                                   */
 package cacophony
 
-sealed trait Monaural
-
 object Monaural:
   given channelLayout: Monaural is ChannelLayout:
     def channels = 1
+
+sealed trait Monaural

--- a/lib/cacophony/src/core/cacophony.Outlet.scala
+++ b/lib/cacophony/src/core/cacophony.Outlet.scala
@@ -76,20 +76,18 @@ case class Outlet(private[cacophony] val mixerInfo: jss.Mixer.Info):
 
       case _ => Nil
 
-  def supports[layout: ChannelLayout as cl]
-                (rate: Quantity[Seconds[-1]], bits: Int)
-              : Boolean =
+  def supports[layout: ChannelLayout as cl](rate: Quantity[Seconds[-1]], bits: Int): Boolean =
     val sampleRate = rate.value.toFloat
     val bytesPerFrame = cl.channels*(bits/8)
 
     val format = jss.AudioFormat
-                  (jss.AudioFormat.Encoding.PCM_SIGNED,
-                   sampleRate,
-                   bits,
-                   cl.channels,
-                   bytesPerFrame,
-                   sampleRate,
-                   false)
+      ( jss.AudioFormat.Encoding.PCM_SIGNED,
+        sampleRate,
+        bits,
+        cl.channels,
+        bytesPerFrame,
+        sampleRate,
+        false )
 
     val mixer = jss.AudioSystem.getMixer(mixerInfo).nn
     mixer.isLineSupported(jss.DataLine.Info(classOf[jss.SourceDataLine], format))

--- a/lib/cacophony/src/core/cacophony.Snd.scala
+++ b/lib/cacophony/src/core/cacophony.Snd.scala
@@ -35,11 +35,11 @@ package cacophony
 import anticipation.*
 import gesticulate.*
 
-sealed trait Snd
-
 object Snd:
   def apply(): Audible = audibility
 
   given audibility: Snd is Audible:
     def name: Text           = "SND".tt
     def mediaType: MediaType = media"audio/basic"
+
+sealed trait Snd

--- a/lib/cacophony/src/core/cacophony.Stereo.scala
+++ b/lib/cacophony/src/core/cacophony.Stereo.scala
@@ -32,8 +32,8 @@
                                                                                                   */
 package cacophony
 
-sealed trait Stereo
-
 object Stereo:
   given channelLayout: Stereo is ChannelLayout:
     def channels = 2
+
+sealed trait Stereo

--- a/lib/cacophony/src/core/cacophony.Surround.scala
+++ b/lib/cacophony/src/core/cacophony.Surround.scala
@@ -32,10 +32,10 @@
                                                                                                   */
 package cacophony
 
-sealed trait Surround[N <: Int & Singleton]
-
 object Surround:
   given channelLayout: [n <: Int & Singleton: ValueOf] => Surround[n] is ChannelLayout =
     new ChannelLayout:
       type Self = Surround[n]
       def channels = valueOf[n]
+
+sealed trait Surround[N <: Int & Singleton]

--- a/lib/cacophony/src/core/cacophony.Wave.scala
+++ b/lib/cacophony/src/core/cacophony.Wave.scala
@@ -35,11 +35,11 @@ package cacophony
 import anticipation.*
 import gesticulate.*
 
-sealed trait Wave
-
 object Wave:
   def apply(): Audible = audibility
 
   given audibility: Wave is Audible:
     def name: Text           = "WAVE".tt
     def mediaType: MediaType = media"audio/x-wav"
+
+sealed trait Wave


### PR DESCRIPTION
## Summary

- Apply layout conventions to clear all 50 SN-de warnings originally reported in `cacophony.core`.
- Move companion `object`s above their `sealed trait`/`class` (SN-de/28) for `Aifc`, `Aiff`, `Au`, `Snd`, `Wave`, `Monaural`, `Stereo`, `Surround`.
- Reformat multi-line constructor invocations and parameter blocks with internal padding (`( arg, … )`) and corrected indentation (SN-de/30, /31.1, /3); reformat heavy-signature return types (SN-de/25); add the required blank line before bodies (SN-de/21) where needed; consolidate `def supports` onto a single line where it now fits.

## Notes

A small number of SN-de/27, /31.1, /33.x warnings remain in `Audio.scala` (109), `Feed.scala` (73), and `Outlet.scala` (70, 127). These are pre-existing patterns flagged by the new keyword-sequence rules from #909 and the unresolved `=>`-after-`given` indent — not regressions from this PR.

## Test plan

- [x] `mill cacophony.core.compile` shows no warnings introduced by these changes.
- [x] `mill cacophony.test.compile` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)