### PR TITLE
Replace signal Spool with cascading trap handlers in Ethereal

### DIFF
--- a/lib/ethereal/src/core/ethereal.Client.scala
+++ b/lib/ethereal/src/core/ethereal.Client.scala
@@ -39,10 +39,10 @@ import java.nio.channels as jnc
 
 import anticipation.*
 import contingency.*
+import exoskeleton.*
 import guillotine.*
 import parasite.*
 import prepositional.*
-import profanity.*
 import proscenium.*
 import rudiments.*
 import turbulence.*
@@ -59,7 +59,7 @@ case class Client(pid: Pid) extends Topical:
   type Topic <: Matchable
 
   val stderr: Promise[ji.OutputStream] = Promise()
-  val signals: Spool[UnixSignal | WindowsSignal] = Spool()
+  val invocation: Promise[Cli] = Promise()
   val bus: Spool[Topic] = Spool()
   val terminatePid: Promise[Pid] = Promise()
   val exitPromise: Promise[Exit] = Promise()

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -72,6 +72,7 @@ import symbolism.*
 import turbulence.*
 import vacuous.*
 
+import anticipation.abstractables.durationIsAbstractable
 import filesystemOptions.createNonexistent.enabled
 import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.deleteRecursively.enabled
@@ -299,7 +300,16 @@ def cli[bus <: Matchable](using executive: Executive)
 
         case DaemonEvent.Trap(pid, signal) =>
           Log.info(DaemonLogEvent.ReceivedSignal(signal))
-          client(pid).signals.put(signal)
+          val response: SignalResponse =
+            safely:
+              val invocation = client(pid).invocation.await(250L*1_000_000L)
+              invocation.dispatchSignal(signal)
+
+            . or(SignalResponse.Reject)
+
+          val ackByte: Byte = if response == SignalResponse.Accept then 'a' else 'r'
+          safely(rawOut.write(Array[Byte](ackByte, '\n'.toByte)))
+          safely(rawOut.flush())
           channel.close()
 
         case DaemonEvent.Exit(pid) =>
@@ -387,9 +397,10 @@ def cli[bus <: Matchable](using executive: Executive)
                   environment,
                   () => directory,
                   stdio,
-                  connection.signals,
                   service,
                   login )
+
+            connection.invocation.offer(cli)
 
             if cli.proceed then
               val result = block(using service, cli)

--- a/lib/ethereal/src/runner/src/protocol.rs
+++ b/lib/ethereal/src/runner/src/protocol.rs
@@ -1,7 +1,15 @@
 use std::io::{Read, Write};
 use std::path::Path;
