### PR TITLE
Set up release-branch mirroring and PR/commit conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--
+Single summary paragraph below: plain prose, user-facing voice, no headings or
+bullets. This becomes the changelog blurb on the `release` branch.
+-->
+
+
+<!--
+Below the blank line, write release notes in Markdown addressed to users of
+the library. Include short code examples if they help illustrate the change.
+This appears as the body of the commit message on `release`.
+-->
+
+

--- a/.github/workflows/mirror-to-release.yml
+++ b/.github/workflows/mirror-to-release.yml
@@ -82,15 +82,18 @@ jobs:
             exit 0
           fi
 
-          # First-run bootstrap: create release as an orphan branch with a
-          # baseline commit holding the tree at the first PR's parent. This
-          # makes the demarcation between pre-mirror and mirrored history
-          # explicit (no pre-existing commits on release).
+          # First-run bootstrap: create release as an orphan branch whose first
+          # commit holds the state of main *immediately before* the first PR
+          # being mirrored landed. We derive that state by checking out the
+          # first PR's merge-tip tree and reverse-applying its diff. This is
+          # method-agnostic (works for merge / rebase / squash merges).
           if ! git rev-parse --verify refs/remotes/origin/release >/dev/null 2>&1; then
             first_sha=$(jq -r '.[0].mergeCommit.oid' /tmp/todo.json)
-            base_sha=$(git rev-parse "${first_sha}^1")
-            echo "Bootstrapping release from tree at $base_sha"
-            git checkout --orphan release "$base_sha"
+            first_num=$(jq -r '.[0].number' /tmp/todo.json)
+            echo "Bootstrapping release from state before PR #$first_num"
+            git checkout --orphan release "$first_sha"
+            gh pr diff "$first_num" --repo "$REPO" --patch \
+              | git apply -R --index
             git commit -m 'Initial release branch baseline'
           else
             git checkout -B release origin/release
@@ -106,15 +109,20 @@ jobs:
 
             echo "::group::Mirroring #$number ($sha): $title"
 
-            parent=$(git rev-parse "${sha}^1")
+            # Pull the diff from the GitHub API so we don't depend on the merge
+            # method (merge-commit / rebase / squash all produce a usable
+            # patch this way). Same for the changed-files list used to build
+            # the Modules trailer.
+            gh pr diff "$number" --repo "$REPO" --patch > /tmp/pr.patch
+            gh pr view "$number" --repo "$REPO" --json files \
+              --jq '.files[].path' > /tmp/files.txt
 
             # Modules trailer: lib/<module> for files inside lib/, "core" for
             # any file outside lib/. Deduped, comma-separated.
-            modules=$(git diff --name-only "$parent" "$sha" \
-              | awk -F/ '
-                  $1=="lib" && NF>=3 { print "lib/" $2; next }
-                  { print "core" }
-                ' \
+            modules=$(awk -F/ '
+                $1=="lib" && NF>=3 { print "lib/" $2; next }
+                { print "core" }
+              ' /tmp/files.txt \
               | sort -u \
               | paste -sd, - \
               | sed 's/,/, /g')
@@ -142,7 +150,6 @@ jobs:
               printf 'PR: %s\n' "$url"
             } > /tmp/msg.txt
 
-            git diff "$parent" "$sha" > /tmp/pr.patch
             if [ ! -s /tmp/pr.patch ]; then
               echo "PR #$number has empty diff; skipping."
               echo "::endgroup::"

