### PR TITLE
Add watermark and squash detection to mirror workflow

### DIFF
--- a/.github/workflows/mirror-to-release.yml
+++ b/.github/workflows/mirror-to-release.yml
@@ -38,6 +38,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          # Only mirror PRs merged strictly after this timestamp. The release
+          # branch starts the day this workflow lands; earlier `main` history
+          # (mixed merge methods, intervening "Merge main into ..." commits) is
+          # not retroactively mirrored. Adjust if you need to backfill.
+          WATERMARK_MERGED_AFTER: '2026-04-29T11:48:00Z'
         run: |
           set -euo pipefail
 
@@ -67,10 +72,12 @@ jobs:
             --json number,title,body,url,mergedAt,mergeCommit \
             > /tmp/prs.json
 
-          # Drop already-mirrored PRs and PRs without a merge commit; sort
-          # ascending by mergedAt so we apply them in the order they landed.
-          jq --slurpfile m /tmp/mirrored.json '
+          # Drop PRs without a merge commit, PRs merged at/before the
+          # watermark, and PRs already mirrored. Sort ascending by mergedAt so
+          # we apply them in the order they landed.
+          jq --slurpfile m /tmp/mirrored.json --arg w "$WATERMARK_MERGED_AFTER" '
             map(select(.mergeCommit != null and .mergeCommit.oid != null))
+            | map(select(.mergedAt > $w))
             | map(select((.number | tostring) as $n | ($m[0] // []) | index($n) | not))
             | sort_by(.mergedAt)
           ' /tmp/prs.json > /tmp/todo.json
@@ -85,16 +92,28 @@ jobs:
           # Compute the number of commits a PR introduced onto main, given its
           # merge commit's SHA. Merge-commit and squash methods always add one
           # commit; rebase adds N (the PR's commit count, queried from the
-          # API). The method is detected from the merge commit's parent count.
+          # API). Method detection:
+          #   - 2 parents → merge-commit
+          #   - 1 parent + subject ends with " (#<number>)" → squash (this is
+          #     GitHub's default subject format for squash merges)
+          #   - 1 parent otherwise → rebase
           commits_on_main() {
-            local sha=$1 number=$2 parents
+            local sha=$1 number=$2 parents subject
             parents=$(git cat-file -p "$sha" | grep -c '^parent ')
             if [ "$parents" -eq 2 ]; then
               echo 1
-            else
-              gh pr view "$number" --repo "$REPO" --json commits \
-                --jq '.commits | length'
+              return
             fi
+            subject=$(git log -1 --format=%s "$sha")
+            case "$subject" in
+              *" (#${number})")
+                echo 1
+                ;;
+              *)
+                gh pr view "$number" --repo "$REPO" --json commits \
+                  --jq '.commits | length'
+                ;;
+            esac
           }
 
           # First-run bootstrap: create release as an orphan branch with a


### PR DESCRIPTION
The mirror-to-release workflow's first run after PR #915 still failed (run [25107024186](https://github.com/propensive/soundness/actions/runs/25107024186)) because of two compounding issues. This PR fixes both: detect squash merges by subject pattern, and add a watermark so we don't try to backfill historical PRs whose merges predate this workflow.

## Squash detection

PR #860 (`Rename Table to Scaffold`) is a squash merge: its merge commit has 1 parent and the subject ends with `(#860)`. The previous code treated any 1-parent merge as a rebase, queried the GitHub API for the PR's commit count (5), and walked back 5 commits along main's first-parent chain. That landed 6 PRs too far back (state before PR #855), so applying PR #860's diff on top failed with hunk conflicts and `does not exist in index` errors for files that hadn't been added yet at that ancestor.

Now `commits_on_main` distinguishes the three methods:

- 2 parents → merge-commit (n = 1)
- 1 parent + subject matches `*" (#<number>)"` → squash (n = 1)
- 1 parent otherwise → rebase (n = PR commit count from API)

## Watermark

Even with method detection correct, mirroring ~50 historical PRs is fragile: many of them were merged via the `merge` method with `Merge branch 'main' into <branch>` commits in their history, and those merge resolutions produce diffs that conflict when re-applied to a freshly-bootstrapped release branch. The original plan stated *release history starts the day this lands; pre-existing main history is not retroactively mirrored*. This PR enforces that with a `WATERMARK_MERGED_AFTER` env var on the workflow step, defaulting to `2026-04-29T11:48:00Z` (just after PR #915 landed).

PRs merged at or before the watermark are skipped silently. The `release` branch will be bootstrapped from the *first* PR merged after the watermark, applying its diff to that PR's parent commit — which, for any PR merged via rebase or squash going forward, gives a clean apply.

## Adjusting the watermark

Edit `WATERMARK_MERGED_AFTER` in `.github/workflows/mirror-to-release.yml`. If you ever want to backfill, set it to an earlier ISO timestamp; bear in mind that pre-cutover PRs may fail to apply, in which case you'll need to mirror them manually.