### PR TITLE
Fix `race` to cancel losing tasks

### DIFF
--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -75,7 +75,7 @@ object Task:
       val promise: Promise[result] = Promise()
       tasks.foreach(_.map(promise.offer(_)))
 
-      promise.await()
+      try promise.await() finally tasks.foreach(_.cancel())
 
 trait Task[+result]:
   def ready: Boolean

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -1108,6 +1108,23 @@ object Tests extends Suite(m"Parasite tests"):
           result
         . assert(_ == t"fast")
 
+        test(m"Race cancels losing tasks"):
+          val loserGate = Promise[Unit]()
+          val winnerGate = Promise[Unit]()
+          val loser = async:
+            loserGate.await()
+            t"loser"
+          val winner = async:
+            winnerGate.await()
+            t"winner"
+          val tasks = Vector(winner, loser)
+          val raceTask = async(tasks.race())
+          winnerGate.fulfill(())
+          raceTask.await()
+          snooze(200.0*Milli(Second))
+          loser.ready
+        . assert(_ == true)
+
       suite(m"Heap"):
         test(m"Heap.used returns a positive number of bytes"):
           Heap.used.long > 0L


### PR DESCRIPTION
The `Iterable[Task].race()` extension method previously returned the winner's value but left losing tasks running until they completed naturally or were cleaned up by the enclosing supervise block's codicil. This change cancels every input task once the winner is known, so `race()` honours the cancellation expected by clients like the EasyRacer benchmarks reported in #628 by jackgene.

`Iterable[Task].race()` now cancels losing tasks once a winner has been determined. Previously, losers continued running to completion, even after `race()` had returned the winner's value:

```scala
import soundness.*, threading.virtual, codicils.cancel

supervise:
  Vector(
    async:
      // wins immediately
      t"first",
    async:
      // long-running work — previously kept running, now cancelled
      heavyComputation()
      t"second"
  ).race()
```

When `race()` returns, every input task is guaranteed to have terminated (cancelled, completed, or failed). Cancelling a task that has already completed is a no-op, so the winner and any near-simultaneous finishers are unaffected.

Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)