+use std::time::Duration;
 
 use crate::uds::UnixStream;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SignalAck {
+    Accept,
+    Reject,
+    Timeout,
+}
 
 pub struct ClientInfo {
     pub pid:       u32,
@@ -34,10 +42,19 @@ pub fn send_stderr_request(connection: &mut UnixStream, pid: u32) {
     let _ = connection.flush();
 }
 
-pub fn send_signal(socket_path: &Path, pid: u32, name: &str) {
-    if let Ok(mut connection) = UnixStream::connect(socket_path) {
-        let _ = write!(connection, "s\n{}\n{}\n", pid, name);
-        let _ = connection.flush();
+pub fn send_signal(socket_path: &Path, pid: u32, name: &str, timeout_ms: u64) -> SignalAck {
+    let mut connection = match UnixStream::connect(socket_path) {
+        Ok(connection) => connection,
+        Err(_) => return SignalAck::Timeout,
+    };
+    if write!(connection, "s\n{}\n{}\n", pid, name).is_err() { return SignalAck::Timeout; }
+    if connection.flush().is_err() { return SignalAck::Timeout; }
+    let _ = connection.set_read_timeout(Some(Duration::from_millis(timeout_ms)));
+    let mut reply = [0u8; 1];
+    match connection.read_exact(&mut reply) {
+        Ok(()) if reply[0] == b'a' => SignalAck::Accept,
+        Ok(()) if reply[0] == b'r' => SignalAck::Reject,
+        _                          => SignalAck::Timeout,
     }
 }
 

--- a/lib/ethereal/src/runner/src/signals.rs
+++ b/lib/ethereal/src/runner/src/signals.rs
@@ -2,17 +2,29 @@ use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 use std::sync::atomic::{AtomicU32, AtomicBool, Ordering};
 
+use crate::protocol::SignalAck;
+
 static SOCKET_PATH: OnceLock<PathBuf> = OnceLock::new();
 static CLIENT_PID: AtomicU32 = AtomicU32::new(0);
 static TERMINATION_FLAG: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+static TIMEOUT_MS: AtomicU32 = AtomicU32::new(250);
 
-fn forward_signal(name: &str) {
+const DEFAULT_TIMEOUT_MS: u32 = 250;
+
+fn forward_signal(name: &str) -> SignalAck {
     if let Some(path) = SOCKET_PATH.get() {
         // UnixStream::connect is not strictly async-signal-safe (allocates),
         // but this matches the pre-existing TcpStream::connect behaviour and
         // has been reliable in practice. Revisit only if signal storms cause
         // trouble.
-        crate::protocol::send_signal(path.as_path(), CLIENT_PID.load(Ordering::SeqCst), name);
+        crate::protocol::send_signal(
+            path.as_path(),
+            CLIENT_PID.load(Ordering::SeqCst),
+            name,
+            TIMEOUT_MS.load(Ordering::SeqCst) as u64,
+        )
+    } else {
+        SignalAck::Timeout
     }
 }
 
@@ -26,6 +38,36 @@ fn install_state(socket_path: PathBuf, pid: u32, termination_flag: Arc<AtomicBoo
     let _ = SOCKET_PATH.set(socket_path);
     CLIENT_PID.store(pid, Ordering::SeqCst);
     let _ = TERMINATION_FLAG.set(termination_flag);
+    let timeout = std::env::var("ETHEREAL_SIGNAL_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_TIMEOUT_MS);
+    TIMEOUT_MS.store(timeout, Ordering::SeqCst);
+}
+
+#[cfg(unix)]
+fn unix_signum(name: &str) -> Option<i32> {
+    match name {
+        "INT"  => Some(libc::SIGINT),
+        "TERM" => Some(libc::SIGTERM),
+        "HUP"  => Some(libc::SIGHUP),
+        _      => None,
+    }
+}
+
+#[cfg(unix)]
+fn fallback(name: &str) {
+    if let Some(signum) = unix_signum(name) {
+        // Restore the OS default action for this signal and re-raise it on
+        // ourselves. SIGINT/SIGTERM/SIGHUP terminate the process; the parent
+        // shell sees the conventional 128+signum exit status.
+        unsafe {
+            libc::signal(signum, libc::SIG_DFL);
+            libc::raise(signum);
+        }
+    }
+    // WINCH, USR1, USR2: no fallback action — the daemon declined and we
+    // intentionally drop the signal.
 }
 
 #[cfg(unix)]
@@ -54,8 +96,22 @@ extern "C" fn handler(signal: libc::c_int) {
         libc::SIGUSR2  => "USR2",
         _ => return,
     };
-    forward_signal(name);
+    let ack = forward_signal(name);
     if signal == libc::SIGTERM { flag_termination(); }
+    match ack {
+        SignalAck::Accept                    => {}
+        SignalAck::Reject | SignalAck::Timeout => fallback(name),
+    }
+}
+
+#[cfg(windows)]
+fn fallback(name: &str) {
+    match name {
+        "CTRL_C" | "CTRL_BREAK" | "CTRL_CLOSE" | "CTRL_LOGOFF" | "CTRL_SHUTDOWN" => {
+            std::process::exit(1);
+        }
+        _ => {}
+    }
 }
 
 #[cfg(windows)]
@@ -78,9 +134,13 @@ unsafe extern "system" fn console_handler(ctrl_type: u32) -> windows_sys::Win32:
         CTRL_SHUTDOWN_EVENT => "CTRL_SHUTDOWN",
         _ => return 0,
     };
-    forward_signal(name);
+    let ack = forward_signal(name);
     if matches!(ctrl_type, CTRL_CLOSE_EVENT | CTRL_LOGOFF_EVENT | CTRL_SHUTDOWN_EVENT) {
         flag_termination();
+    }
+    match ack {
+        SignalAck::Accept                    => {}
+        SignalAck::Reject | SignalAck::Timeout => fallback(name),
     }
     1
 }

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -34,6 +34,7 @@ package ethereal
 
 import java.lang as jl
 import java.io as ji
+import java.util.concurrent as juc
 
 import soundness.*
 
@@ -118,10 +119,54 @@ object Tests extends Suite(m"Ethereal Tests"):
 
               case Argument("signal") :: Nil =>
                 execute:
-                  val name = summon[Invocation].signals.stream.head match
-                    case unix: UnixSignal       => unix.shortName
-                    case windows: WindowsSignal => windows.shortName
-                  Out.print(name) yet Exit.Ok
+                  val received: juc.LinkedBlockingQueue[Text] = juc.LinkedBlockingQueue()
+
+                  trap:
+                    case sig: UnixSignal =>
+                      received.offer(sig.shortName)
+                      SignalResponse.Accept
+
+                    case sig: WindowsSignal =>
+                      received.offer(sig.shortName)
+                      SignalResponse.Accept
+
+                  val raw: Text | Null = received.poll(2L, juc.TimeUnit.SECONDS)
+                  val text: Text = if raw == null then t"(timeout)" else raw
+                  Out.print(text) yet Exit.Ok
+
+              case Argument("trap-reject") :: Nil =>
+                execute:
+                  trap { case _: UnixSignal => SignalResponse.Reject }
+                  snooze(5*Second) yet Exit.Ok
+
+              case Argument("trap-defer") :: Nil =>
+                execute:
+                  val received: juc.LinkedBlockingQueue[Text] = juc.LinkedBlockingQueue()
+
+                  trap:
+                    case Signal.Int =>
+                      received.offer(t"outer")
+                      SignalResponse.Accept
+
+                  trap { case _: UnixSignal => SignalResponse.Defer }
+
+                  val raw: Text | Null = received.poll(2L, juc.TimeUnit.SECONDS)
+                  val text: Text = if raw == null then t"(timeout)" else raw
+                  Out.print(text) yet Exit.Ok
+
+              case Argument("trap-undefined") :: Nil =>
+                execute:
+                  trap { case Signal.Winch => SignalResponse.Accept }
+                  snooze(5*Second) yet Exit.Ok
+
+              case Argument("trap-slow") :: Nil =>
+                execute:
+                  trap:
+                    case _: UnixSignal =>
+                      snooze(2*Second)
+                      SignalResponse.Accept
+
+                  snooze(5*Second) yet Exit.Ok
 
               case _ =>
                 execute(Exit.Fail(1))
@@ -199,7 +244,7 @@ object Tests extends Suite(m"Ethereal Tests"):
             val proc = sh"$tool sleep 1".fork[Exit]()
             snooze(0.1*Second)
             sh"kill -TERM ${proc.pid.value}".exec[Unit]()
-            proc.await()
+            proc.await(3*Second)
             jl.System.currentTimeMillis - t0
           .assert(_ < 750L)
 
@@ -207,14 +252,14 @@ object Tests extends Suite(m"Ethereal Tests"):
             val proc = sh"$tool signal".fork[Text]()
             snooze(0.1*Second)
             sh"kill -WINCH ${proc.pid.value}".exec[Unit]()
-            proc.await()
+            proc.await(3*Second)
           . assert(_ == t"WINCH")
 
           test(m"SIGUSR1 is forwarded to the application"):
             val proc = sh"$tool signal".fork[Text]()
             snooze(0.1*Second)
             sh"kill -USR1 ${proc.pid.value}".exec[Unit]()
-            proc.await()
+            proc.await(3*Second)
 
           . assert(_ == t"USR1")
 
@@ -222,7 +267,7 @@ object Tests extends Suite(m"Ethereal Tests"):
             val proc = sh"$tool signal".fork[Text]()
             snooze(0.1*Second)
             sh"kill -USR2 ${proc.pid.value}".exec[Unit]()
-            proc.await()
+            proc.await(3*Second)
 
           . assert(_ == t"USR2")
 
@@ -230,7 +275,7 @@ object Tests extends Suite(m"Ethereal Tests"):
             val proc = sh"$tool signal".fork[Text]()
             snooze(0.1*Second)
             sh"kill -HUP ${proc.pid.value}".exec[Unit]()
-            proc.await()
+            proc.await(3*Second)
 
           . assert(_ == t"HUP")
 
@@ -238,9 +283,54 @@ object Tests extends Suite(m"Ethereal Tests"):
             val proc = sh"$tool signal".fork[Text]()
             snooze(0.1*Second)
             sh"kill -INT ${proc.pid.value}".exec[Unit]()
-            proc.await()
+            proc.await(3*Second)
 
           . assert(_ == t"INT")
+
+          test(m"trap returning Reject lets the launcher fall back to OS default"):
+            val proc = sh"$tool trap-reject".fork[Exit]()
+            snooze(0.1*Second)
+            sh"kill -TERM ${proc.pid.value}".exec[Unit]()
+            proc.await(3*Second)
+          . assert(_ != Exit.Ok)
+
+          test(m"Defer cascades to a previously-defined trap"):
+            val proc = sh"$tool trap-defer".fork[Text]()
+            snooze(0.1*Second)
+            sh"kill -INT ${proc.pid.value}".exec[Unit]()
+            proc.await(3*Second)
+
+          . assert(_ == t"outer")
+
+          test(m"signal not matched by any trap PF causes launcher to fall back"):
+            val proc = sh"$tool trap-undefined".fork[Exit]()
+            snooze(0.1*Second)
+            sh"kill -INT ${proc.pid.value}".exec[Unit]()
+            proc.await(3*Second)
+
+          . assert(_ != Exit.Ok)
+
+          test(m"slow handler past timeout causes launcher to fall back"):
+            val t0 = jl.System.currentTimeMillis
+            val proc = sh"$tool trap-slow".fork[Exit]()
+            snooze(0.1*Second)
+            sh"kill -TERM ${proc.pid.value}".exec[Unit]()
+            proc.await(3*Second)
+            jl.System.currentTimeMillis - t0
+
+          . assert(elapsed => elapsed > 200L && elapsed < 1500L)
+
+          test(m"WINCH with no matching trap does not kill the launcher"):
+            val proc = sh"$tool trap-undefined".fork[Exit]()
+            snooze(0.1*Second)
+            sh"kill -WINCH ${proc.pid.value}".exec[Unit]()
+            snooze(0.3*Second)
+            val alive = safely(Process(proc.pid).alive).or(false)
+            safely(sh"kill -KILL ${proc.pid.value}".exec[Unit]())
+            safely(proc.await(2*Second))
+            alive
+
+          . assert(_ == true)
 
         suite(m"State file monitoring"):
           test(m"daemon restarts after pid file is deleted"):

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package exoskeleton
 
+import java.util.concurrent.atomic as juca
+
 import ambience.*
 import anticipation.*
 import contingency.*
@@ -77,6 +79,34 @@ trait Cli extends Console:
   def register(flag: Flag, discoverable: Discoverable): Unit = ()
   def present(flag: Flag): Unit = ()
   def explain(update: (Optional[Text] aka "prior") ?=> Optional[Text]): Unit = ()
+
+  private val signalHandlers:
+  juca.AtomicReference[List[PartialFunction[UnixSignal | WindowsSignal, SignalResponse]]] =
+    juca.AtomicReference(Nil)
+
+  override def trap
+    ( handler: PartialFunction[UnixSignal | WindowsSignal, SignalResponse] )
+  :   Unit =
+
+    signalHandlers.updateAndGet(handler :: _.nn)
+
+
+  def dispatchSignal(signal: UnixSignal | WindowsSignal): SignalResponse =
+    def loop(handlers: List[PartialFunction[UnixSignal | WindowsSignal, SignalResponse]])
+    :   SignalResponse =
+
+      handlers match
+        case Nil =>
+          SignalResponse.Reject
+
+        case pf :: rest =>
+          if pf.isDefinedAt(signal) then pf(signal) match
+            case SignalResponse.Defer => loop(rest)
+            case decided              => decided
+          else loop(rest)
+
+    loop(signalHandlers.get.nn)
+
 
   def parameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
   :   Optional[operand]

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -42,7 +42,6 @@ import gossamer.*
 import guillotine.*
 import hieroglyph.*, textMetrics.uniform
 import hypotenuse.*
-import profanity.*
 import proscenium.*
 import spectacular.*
 import symbolism.*
@@ -58,7 +57,6 @@ case class Completion
     currentArgument:  Int,
     focusPosition:    Optional[Int],
     stdio:            Stdio,
-    signals:          Spool[UnixSignal | WindowsSignal],
     tty:              Text,
     tab:              Ordinal,
     login:            Login )

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -41,7 +41,6 @@ import eucalyptus.*
 import fulminate.*
 import gossamer.*
 import guillotine.*
-import profanity.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
@@ -67,7 +66,6 @@ package executives:
         environment:      Environment,
         workingDirectory: WorkingDirectory,
         stdio:            Stdio,
-        signals:          Spool[UnixSignal | WindowsSignal],
         entrypoint:       Entrypoint,
         login:            Login )
       ( using interpreter: Interpreter )
