### PR TITLE
Reformat code to satisfy Decorum layout warnings

### DIFF
--- a/lib/aviation/src/core/aviation.Iso8601.scala
+++ b/lib/aviation/src/core/aviation.Iso8601.scala
@@ -107,7 +107,9 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
           next()
           yearWeekDay(week, number(1))
 
-        else if !digit then fail(Digit) yet today() else
+        else if !digit
+        then fail(Digit) yet today()
+        else
           val month: Month = Month(number(2))
 
           next() match

--- a/lib/aviation/src/core/aviation.Weekday.scala
+++ b/lib/aviation/src/core/aviation.Weekday.scala
@@ -50,7 +50,8 @@ object Weekday:
 
     val extra =
       if dayOrdinal + (if dayOrdinal < startOrdinal then 7 else 0) < startOrdinal + extras
-      then 1 else 0
+      then 1
+      else 0
 
     (total/7) + extra
 

--- a/lib/cacophony/src/core/cacophony.Audio.scala
+++ b/lib/cacophony/src/core/cacophony.Audio.scala
@@ -58,11 +58,13 @@ object Audio:
     val encoding = raw.getFormat.nn.getEncoding.nn
 
     val pcm: jss.AudioInputStream =
-      if encoding == jss.AudioFormat.Encoding.PCM_SIGNED
+      if
+        encoding == jss.AudioFormat.Encoding.PCM_SIGNED
         || encoding == jss.AudioFormat.Encoding.PCM_UNSIGNED
       then raw
       else
         val src = raw.getFormat.nn
