### PR TITLE
Re-enable Bitumen against current Soundness APIs

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -198,7 +198,7 @@ object test extends ScalaModule:
     austronesian.test,
     aviation.test,
     baroque.test,
-    //bitumen.test,
+    bitumen.test,
     burdock.test,
     cacophony.test,
     caduceus.test,
@@ -385,9 +385,9 @@ object baroque extends Library:
   object core extends Component(quantitative.core, geodesy.core)
   object test extends Tests(core, abacist.core, quantitative.units, mosquito.core)
 
-// object bitumen extends Library:
-//   object core extends Component(polaris.core, serpentine.core, turbulence.core)
-//   object test extends Tests(core)
+object bitumen extends Library:
+  object core extends Component(serpentine.core, turbulence.core)
+  object test extends Tests(core)
 
 object burdock extends Library:
   object boot extends Component

--- a/lib/bitumen/src/core/bitumen.TarEntry.scala
+++ b/lib/bitumen/src/core/bitumen.TarEntry.scala
@@ -47,7 +47,7 @@ import turbulence.*
 import vacuous.*
 
 object TarEntry:
-  def apply[data: Readable by Data, instant: Abstractable across Instants]
+  def apply[data: Streamable by Data, instant: Abstractable across Instants to Long]
     ( name:  TarRef,
       data:  data,
       mode:  UnixMode          = UnixMode(),
@@ -57,7 +57,7 @@ object TarEntry:
           :   TarEntry =
 
     val mtimeU32: U32 =
-      (mtime.let(_.milliseconds).or(System.currentTimeMillis)/1000).toInt.bits.u32
+      (mtime.let(_.generic).or(System.currentTimeMillis)/1000).toInt.bits.u32
 
     TarEntry.File(name, mode, user, group, mtimeU32, data.stream[Data])
 
@@ -134,29 +134,29 @@ enum TarEntry(path: TarRef, mode: UnixMode, user: UnixUser, group: UnixGroup, mt
     case special: BlockSpecial => special.device
 
   def format(number: U32, width: Int): Data =
-    number.octal.pad(width - 1).bytes
+    number.octal.pad(width - 1).data
 
   lazy val header: Data = Data.build(512): array =>
-    array.place(entryName.bytes, Prim)
+    array.place(entryName.data, Prim)
     array.place(mode.bytes, 100.z)
     array.place(user.bytes, 108.z)
     array.place(group.bytes, 116.z)
-    array.place(format(size, 12.z), 124.z)
-    array.place(format(mtime, 12.z), 136.z)
-    array.place(t"        ".bytes, 148.z)
+    array.place(format(size, 12), 124.z)
+    array.place(format(mtime, 12), 136.z)
+    array.place(t"        ".data, 148.z)
     array(156) = typeFlag.id.toByte
 
-    link.let { link => array.place(link.bytes, 157.z) }
+    link.let { link => array.place(link.data, 157.z) }
 
     deviceNumbers.let: (devMajor, devMinor) =>
       array.place(format(devMajor, 8), 329.z)
       array.place(format(devMinor, 8), 337.z)
 
-    user.name.let { name => array.place(name.bytes, 265.z) }
-    group.name.let { name => array.place(name.bytes, 297.z) }
+    user.name.let { name => array.place(name.data, 265.z) }
+    group.name.let { name => array.place(name.data, 297.z) }
 
-    array.place(t"ustar\u0000".bytes, 257.z)
-    array.place(t"00".bytes, 263.z)
+    array.place(t"ustar\u0000".data, 257.z)
+    array.place(t"00".data, 263.z)
 
     val total = array.map(_.bits.u8.u32).reduce(_ + _)
     array.place(format(total, 8), 148.z)

--- a/lib/bitumen/src/core/bitumen.TarRef.scala
+++ b/lib/bitumen/src/core/bitumen.TarRef.scala
@@ -32,49 +32,7 @@
                                                                                                   */
 package bitumen
 
-import anticipation.*
-import contingency.*
-import denominative.*
-import gossamer.*
-import hieroglyph.*, charEncoders.ascii, textMetrics.uniform
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
-import nomenclature.*
 import prepositional.*
-import rudiments.*
 import serpentine.*
-import spectacular.*
-import turbulence.*
-import vacuous.*
 
-object TarRef:
-  def apply(text: Text)
-    ( using pathError:  Tactic[PathError],
-            navigable:  TarRef is Navigable[InvalidTarNames, Unset.type],
-            rootParser: RootParser[TarRef, Unset.type],
-            creator:    PathCreator[TarRef, InvalidTarNames, Unset.type] )
-    :   TarRef =
-
-    Navigable.decode[TarRef](text)
-
-  @targetName("child")
-  infix def / (name: Name[InvalidTarNames]): TarRef = TarRef(List(name))
-
-  given navigable: TarRef is Navigable[InvalidTarNames, Unset.type]:
-    def root(path: TarRef): Unset.type = Unset
-    def descent(path: TarRef): List[Name[InvalidTarNames]] = path.descent
-    def prefix(ref: Unset.type): Text = t""
-    def separator(path: TarRef): Text = t"/"
-
-  given rootParser: RootParser[TarRef, Unset.type]:
-    def parse(text: Text): (Unset.type, Text) =
-      (Unset, if text.at(Prim) == '/' then text.skip(1) else text)
-
-  given pathCreator: PathCreator[TarRef, InvalidTarNames, Unset.type] =
-    (root, descent) => TarRef(descent)
-
-  given showable: TarRef is Showable = _.descent.reverse.map(_.render).join(t"/")
-
-case class TarRef(descent: List[Name[InvalidTarNames]]):
-  def parent: Optional[TarRef] = descent match
-    case Nil       => Unset
-    case _ :: tail => TarRef(tail)
+type TarRef = Relative on Posix

--- a/lib/bitumen/src/core/bitumen.UnixGroup.scala
+++ b/lib/bitumen/src/core/bitumen.UnixGroup.scala
@@ -47,4 +47,4 @@ import turbulence.*
 import vacuous.*
 
 case class UnixGroup(value: Int, name: Optional[Text] = Unset):
-  def bytes: Data = value.octal.pad(7, Rtl, '0').bytes
+  def bytes: Data = value.octal.pad(7, Rtl, '0').data

--- a/lib/bitumen/src/core/bitumen.UnixMode.scala
+++ b/lib/bitumen/src/core/bitumen.UnixMode.scala
@@ -74,4 +74,4 @@ case class UnixMode
     if otherExec then sum += 1
     sum
 
-  def bytes: Data = int.octal.pad(7, Rtl, '0').bytes
+  def bytes: Data = int.octal.pad(7, Rtl, '0').data

--- a/lib/bitumen/src/core/bitumen.UnixUser.scala
+++ b/lib/bitumen/src/core/bitumen.UnixUser.scala
@@ -47,4 +47,4 @@ import turbulence.*
 import vacuous.*
 
 case class UnixUser(value: Int, name: Optional[Text] = Unset):
-  def bytes: Data = value.octal.pad(7, Rtl, '0').bytes
+  def bytes: Data = value.octal.pad(7, Rtl, '0').data

--- a/lib/bitumen/src/core/bitumen_core.scala
+++ b/lib/bitumen/src/core/bitumen_core.scala
@@ -33,17 +33,6 @@
 package bitumen
 
 import anticipation.*
-import contingency.*
-import denominative.*
-import gossamer.*
-import hieroglyph.*, charEncoders.ascii, textMetrics.uniform
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
-import nomenclature.*
-import prepositional.*
-import rudiments.*
-import serpentine.*
-import spectacular.*
-import turbulence.*
-import vacuous.*
 
-type InvalidTarNames = ".*[\u0000-\u0019].*" | ".*\u007f-\uffff.*" | ".*\\/.*" | ".*\\\\.*"
+private[bitumen] given Realm = Realm("bitumen")
+

--- a/lib/bitumen/src/core/soundness_bitumen_core.scala
+++ b/lib/bitumen/src/core/soundness_bitumen_core.scala
@@ -34,4 +34,4 @@ package soundness
 
 export
   bitumen
-  . { InvalidTarNames, Tar, TarEntry, TarPath, TarRef, TypeFlag, UnixGroup, UnixMode, UnixUser }
+  . { Tar, TarEntry, TarPath, TarRef, TypeFlag, UnixGroup, UnixMode, UnixUser }

--- a/lib/bitumen/src/test/bitumen_test.scala
+++ b/lib/bitumen/src/test/bitumen_test.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package bitumen
 
+import fulminate.*
 import probably.*
 
 object Tests extends Suite(m"Bitumen Tests"):


### PR DESCRIPTION
Bitumen, the Soundness module for reading and writing TAR files, had been commented out of the Mill build because of accumulated drift in its dependencies; this restores it as a compiling, build-enabled module without changing its (still write-only USTAR) feature surface, so that subsequent work can add a reader, long-name handling, and a real test suite on a green baseline.

### What changed

- `TarEntry.apply` now takes `data: Streamable by Data` (turbulence's `Readable` typeclass is gone) and `instant: Abstractable across Instants to Long` with the millisecond conversion happening through the `.generic` extension method.
- `TarRef` collapses to `Relative on Posix` — TAR paths are relative POSIX-style paths, and serpentine's `Relative` already supplies the navigation, encoding and decoding instances. The bespoke `Navigable[Constraint, Root]` / `RootParser` / `PathCreator` instances and the `InvalidTarNames` regex are removed (the latter is dropped from the public exports).
- All `text.bytes` calls become `text.data` (the modern hieroglyph/gossamer extension for `Text -> Data` given a `CharEncoder`); the `format` width helper now takes plain `Int`s rather than `Ordinal`s.
- A private `Realm("bitumen")` is added in `bitumen_core.scala`, ready for a future `TarError` type.
- `polaris.core` is removed from the declared deps because no source actually imports it; `serpentine.core` and `turbulence.core` are sufficient (and `anticipation.time` arrives transitively via `parasite`).

```scala
// before
def apply[data: Readable by Data, instant: Abstractable across Instants]
  (..., mtime: Optional[instant] = Unset): TarEntry =
  val mtimeU32 = (mtime.let(_.milliseconds).or(System.currentTimeMillis)/1000)...

// after
def apply[data: Streamable by Data, instant: Abstractable across Instants to Long]
  (..., mtime: Optional[instant] = Unset): TarEntry =
  val mtimeU32 = (mtime.let(_.generic).or(System.currentTimeMillis)/1000)...
```

```scala
// before
type InvalidTarNames = ...regex...
case class TarRef(descent: List[Name[InvalidTarNames]])
object TarRef:
  given navigable: TarRef is Navigable[InvalidTarNames, Unset.type] = ...
  given rootParser: RootParser[TarRef, Unset.type] = ...
  given pathCreator: PathCreator[TarRef, InvalidTarNames, Unset.type] = ...

// after
type TarRef = Relative on Posix
```

### Out of scope

`TarPath.entry` is still `???`, there is still no reader, long file names (>100 bytes) still silently corrupt, and the test suite is still an empty `Suite`. Those are follow-up work.