@@ -98,7 +96,6 @@ package executives:
                 focus,
                 posInWord,
                 stdio,
-                signals,
                 tty,
                 tab,
                 login )
@@ -142,7 +139,6 @@ package executives:
                 focus2,
                 position,
                 stdio,
-                signals,
                 tty,
                 tab,
                 login )
@@ -174,7 +170,6 @@ package executives:
               environment,
               workingDirectory,
               stdio,
-              signals,
               false,
               login )
 
@@ -184,7 +179,6 @@ package executives:
               environment,
               workingDirectory,
               stdio,
-              signals,
               true,
               login )
 

--- a/lib/exoskeleton/src/core/exoskeleton.Executive.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Executive.scala
@@ -34,7 +34,6 @@ package exoskeleton
 
 import ambience.*
 import anticipation.*
-import profanity.*
 import rudiments.*
 import turbulence.*
 
@@ -47,7 +46,6 @@ trait Executive:
       environment:      Environment,
       workingDirectory: WorkingDirectory,
       stdio:            Stdio,
-      signals:          Spool[UnixSignal | WindowsSignal],
       entrypoint:       Entrypoint,
       login:            Login )
     ( using interpreter: Interpreter )

--- a/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
@@ -34,7 +34,6 @@ package exoskeleton
 
 import ambience.*
 import anticipation.*
