### PR TITLE
Wrap SN-xx/n error codes in OSC 8 hyperlinks (gated off)

### DIFF
--- a/lib/decorum/src/plugin/decorum.DecorumPhase.scala
+++ b/lib/decorum/src/plugin/decorum.DecorumPhase.scala
@@ -46,6 +46,7 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
   private val seen: mutable.Set[String] = mutable.Set.empty
 
   private val esc: Char = 27.toChar
+  private val bel: Char = 7.toChar
   private val gray   = s"$esc[38;2;128;128;128m"
   private val orange = s"$esc[38;2;255;165;0m"
   private val yellow = s"$esc[38;2;255;215;0m"
@@ -54,8 +55,12 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
 
   private def colourPrefix(rule: String, useColor: Boolean): String =
     if useColor then
-      val rendered = rule.replace(".", s"$gray.$cyan")
-      s"$gray[$orange↯SN$gray-${yellow}de$gray/$cyan$rendered$gray]$reset "
+      val hyperlink = false
+      val rendered  = rule.replace(".", s"$gray.$cyan")
+      val d         = rule.takeWhile(_ != '.')
+      val link      = if hyperlink then s"$esc]8;;https://soundness.dev/SN-de/$d$bel" else ""
+      val unlink    = if hyperlink then s"$esc]8;;$bel" else ""
+      s"$link$gray[$orange↯SN$gray-${yellow}de$gray/$cyan$rendered$gray]$reset$unlink "
     else
       s"[↯SN-de/$rule] "
 

--- a/lib/fulminate/src/core/fulminate.Error.scala
+++ b/lib/fulminate/src/core/fulminate.Error.scala
@@ -64,14 +64,19 @@ extends Exception(message.text.s, cause, false, diagnostics.captureStack):
   def colourCode: Text =
     if d == 0 then "".tt
     else
+      val hyperlink = false
       val esc = 27.toChar
+      val bel = 7.toChar
       val gray   = s"$esc[38;2;128;128;128m"
       val orange = s"$esc[38;2;255;165;0m"
       val yellow = s"$esc[38;2;255;215;0m"
       val cyan   = s"$esc[38;2;0;200;255m"
       val reset  = s"$esc[0m"
       val ePart  = if e == 0 then "" else s"$gray.$cyan$e"
-      s"$gray[$orange↯SN$gray-$yellow${realm.code}$gray/$cyan$d$ePart$gray]$reset".tt
+      val link   = if hyperlink then s"$esc]8;;https://soundness.dev/SN-${realm.code}/$d$bel" else ""
+      val unlink = if hyperlink then s"$esc]8;;$bel" else ""
+      s"$link$gray[$orange↯SN$gray-$yellow${realm.code}$gray/$cyan$d$ePart$gray]$reset$unlink"
+      .tt
 
   def labelled: Message =
     if d == 0 then message

--- a/lib/fulminate/src/core/fulminate_core.scala
+++ b/lib/fulminate/src/core/fulminate_core.scala
@@ -49,13 +49,17 @@ def panic(message: Message): Nothing = throw Panic(message)
 private def errorPrefix(realm: Realm, d: Int, e: Int, useColor: Boolean): String =
   val esc = 27.toChar
   if useColor then
+    val hyperlink = false
+    val bel = 7.toChar
     val gray   = s"$esc[38;2;128;128;128m"
     val orange = s"$esc[38;2;255;165;0m"
     val yellow = s"$esc[38;2;255;215;0m"
     val cyan   = s"$esc[38;2;0;200;255m"
     val reset  = s"$esc[0m"
     val ePart  = if e == 0 then "" else s"$gray.$cyan$e"
-    s"$gray[$orange↯SN$gray-$yellow${realm.code}$gray/$cyan$d$ePart$gray]$reset "
+    val link   = if hyperlink then s"$esc]8;;https://soundness.dev/SN-${realm.code}/$d$bel" else ""
+    val unlink = if hyperlink then s"$esc]8;;$bel" else ""
+    s"$link$gray[$orange↯SN$gray-$yellow${realm.code}$gray/$cyan$d$ePart$gray]$reset$unlink "
   else
     val ePart = if e == 0 then "" else s".$e"
     s"[↯SN-${realm.code}/$d$ePart] "


### PR DESCRIPTION
Soundness now wraps the bracketed `[↯SN-xx/n]` error code in OSC 8 terminal hyperlink escape sequences pointing to `https://soundness.dev/SN-xx/n`, so supporting terminals can render the code as a clickable link straight to its documentation page. The wrapping is currently gated behind a local `val hyperlink = false` at each rendering site (`fulminate.Error.colourCode`, `fulminate_core.errorPrefix`, `decorum.DecorumPhase.colourPrefix`) because mill's prompt logger pipes output through fansi 0.5.1, whose ANSI-stripping regex only matches CSI sequences and throws `IllegalStateException` on OSC sequences — when fansi/mill ship a fix, flipping the flag at each site enables the links without re-deriving the OSC 8 logic.

Compile- and runtime errors carrying an `SN-xx/n` code now embed an OSC 8 hyperlink to `https://soundness.dev/SN-xx/n`, the documentation page for that error. Terminals that recognise OSC 8 (iTerm2, WezTerm, recent VS Code, Kitty, Windows Terminal, etc.) render the code as a clickable link; terminals that don't simply ignore the escape sequence.

```
[↯SN-fu/1] some message
   ^^^^^^^
   clickable, opens https://soundness.dev/SN-fu/1
```

The feature is currently gated off with `val hyperlink = false` at each site, pending a fansi/mill fix for OSC sequence handling. No behaviour change ships yet.