--- a/.github/workflows/mirror-to-release.yml
+++ b/.github/workflows/mirror-to-release.yml
@@ -1,0 +1,157 @@
+name: Mirror to release branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-branch
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Fetch release branch (if it exists)
+        run: git fetch origin release || true
+
+      - name: Mirror unmirrored PRs to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Collect PR numbers already mirrored on release (extracted from the
+          # `(#N)` suffix of each commit subject).
+          if git rev-parse --verify refs/remotes/origin/release >/dev/null 2>&1; then
+            git log origin/release --format=%s \
+              | grep -oE '\(#[0-9]+\)$' \
+              | tr -d '()#' \
+              | sort -u > /tmp/mirrored.txt
+          else
+            : > /tmp/mirrored.txt
+          fi
+
+          if [ -s /tmp/mirrored.txt ]; then
+            jq -R . /tmp/mirrored.txt | jq -s . > /tmp/mirrored.json
+          else
+            echo '[]' > /tmp/mirrored.json
+          fi
+
+          # Fetch recent merged PRs against main.
+          gh pr list \
+            --repo "$REPO" \
+            --state merged \
+            --base main \
+            --limit 50 \
+            --json number,title,body,url,mergedAt,mergeCommit \
+            > /tmp/prs.json
+
+          # Drop already-mirrored PRs and PRs without a merge commit; sort
+          # ascending by mergedAt so we apply them in the order they landed.
+          jq --slurpfile m /tmp/mirrored.json '
+            map(select(.mergeCommit != null and .mergeCommit.oid != null))
+            | map(select((.number | tostring) as $n | ($m[0] // []) | index($n) | not))
+            | sort_by(.mergedAt)
+          ' /tmp/prs.json > /tmp/todo.json
+
+          count=$(jq 'length' /tmp/todo.json)
+          echo "::notice::$count PR(s) to mirror"
+          if [ "$count" -eq 0 ]; then
+            echo "Nothing to do."
+            exit 0
+          fi
+
+          # First-run bootstrap: create release as an orphan branch with a
+          # baseline commit holding the tree at the first PR's parent. This
+          # makes the demarcation between pre-mirror and mirrored history
+          # explicit (no pre-existing commits on release).
+          if ! git rev-parse --verify refs/remotes/origin/release >/dev/null 2>&1; then
+            first_sha=$(jq -r '.[0].mergeCommit.oid' /tmp/todo.json)
+            base_sha=$(git rev-parse "${first_sha}^1")
+            echo "Bootstrapping release from tree at $base_sha"
+            git checkout --orphan release "$base_sha"
+            git commit -m 'Initial release branch baseline'
+          else
+            git checkout -B release origin/release
+          fi
+
+          # Apply each PR's diff as a single commit on release.
+          for i in $(seq 0 $((count - 1))); do
+            number=$(jq -r ".[$i].number" /tmp/todo.json)
+            title=$(jq -r ".[$i].title" /tmp/todo.json)
+            url=$(jq -r ".[$i].url" /tmp/todo.json)
+            sha=$(jq -r ".[$i].mergeCommit.oid" /tmp/todo.json)
+            jq -r ".[$i].body // \"\"" /tmp/todo.json > /tmp/body.raw
+
+            echo "::group::Mirroring #$number ($sha): $title"
+
+            parent=$(git rev-parse "${sha}^1")
+
+            # Modules trailer: lib/<module> for files inside lib/, "core" for
+            # any file outside lib/. Deduped, comma-separated.
+            modules=$(git diff --name-only "$parent" "$sha" \
+              | awk -F/ '
+                  $1=="lib" && NF>=3 { print "lib/" $2; next }
+                  { print "core" }
+                ' \
+              | sort -u \
+              | paste -sd, - \
+              | sed 's/,/, /g')
+
+            # Strip HTML comments, collapse blank-line runs left behind, and
+            # trim surrounding whitespace.
+            perl -0777 -pe '
+              s/<!--.*?-->//gs;
+              s/\n{3,}/\n\n/g;
+              s/\A\s+//;
+              s/\s+\z//;
+            ' /tmp/body.raw > /tmp/body.clean
+
+            {
+              printf '%s (#%s)\n' "$title" "$number"
+              if [ -s /tmp/body.clean ]; then
+                printf '\n'
+                cat /tmp/body.clean
+                printf '\n'
+              fi
+              printf '\n'
+              if [ -n "$modules" ]; then
+                printf 'Modules: %s\n' "$modules"
+              fi
+              printf 'PR: %s\n' "$url"
+            } > /tmp/msg.txt
+
+            git diff "$parent" "$sha" > /tmp/pr.patch
+            if [ ! -s /tmp/pr.patch ]; then
+              echo "PR #$number has empty diff; skipping."
+              echo "::endgroup::"
+              continue
+            fi
+            git apply --3way --index /tmp/pr.patch
+            git commit -F /tmp/msg.txt
+
+            echo "::endgroup::"
+          done
+
+          git push origin release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,31 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify tag points into release branch
+        id: check
+        run: |
+          git fetch origin release || { echo "release branch not found"; exit 1; }
+          if git merge-base --is-ancestor "${{ github.sha }}" origin/release; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${{ github.ref_name }} does not point at a commit reachable from release; skipping publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
   publish:
+    needs: guard
+    if: needs.guard.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/claude.md
+++ b/claude.md
@@ -18,3 +18,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Tests extend `Suite(name)` class and implement `run()` method
 - Test assertions use fluent pattern (`.assert(_ == expectedValue)`)
 - Strong emphasis on compile-time type safety and immutability
+
+## Workflow
+
+### Before the first commit of any task
+- Never commit while on `main` or in detached-HEAD state. Stop and create a new branch first.
+- The new branch must be based on the branch of the open PR at the top of the stack (not `main`). Use `gh pr list` / `gh pr view` to identify the top-of-stack PR and its head branch, then `git checkout -b <new-branch> <top-of-stack-branch>`.
+- If there are no open PRs in the stack, branch from `main`.
+
+### Commits
+- Commit incrementally as you edit. The bar is *incremental compilation passes* for the changed code — full clean compilation is not required per commit. If a change leaves the code uncompilable, keep editing until incremental compilation succeeds, then commit.
+- Before each commit, propose the commit message and pause so the user can review the staged changes (and may decide to amend them).
+- Push commits as soon as they're made.
+
+### Commit messages
+- Subject: imperative one-line summary (≤ 70 chars).
+- Body (optional): explanation of *why*, not *what*. Markdown is fine.
+
+### Pull requests
+- Open as **draft** until ready for review.
+- Title is a clear one-line description of the work.
+- Body follows `.github/pull_request_template.md`: a single summary paragraph, a blank line, then Markdown release notes for users (with code examples if useful).
+- Whenever a new commit is added to a PR, re-read the PR description and update it if it no longer accurately describes the full set of commits.
+
+### Stacked PRs
+- A new PR is always stacked on top of the highest open PR in the current stack, so the stack merges in order from the bottom up. Branch from the top-of-stack branch, not from `main`.
+- Use `git-branchless` (`git smartlog`, `git restack`, `git move`) to keep the stack consistent as commits are added to or rebased onto branches lower in the stack.

--- a/claude.md
+++ b/claude.md
@@ -23,8 +23,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Before the first commit of any task
 - Never commit while on `main` or in detached-HEAD state. Stop and create a new branch first.
-- The new branch must be based on the branch of the open PR at the top of the stack (not `main`). Use `gh pr list` / `gh pr view` to identify the top-of-stack PR and its head branch, then `git checkout -b <new-branch> <top-of-stack-branch>`.
-- If there are no open PRs in the stack, branch from `main`.
+- Always `git fetch origin` first, so the chosen base is current; never branch from a stale local ref.
+- Use `gh pr list --state open --base main` to find the open PR stack and identify the top-of-stack PR's head branch.
+- If the stack is non-empty, branch from `origin/<top-of-stack-head-ref>`: `git checkout -b <new-branch> origin/<top-of-stack-head-ref>`.
+- If the stack is empty, branch from `origin/main`: `git checkout -b <new-branch> origin/main`.
 
 ### Commits
 - Commit incrementally as you edit. The bar is *incremental compilation passes* for the changed code — full clean compilation is not required per commit. If a change leaves the code uncompilable, keep editing until incremental compilation succeeds, then commit.
@@ -42,5 +44,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Whenever a new commit is added to a PR, re-read the PR description and update it if it no longer accurately describes the full set of commits.
 
 ### Stacked PRs
-- A new PR is always stacked on top of the highest open PR in the current stack, so the stack merges in order from the bottom up. Branch from the top-of-stack branch, not from `main`.
+- A new PR is always stacked on top of the highest open PR in the current stack, so the stack merges in order from the bottom up. Branch from `origin/<top-of-stack-branch>`, not from `main` or a local copy.
+- Open the PR with `gh pr create --base <top-of-stack-branch>` (or `--base main` for an empty stack), so the diff GitHub shows is just the new commits, not the whole parent stack.
+- If the parent stack moves (its branch gets new commits or is rebased), bring this branch up to date by rebasing onto the latest `origin/<parent-branch>` before adding more commits.
 - Use `git-branchless` (`git smartlog`, `git restack`, `git move`) to keep the stack consistent as commits are added to or rebased onto branches lower in the stack.


### PR DESCRIPTION
A new workflow mirrors each merged PR onto a parallel `release` branch as a single commit whose message is built from the PR description, and the publish workflow now fires only for tags reachable from `release` — separating release semantics from `main`'s granular history.

## Mirror workflow

- Each merged PR becomes one commit on `release`. Subject: `<PR title> (#N)`. Body: the PR description with HTML comment hints stripped. Trailers: `Modules: lib/foo, ...` and `PR: <url>`.
- PR diffs are pulled via the GitHub API (`gh pr diff`), so the workflow is independent of the repo's merge method (works for merge-commit, rebase, and squash merges).
- First run creates `release` as an orphan branch whose baseline commit holds the state of `main` immediately before the first mirrored PR landed (derived by reverse-applying that PR's diff). No pre-existing `main` history is retroactively pulled in.
- Every run catches up any unmirrored merged PRs in merge order, so dropped events from concurrent merges self-heal.

## Publish workflow

- Tag `release` (not `main`) with `MAJOR.MINOR.PATCH` to publish.
- Split into a `guard` job and a `publish` job; `publish` runs only when the tag is reachable from `origin/release`.

## PR template

Every PR description has a single summary paragraph (plain prose, no bullets) followed by a blank line and Markdown release notes for users, with code examples where helpful.

## CLAUDE.md

New "Workflow" section covering:

- **Branch hygiene** — no commits on `main` or detached HEAD; always `git fetch origin` first; branch from `origin/<top-of-stack-branch>` (or `origin/main` for an empty stack).
- **Commits** — incremental cadence (incremental compilation suffices, not a clean build), user review of staged changes before each commit, push immediately.
- **PRs** — open as draft, follow the template, keep the description in sync with new commits, target the top-of-stack branch via `gh pr create --base`.
- **Stacked PRs** — rebase onto `origin/<parent-branch>` when the parent moves; `git-branchless` for stack maintenance.