-import profanity.*
 import turbulence.*
 import vacuous.*
 
@@ -43,7 +42,6 @@ case class Invocation
     environment:      Environment,
     workingDirectory: WorkingDirectory,
     stdio:            Stdio,
-    signals:          Spool[UnixSignal | WindowsSignal],
     proceed:          Boolean,
     login:            Login )
   ( using interpreter: Interpreter )

--- a/lib/exoskeleton/src/core/exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton_core.scala
@@ -102,7 +102,6 @@ package executives:
         environment:      Environment,
         workingDirectory: WorkingDirectory,
         stdio:            Stdio,
-        signals:          Spool[UnixSignal | WindowsSignal],
         entrypoint:       Entrypoint,
         login:            Login )
       ( using interpreter: Interpreter )
@@ -113,7 +112,6 @@ package executives:
           environments.java,
           workingDirectories.java,
           stdio,
-          signals,
           arguments.size == 0 || arguments.head != t"{admin}",
           login )
 
@@ -125,14 +123,16 @@ package executives:
 inline def effectful[result](lambda: (erased Effectful) ?=> result): result =
   lambda(using !![Effectful])
 
+inline def trap(handler: PartialFunction[UnixSignal | WindowsSignal, SignalResponse])
+  ( using cli: Cli )
+:   Unit =
+
+  cli.trap(handler)
+
 def application(using executive: Executive, interpreter: Interpreter)
   ( arguments: Iterable[Text], signals: List[UnixSignal] = Nil )
   ( block: Cli ?=> executive.Return )
 :   Unit =
