### PR TITLE
Run CI on pull requests targeting any branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Drop the `branches: [ main ]` filter from the `pull_request` trigger in `.github/workflows/main.yml`, so stacked PRs (whose base is another feature branch) get CI without waiting for their base to land on `main`.
- The `push` trigger is unchanged — pushes still only run CI on `main`; intermediate branches get CI via the `pull_request` event.

## Test plan
- [ ] Confirm this PR (which targets `ethereal-trap-api`, not `main`) triggers the Build workflow once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)