### PR TITLE
Shut down ethereal daemons after six hours of inactivity

### DIFF
--- a/lib/ethereal/src/core/ethereal.DaemonLogEvent.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonLogEvent.scala
@@ -42,6 +42,7 @@ object DaemonLogEvent:
     case WriteExecutable(location) => m"Writing executable to $location"
     case Shutdown                  => m"Shutting down"
     case Termination               => m"Terminating client connection"
+    case IdleTimeout               => m"Shutting down after idle timeout"
     case Failure                   => m"A failure occurred"
     case NewCli                    => m"Instantiating a new CLI"
     case UnrecognizedMessage       => m"Unrecognized message"
@@ -57,6 +58,7 @@ enum DaemonLogEvent:
   case WriteExecutable(location: Text)
   case Shutdown
   case Termination
+  case IdleTimeout
   case Failure
   case NewCli
   case UnrecognizedMessage

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -219,7 +219,7 @@ def cli[bus <: Matchable](using executive: Executive)
   val socketFile: Path on Linux = baseDir/name/"socket"
   val clients: scc.TrieMap[Pid, Client of bus] = scc.TrieMap()
   val terminatePid: Promise[Pid] = Promise()
-  val idleTimeout: Long = 60L*1_000_000_000L
+  val idleTimeout: Long = 6L*60L*60L*1_000_000_000L
 
   def client(pid: Pid): Client of bus = clients.getOrElseUpdate(pid, Client[bus](pid))
 

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -219,6 +219,7 @@ def cli[bus <: Matchable](using executive: Executive)
   val socketFile: Path on Linux = baseDir/name/"socket"
   val clients: scc.TrieMap[Pid, Client of bus] = scc.TrieMap()
   val terminatePid: Promise[Pid] = Promise()
+  val idleTimeout: Long = 60L*1_000_000_000L
 
   def client(pid: Pid): Client of bus = clients.getOrElseUpdate(pid, Client[bus](pid))
 
@@ -459,7 +460,16 @@ def cli[bus <: Matchable](using executive: Executive)
               case other =>
                 ()
 
-      loop(safely(makeClient(channel.accept().nn))).run()
+      val inactivityTimer: Timeout = Timeout(idleTimeout):
+        Log.warn(DaemonLogEvent.IdleTimeout)
+        termination
+
+      loop:
+        val socket = channel.accept().nn
+        inactivityTimer.nudge()
+        safely(makeClient(socket))
+
+      . run()
 
     Exit.Ok
 


### PR DESCRIPTION
Long-running Ethereal daemons that nobody connects to no longer linger forever; each daemon now self-terminates after six hours without a new client connection, freeing the JVM and cleaning up its state files.

Each new client connection extends the deadline by another six hours, so daemons under any kind of regular use stay alive indefinitely. When the deadline does pass, the daemon wipes its `pid`, `socket`, and `build` files and exits cleanly — the next client invocation will spawn a fresh one through the usual launcher path. A new `DaemonLogEvent.IdleTimeout` is logged to syslog so the inactivity-shutdown path is distinguishable from the existing state-file-watcher termination.

The mechanism is built on `parasite.Timeout`: a single timer is constructed inside the daemon's `supervise` block and `nudge()`d from the accept loop on every returned socket. There's nothing for callers of `ethereal.cli` to change.