-
-  val spool: Spool[UnixSignal | WindowsSignal] = Spool()
-  signals.each: signal =>
-    sm.Signal.handle(sm.Signal(signal.shortName.s), event => spool.put(signal))
 
   val entrypoint = new Entrypoint:
     def executable: Path on Linux =
@@ -149,8 +149,10 @@ def application(using executive: Executive, interpreter: Interpreter)
         environments.java,
         workingDirectories.java,
         stdios.virtualMachine,
-        spool,
         entrypoint,
         Login(ProcessHandle.current().nn.info().nn.user().nn.get().nn.tt, Unset) )
+
+  signals.each: signal =>
+    sm.Signal.handle(sm.Signal(signal.shortName.s), _ => cli.dispatchSignal(signal))
 
   jl.System.exit(executive.process(cli)(block)())

--- a/lib/exoskeleton/src/core/soundness_exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/soundness_exoskeleton_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   exoskeleton
   . { Application, application, Backstop, Effectful, effectful, Entrypoint, Executive, InstallError,
-      Invocation }
+      Invocation, trap }
 
 package backstops:
   export exoskeleton.backstops.{exceptionMessage, genericErrorMessage, silent, stackTrace}

--- a/lib/profanity/src/core/profanity.SignalResponse.scala
+++ b/lib/profanity/src/core/profanity.SignalResponse.scala
@@ -32,15 +32,5 @@
                                                                                                   */
 package profanity
 