+
         val target =
           jss.AudioFormat
             ( jss.AudioFormat.Encoding.PCM_SIGNED,
@@ -105,10 +107,12 @@ object Audio:
   given streamable: [form: Audible] => (Audio in form) is Streamable by Data = audio =>
     writeAudio(audio, form.name)
 
+
   given streamableAcross: [form: Audible, layout]
-        =>  (Audio in form across layout) is Streamable by Data =
+  =>  (Audio in form across layout) is Streamable by Data =
 
     audio => writeAudio(audio, form.name)
+
 
   given abstractable: [format: Audible] => (Audio in format) is Abstractable:
     type Domain = HttpStreams
@@ -159,7 +163,8 @@ extends Formal, Domainal:
     if signed && bytesPerSample < 4 then
       val shift = 32 - 8*bytesPerSample
       (value << shift) >> shift
-    else value
+    else
+      value
 
   def to[form: Audible as audible]: Audio in form across audio.Domain =
     new Audio(format, data):

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -163,7 +163,8 @@ object Sheet:
           case '\n' | '\r' =>
             if column == 0 && builder.nil
             then recur(content, index + 1, 0, cells, builder, State.Fresh, headings)
-            else if state != State.Quoted then putDsv()
+            else if state != State.Quoted
+            then putDsv()
             else proceed(next.s.charAt(index.n0))
 
           case char =>

--- a/lib/cardinality/src/core/cardinality.internal.scala
+++ b/lib/cardinality/src/core/cardinality.internal.scala
@@ -82,7 +82,7 @@ object internal:
                     m"""
                       the value $string is less than the lower bound for this value,
                       ${lowerBound.toString}
-                    """)
+                    """ )
 
                 if value > upperBound
                 then halt

--- a/lib/cataclysm/src/core/cataclysm.MixBlendMode.scala
+++ b/lib/cataclysm/src/core/cataclysm.MixBlendMode.scala
@@ -33,5 +33,6 @@
 package cataclysm
 
 enum MixBlendMode extends PropertyValue:
-  case Normal, Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorDurn, Difference,
-      Exclusion, Hue, Saturation, Color, Luminos
+  case
+    Normal, Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorDurn, Difference,
+    Exclusion, Hue, Saturation, Color, Luminos

--- a/lib/cataclysm/src/core/cataclysm.internal.scala
+++ b/lib/cataclysm/src/core/cataclysm.internal.scala
@@ -56,7 +56,7 @@ object internal:
             val typeName = Type.of[value].show
             halt
               ( 1,
-                m"no valid CSS element ${key.valueOrAbort} taking values of type $typeName exists")
+                m"no valid CSS element ${key.valueOrAbort} taking values of type $typeName exists" )
 
         '{CssProperty(Text($key).uncamel.kebab, infer[ShowProperty[value]].show($value))}
         :: recur(tail)

--- a/lib/cellulose/src/core/cellulose.CodlDoc.scala
+++ b/lib/cellulose/src/core/cellulose.CodlDoc.scala
@@ -89,7 +89,8 @@ extends Indexed:
       if x.uniqueId.absent || y.uniqueId.absent then
         if x.data.absent || y.data.absent then x.extra == y.extra
         else x.data == y.data
-      else x.id == y.id
+      else
+        x.id == y.id
 
     def recur(original: IArray[CodlNode], updates: IArray[CodlNode]): IArray[CodlNode] =
       val changes = diff[CodlNode](children, updates, cmp).edits

--- a/lib/cellulose/src/core/cellulose.CodlSchema.scala
+++ b/lib/cellulose/src/core/cellulose.CodlSchema.scala
@@ -94,7 +94,8 @@ extends Dynamic:
 
   def param(index: Int): Optional[Entry] =
     if index < paramCount then subschemas(index)
-    else if endlessParams && paramCount > 0 then subschemas(paramCount - 1) else Unset
+    else if endlessParams && paramCount > 0 then subschemas(paramCount - 1)
+    else Unset
 
   def has(key: Optional[Text]): Boolean = dictionary.contains(key)
 

--- a/lib/cellulose/src/core/cellulose.internal.scala
+++ b/lib/cellulose/src/core/cellulose.internal.scala
@@ -257,7 +257,8 @@ object internal extends protointernal:
 
           val uniqueId2 =
             if child.schema.arity == Arity.Unique
-            then (child.key.vouch, (child.line, child.col)) else Unset
+            then (child.key.vouch, (child.line, child.col))
+            else Unset
 
           (uniqueId2, copy(children = closed :: children, params = params + 1))
 
@@ -484,8 +485,8 @@ object internal extends protointernal:
               case _ =>
                 go(Stream(CodlToken.Outdent(stack.length + 1)))
 
-      if stream.nil
-      then CodlDoc() else recur(stream, Proto(), Nil, Map(), Nil, 0, subs.reverse, Stream(), Nil)
+      if stream.nil then CodlDoc()
+      else recur(stream, Proto(), Nil, Map(), Nil, 0, subs.reverse, Stream(), Nil)
 
 
     def tokenize(in: Stream[Text], fromStart: Boolean = false)(using Diagnostics)
@@ -626,10 +627,11 @@ object internal extends protointernal:
                 ParseError
                   ( Codl, Position(char.line, col(char), 1), UnevenIndent(margin, char.column) ),
                 char.column + 1 )
-          else diff match
-            case 2 => CodlToken.Indent #:: irecur(next, indent = char.column)
-            case 0 => CodlToken.Peer #:: irecur(next, indent = char.column)
-            case n => CodlToken.Outdent(-diff/2) #:: irecur(next, indent = char.column)
+          else
+            diff match
+              case 2 => CodlToken.Indent #:: irecur(next, indent = char.column)
+              case 0 => CodlToken.Peer #:: irecur(next, indent = char.column)
+              case n => CodlToken.Outdent(-diff/2) #:: irecur(next, indent = char.column)
 
         char.char match
           case _ if char == Character.End =>

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -101,8 +101,8 @@ object Contrastable:
           val rightOnly: Set[Text] = (right -- left).map(_.show)
 
           def describe(set: Set[Text]): Text =
-            ( if set.size > 5
-              then set.take(4).to(List) :+ t"…${(set.size - 4).show.subscripts}" else set.to(List) )
+            ( if set.size > 5 then set.take(4).to(List) :+ t"…${(set.size - 4).show.subscripts}"
+              else set.to(List) )
 
             . join(t"{", t", ", t"}")
 

--- a/lib/contingency/src/core/contingency.Tracking.scala
+++ b/lib/contingency/src/core/contingency.Tracking.scala
@@ -37,8 +37,7 @@ import proscenium.*
 import vacuous.*
 
 object Tracking:
-  extension [accrual <: Exception, lambda[_], focus]
-            (inline track: Tracking[accrual, lambda, focus])
+  extension [accrual <: Exception, lambda[_], focus](inline track: Tracking[accrual, lambda, focus])
     inline def within[result](inline lambda: Foci[focus] ?=> lambda[result])
       ( using tactic: Tactic[accrual], diagnostics: Diagnostics )
     :   result =

--- a/lib/contingency/src/core/contingency.Validate.scala
+++ b/lib/contingency/src/core/contingency.Validate.scala
@@ -38,13 +38,14 @@ import vacuous.*
 
 object Validate:
   extension [accrual <: Exception, lambda[_], focus]
-            (inline validate: Validate[accrual, lambda, focus])
+    ( inline validate: Validate[accrual, lambda, focus] )
+
     inline def within(inline lambda: Foci[focus] ?=> lambda[Any])(using diagnostics: Diagnostics)
     :   accrual =
 
-      ${
+      $ {
           contingency.internal.validateWithin[accrual, lambda, focus]
-            ('validate, 'lambda, 'diagnostics)
+            ( 'validate, 'lambda, 'diagnostics )
         }
 
 class Validate[accrual, lambda[_], focus]

--- a/lib/decorum/src/plugin/decorum.ScanAll.scala
+++ b/lib/decorum/src/plugin/decorum.ScanAll.scala
@@ -60,6 +60,7 @@ object ScanAll:
 
     filtered.foreach: v =>
       val short = v.file.split("/lib/").nn match
-        case parts if parts.length >= 2 => "lib/" + parts(1)
+        case parts if parts.length >= 2 => "lib/"+parts(1)
         case _                          => v.file
+
       println(s"${short}:${v.line}:${v.column}  [${v.rule}] ${v.message}")

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -246,7 +246,8 @@ object StackTrace:
 
       (rewritten.s.substring(0, pivot).nn+"."+sub+rewritten.s.substring(pivot + 1).nn.dropRight(1))
       . tt
-    else rewritten
+    else
+      rewritten
 
   def apply(exception: Throwable): StackTrace =
     val frames = List(exception.getStackTrace.nn.map(_.nn)*).map: frame =>

--- a/lib/escapade/src/core/escapade.Bg.scala
+++ b/lib/escapade/src/core/escapade.Bg.scala
@@ -51,7 +51,8 @@ case class Bg(color: Chroma):
           + ((color.underlying >> 8)&255)*0.72
           + ((color.underlying >> 16)&255)*0.21 )
         > 128
-      then 0 else 16777215
+      then 0
+      else 16777215
 
   def ansi(colorDepth: ColorDepth): Text =
     val red = (color.underlying >> 16)&255
@@ -64,8 +65,10 @@ case class Bg(color: Chroma):
       case _ =>
         val n =
           if red == 0 && green == 0 && blue == 0 then 16
-          else if red == 255 && green == 255 && blue == 255 then 231
-          else if blue == red && red == green then 232 + red*23/255
+          else if red == 255 && green == 255 && blue == 255
+          then 231
+          else if blue == red && red == green
+          then 232 + red*23/255
           else 16 + red*5/255*36 + green*5/255*6 + blue*5/255
 
         t"\e[48;5;${n}m"

--- a/lib/escapade/src/core/escapade.Fg.scala
+++ b/lib/escapade/src/core/escapade.Fg.scala
@@ -55,8 +55,10 @@ case class Fg(color: Chroma):
       case _ =>
         val n =
           if red == 0 && green == 0 && blue == 0 then 16
-          else if red == 255 && green == 255 && blue == 255 then 231
-          else if blue == red && red == green then 232 + red*23/255
+          else if red == 255 && green == 255 && blue == 255
+          then 231
+          else if blue == red && red == green
+          then 232 + red*23/255
           else 16 + red*5/255*36 + green*5/255*6 + blue*5/255
 
         t"\e[38;5;${n}m"

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -116,11 +116,10 @@ object Teletype:
       if limit <= 0 then acc
       else
         val matcher = pattern.matcher(source.plain.s).nn
-        if matcher.matches
-        then
+
+        if !matcher.matches then source :: acc else
           val output = source.keep(matcher.group(2).nn.length, Rtl)
           recur(source.keep(matcher.group(1).nn.length), limit - 1, output :: acc)
-        else source :: acc
 
     recur(text, limit, Nil)
 

--- a/lib/escapade/src/core/escapade.internal.scala
+++ b/lib/escapade/src/core/escapade.internal.scala
@@ -155,4 +155,5 @@ case class Teletype2(plain: Text, ansi: IArray[escapade.internal.AnsiStyle]):
 
             append(plain.s.charAt(index.n0))
             recur(current2, index + 1)
-          else recur(current, index + 1)
+          else
+            recur(current, index + 1)

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -72,7 +72,8 @@ package columnar:
         if textual.unsafeChar(text, position.z) == ' '
         then longestWord(text, position + 1, position + 1, max.max(position - lastStart))
         else longestWord(text, position + 1, lastStart, max)
-      else max.max(position - lastStart)
+      else
+        max.max(position - lastStart)
 
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
     :   Optional[Int] =
@@ -100,7 +101,8 @@ package columnar:
                 text.segment(lineStart.z thru lastSpace.u) :: lines )
 
             else format(text, position + 1, lineStart, lastSpace, lines)
-        else if lineStart == position then lines
+        else if lineStart == position
+        then lines
         else text.segment(lineStart.z thru position.u) :: lines
 
 

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -39,8 +39,6 @@ import java.lang as jl
 import java.net as jn
 import java.nio as jnio
 import java.nio.channels as jnc
-import java.util as ju
-import java.util.concurrent as juc
 import java.util.concurrent.atomic as juca
 
 import scala.collection.concurrent as scc
@@ -145,7 +143,8 @@ def cli[bus <: Matchable](using executive: Executive)
 
               val os =
                 if osName.contains(t"mac") || osName.contains(t"darwin") then t"macos"
-                else if osName.contains(t"win") then t"windows"
+                else if osName.contains(t"win")
+                then t"windows"
                 else t"linux"
 
               val arch =
@@ -365,8 +364,9 @@ def cli[bus <: Matchable](using executive: Executive)
               import workingDirectories.system
 
               if safely(Environment.colorterm[Text]) == t"truecolor" then ColorDepth.TrueColor
-              else ColorDepth
-                    ( safely(mute[ExecEvent](sh"tput colors".exec[Text]().decode[Int])).or(-1) )
+              else
+                ColorDepth
+                  ( safely(mute[ExecEvent](sh"tput colors".exec[Text]().decode[Int])).or(-1) )
 
           val stdio: Stdio =
             Stdio
@@ -408,7 +408,8 @@ def cli[bus <: Matchable](using executive: Executive)
               val exitStatus: Exit = executive.process(cli)(result)
 
               connection.exitPromise.fulfill(exitStatus)
-            else connection.exitPromise.fulfill(Exit.Ok)
+            else
+              connection.exitPromise.fulfill(Exit.Ok)
 
           catch
             case exception: Exception =>

--- a/lib/fulminate/src/core/fulminate.TextEscapes.scala
+++ b/lib/fulminate/src/core/fulminate.TextEscapes.scala
@@ -78,12 +78,12 @@ object TextEscapes:
 
     @tailrec
     def recur(cur: Int = 0, esc: Boolean): Unit =
-      if cur < text.s.length
-      then
+      if cur < text.s.length then
         val (char, index, escape) = standardEscape(text, cur, esc)
         if char >= 0 then buffer.append(char.toChar)
         recur(index, escape)
-      else if esc then throw EscapeError(Message("the final character cannot be an escape".tt))
+      else if esc
+      then throw EscapeError(Message("the final character cannot be an escape".tt))
 
     recur(0, false)
 

--- a/lib/fulminate/src/core/fulminate_core.scala
+++ b/lib/fulminate/src/core/fulminate_core.scala
@@ -149,9 +149,9 @@ def warn(d: Int, message: Message, position: Matchable)(using quotes: Quotes, re
     case _                        => report.warning(text)
 
 
-def warn(d: Int, reason: Clarification, message: Message)
-  (using quotes: Quotes, realm: Realm)
+def warn(d: Int, reason: Clarification, message: Message)(using quotes: Quotes, realm: Realm)
 :   Unit =
+
   import quotes.reflect.*
   val body = if detectColor then message.colorText.s else message.text.s
   report.warning(errorPrefix(realm, d, reason.number, detectColor)+body)

--- a/lib/galilei/src/core/galilei.IoError.scala
+++ b/lib/galilei/src/core/galilei.IoError.scala
@@ -42,8 +42,9 @@ object IoError:
     case Read, Write, Create, Copy, Move, Delete, Metadata, Open, Access
 
   enum Reason:
-    case PermissionDenied, Nonexistent, AlreadyExists, IsNotDirectory, IsDirectory,
-        DirectoryNotEmpty, NotSameVolume, Unsupported, Cycle
+    case
+      PermissionDenied, Nonexistent, AlreadyExists, IsNotDirectory, IsDirectory, DirectoryNotEmpty,
+      NotSameVolume, Unsupported, Cycle
 
   @targetName("apply2")
   def apply(path: Path, operation: Operation, reason: Reason)

--- a/lib/gossamer/src/core/gossamer.Cuttable.scala
+++ b/lib/gossamer/src/core/gossamer.Cuttable.scala
@@ -70,9 +70,7 @@ object Cuttable:
       @tailrec
       def recur(start: Ordinal, results: List[textual]): List[textual] =
         if matcher.find(start.n0)
-        then
-          val interval = matcher.start.z thru matcher.end.z
-          recur(matcher.end.z, text.segment(interval) :: results)
+        then recur(matcher.end.z, text.segment(matcher.start.z thru matcher.end.z) :: results)
         else results
 
       recur(Prim, Nil).reverse

--- a/lib/gossamer/src/core/gossamer.Decimalizer.scala
+++ b/lib/gossamer/src/core/gossamer.Decimalizer.scala
@@ -74,7 +74,7 @@ extends DecimalConverter:
         ( chars: Array[Char], bcd: Long, index: Int, carry: Boolean, point: Int )
       :   Array[Char] =
 
-        if index >= 0 then
+        if index < 0 then chars else
           var digit = bcd & 15
           var carry2 = carry
 
@@ -85,7 +85,6 @@ extends DecimalConverter:
               chars(index) = (digit + '0').toChar
 
           write(chars, if index != point then (bcd >> 4) else bcd, index - 1, carry2, point)
-        else chars
 
       @tailrec
       def recur(focus: Double, bcd: Long, index: Int): Array[Char] =
@@ -99,10 +98,9 @@ extends DecimalConverter:
           val length = shift + index - scale.min(0)
 
           val suffix: Int =
-            if exponentiate then
+            if !exponentiate then 0 else
               exponent.length + (if exponentValue < 0 then 1 else 0)
-              + (exponentScale(exponentValue, 0))
-            else 0
+              + exponentScale(exponentValue, 0)
 
           val fullLength = (if sign then 1 else 0) + (if point < length then 1 else 0) + length
           val array = new Array[Char](fullLength + suffix)
@@ -134,11 +132,15 @@ extends DecimalConverter:
               next >= 5,
               if sign then point + 1 else point )
 
-        else recur(next, bcd2, index + 1)
+        else
+          recur(next, bcd2, index + 1)
 
       val chars: Array[Char] = recur(norm, 0L, 1)
       if sign then chars(0) = (if negative then minusSign else plusSign.vouch)
 
       Text(new String(chars))
-    else if double.isNaN then nan
-    else if double.isNegInfinity then s"$minusSign$infinity".tt else infinity
+    else if double.isNaN
+    then nan
+    else if double.isNegInfinity
+    then s"$minusSign$infinity".tt
+    else infinity

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -222,13 +222,12 @@ extension [textual: Textual](text: textual)
   def extract[value](start: Ordinal)(lambda: Scanner ?=> textual ~> value): Stream[value] =
 
     val input = textual.text(text)
-    if start.n0 < input.s.length then
+
+    if start.n0 >= input.s.length then Stream() else
       val scanner = Scanner(start.n0)
       lambda(using scanner).lift(text) match
         case Some(head) => head #:: extract(scanner.nextStart.or(0).z)(lambda)
         case _          => Stream()
-
-    else Stream()
 
   def seek(regex: Regex): Optional[textual] = regex.seek(textual.text(text)).let(text.segment(_))
   def seek(substring: Text): Optional[Ordinal] = textual.indexOf(text, substring)

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -107,15 +107,12 @@ object SourceCode:
         val start = scanner.offset max lastEnd
 
         val unparsed: Stream[Token] =
-          if lastEnd != start
-          then
+          if lastEnd == start then Stream() else
             text.segment(lastEnd.z thru start.u)
             . cut(t"\n")
             . to(Stream)
             . flatMap(untab(_).filter(_.length > 0))
             . init
-
-          else Stream()
 
         scanner.nextToken()
         val end = scanner.lastOffset max start

--- a/lib/honeycomb/src/core/honeycomb.Rev.scala
+++ b/lib/honeycomb/src/core/honeycomb.Rev.scala
@@ -39,5 +39,6 @@ object Rev:
   given showable: Rev is Showable = _.toString.show.lower
 
 enum Rev:
-  case Alternate, Stylesheet, Start, Next, Prev, Contents, Index, Glossary, Copyright, Chapter,
-      Section, Subsection, Appendix, Help, Bookmark
+  case
+    Alternate, Stylesheet, Start, Next, Prev, Contents, Index, Glossary, Copyright, Chapter,
+    Section, Subsection, Appendix, Help, Bookmark

--- a/lib/honeycomb/src/test/honeycomb_test.scala
+++ b/lib/honeycomb/src/test/honeycomb_test.scala
@@ -406,7 +406,7 @@ object Tests extends Suite(m"Honeycombd Tests"):
           catch case exception: Exception => exception
 
         . assert:
-          case ParseError(_, Html.Position(line, _), _) => line == 2.u
+            case ParseError(_, Html.Position(line, _), _) => line == 2.u
 
       suite(m"Attribute parsing depth"):
         test(m"multiple attributes preserved"):
@@ -449,6 +449,7 @@ object Tests extends Suite(m"Honeycombd Tests"):
         test(m"duplicate attribute"):
           try t"""<img alt="a" alt="b">""".read[Html of "img"]
           catch case exception: Exception => exception
+
         . assert:
             case ParseError(_, _, Html.Issue.DuplicateAttribute(name)) => name == t"alt"
 

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -117,7 +117,8 @@ object Subcompiler:
                   error.point >= start && error.point <= end
 
                 . match
-                    case None                    => recompile(tail, done, source)
+                    case None =>
+                      recompile(tail, done, source)
 
                     case Some(region@(from, to)) =>
                       if done.contains(region) then recompile(tail, done, source) else

--- a/lib/vacuous/src/core/vacuous.internal.scala
+++ b/lib/vacuous/src/core/vacuous.internal.scala
@@ -58,11 +58,13 @@ object internal:
 
     concrete[typeRef]
 
-    if TypeRepr.of[typeRef] <:< TypeRepr.of[union]
-    then
+    if TypeRepr.of[typeRef] <:< TypeRepr.of[union] then
       halt
         ( 4,
-          m"type ${TypeRepr.of[typeRef].show} cannot be proven distinct from ${TypeRepr.of[union].show}" )
+          m"""
+            type ${TypeRepr.of[typeRef].show} cannot be proven distinct from
+            ${TypeRepr.of[union].show}
+          """ )
     else '{Distinct[typeRef, union]()}
 
   def mandatable[typeRef: Type]: Macro[typeRef is Mandatable] =


### PR DESCRIPTION
Whitespace and line-break adjustments across 32 files, mostly splitting `else if … then` and `then BODY else BODY` constructs onto their own lines per R33's cascade rules and dropping a few unused imports surfaced by the warning sweep. Stacked on #938 because the loosened R33 chain attribution there is what makes the remaining warnings precise enough to act on; this PR pays them off.

No user-visible behaviour changes.