-import turbulence.*
-
-object Console:
-  def apply(stdio: Stdio): Console =
-    inline def stdio0: Stdio = stdio
-    new Console:
-      val stdio: Stdio = stdio0
-
-trait Console:
-  val stdio: Stdio
-
-  def trap(handler: PartialFunction[UnixSignal | WindowsSignal, SignalResponse]): Unit = ()
+enum SignalResponse:
+  case Accept, Reject, Defer

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -52,8 +52,7 @@ object Terminal:
   def enablePaste: Text = t"\e[?2004h"
   def disablePaste: Text = t"\e[?2004l"
 
-case class Terminal(signals: Spool[UnixSignal | WindowsSignal])
-  ( using console: Console, monitor: Monitor, codicil: Codicil )
+case class Terminal()(using console: Console, monitor: Monitor, codicil: Codicil)
 extends Interactivity[TerminalEvent]:
 
   export console.stdio.{in, out, err}
@@ -84,14 +83,15 @@ extends Interactivity[TerminalEvent]:
 
   def eventStream(): Stream[TerminalEvent] = events.stream
 
-  val pumpSignals: Daemon = daemon:
-    signals.stream.each:
-      case Signal.Winch =>
-        out.print(Terminal.reportSize)
-        events.put(Signal.Winch)
+  console.trap:
+    case Signal.Winch =>
+      out.print(Terminal.reportSize)
+      events.put(Signal.Winch)
+      SignalResponse.Accept
 
-      case signal =>
-        events.put(signal)
+    case signal =>
+      events.put(signal)
+      SignalResponse.Accept
 
   private def dark(red: Int, green: Int, blue: Int): Boolean =
     (0.299*red + 0.587*green + 0.114*blue) < 32768

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -52,7 +52,7 @@ def interactive[result](block: (terminal: Terminal) ?=> result)
           TerminalSizeDetection )
 :   result raises TerminalError =
 
-  given terminal: Terminal = Terminal(console.signals)
+  given terminal: Terminal = Terminal()
 
   if summon[LuminosityDetection]() then Out.print(Terminal.reportBackground)
   if summon[TerminalFocusDetection]() then Out.print(Terminal.enableFocus)
@@ -69,10 +69,8 @@ def interactive[result](block: (terminal: Terminal) ?=> result)
     block(using terminal)
 
   finally
-    terminal.signals.stop()
     terminal.stdio.in.close()
     terminal.events.stop()
-    safely(terminal.pumpSignals.attend())
     safely(terminal.pumpInput.await())
     if summon[BracketedPasteMode]() then Out.print(Terminal.disablePaste)
     if summon[TerminalFocusDetection]() then Out.print(Terminal.disableFocus)

--- a/lib/profanity/src/core/soundness_profanity_core.scala
+++ b/lib/profanity/src/core/soundness_profanity_core.scala
@@ -35,8 +35,9 @@ package soundness
 export
   profanity
   . { BracketedPasteMode, Console, DismissError, Interaction, interactive, Interactivity, Keyboard,
-      Keypress, LineEditor, LuminosityDetection, Question, SelectMenu, Terminal, TerminalError,
-      TerminalEvent, TerminalFocusDetection, TerminalSizeDetection, UnixSignal, WindowsSignal }
+      Keypress, LineEditor, LuminosityDetection, Question, SelectMenu, Signal, SignalResponse,
+      Terminal, TerminalError, TerminalEvent, TerminalFocusDetection, TerminalSizeDetection,
+      UnixSignal, WindowsSignal }
 
 package keyboards:
   export profanity.keyboards.{numeric, raw, standard}


### PR DESCRIPTION
## Summary

- Replaces Ethereal's fire-and-forget signal forwarding with an explicit `trap` API on `Cli`. Handlers form a stack; on each signal the daemon walks them most-recent-first, running each matching body and stopping at the first `Accept` or `Reject`. `Defer` (or a PartialFunction not defined at the signal) continues the cascade; an empty stack produces `Reject`.
- Wire protocol gains a one-byte ack (`a` / `r`); the Rust runner reads it with a configurable read timeout (`ETHEREAL_SIGNAL_TIMEOUT_MS`, default 250ms) and falls back to OS-default behaviour on Reject or timeout. Per-signal fallback table: `INT`/`TERM`/`HUP` (and the Windows close events) restore `SIG_DFL` and re-raise; `WINCH`/`USR1`/`USR2` are dropped silently.
- Removes `Spool[Signal]` everywhere it appeared (`Console.signals`, `Invocation`/`Completion` constructor parameter, `Executive.invocation` parameter). `profanity.Terminal` registers a `trap` during construction that puts signals onto its `TerminalEvent` spool. `exoskeleton_core.application` (non-Ethereal mode) now routes `sun.misc.Signal.handle` callbacks into the same `cli.dispatchSignal` machinery so direct-mode and daemon-mode share one handler model.

## Test plan

- [x] Existing five signal-forwarding tests rewritten around the new `trap` API and still pass.
- [x] New tests cover `Reject` → launcher falls back to OS default; `Defer` cascades to a previously-defined handler; PartialFunction-not-defined cascades the same way; a handler that runs past the 250ms wire timeout drops the launcher into fallback (timing-bounded assertion); a `WINCH` with no matching trap leaves the launcher running.
- [x] All `proc.await(...)` calls in the new and existing signal tests are bounded so a regression fails the assertion rather than hanging the suite.
- [x] `mill ethereal.test.run` — 47 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)