### PR TITLE
Fulminate: backtick-delimited nesting in m"" interpolator

### DIFF
--- a/lib/fulminate/src/core/fulminate.internal.scala
+++ b/lib/fulminate/src/core/fulminate.internal.scala
@@ -34,10 +34,12 @@ package fulminate
 
 import language.experimental.into
 
+import scala.compiletime.*
 import scala.quoted.*
 
 import anticipation.*
 import gigantism.*
+import proscenium.*
 
 object internal:
   opaque type Diagnostics = Boolean
@@ -50,6 +52,121 @@ object internal:
 
   def realm(context: Expr[StringContext]): Macro[Realm] =
     val name: String = context.valueOrAbort.parts.head
-    if !name.matches("[a-z]+")
-    then halt(3, m"the realm code should contain only lowercase letters")(using summon, Realm("fu"))
+    if !name.matches("[a-z]+") then
+      val msg = Message(List("the realm code should contain only lowercase letters".tt))
+      halt(3, msg)(using summon, Realm("fu"))
     else '{Realm(${Expr(name)}.tt)}
+
+  transparent inline def mSubMessages[param](inline subs: param): List[Message] =
+    inline subs.asMatchable match
+      case tuple: Tuple =>
+        Message[tuple.type](tuple, Nil)
+
+      case other =>
+        import unsafeExceptions.canThrowAny
+        List(infer[(? >: other.type) is Communicable].message(other))
+
+  def mMacro[param: Type](context: Expr[StringContext], subs: Expr[param]): Macro[Message] =
+    import quotes.reflect.*
+
+    val parts: List[String] = context.valueOrAbort.parts.toList
+
+    class Frame:
+      var textsAccum: List[String] = Nil
+      var messagesAccum: List[Expr[Message]] = Nil
+      val buffer: StringBuilder = StringBuilder()
+
+    var stack: List[Frame] = List(Frame())
+
+    def topFrame: Frame = stack.head
+
+    def finalizeBuffer(): Unit =
+      topFrame.textsAccum = topFrame.textsAccum :+ topFrame.buffer.toString
+      topFrame.buffer.setLength(0)
+
+    def buildMessageExpr(frame: Frame): Expr[Message] =
+      val textsExpr: Expr[List[Text]] =
+        Expr.ofList(frame.textsAccum.map { s => '{ ${Expr(s)}.tt } })
+      val messagesExpr: Expr[List[Message]] = Expr.ofList(frame.messagesAccum)
+      '{ Message($textsExpr, $messagesExpr) }
+
+    def openFrame(): Unit =
+      finalizeBuffer()
+      stack = Frame() :: stack
+
+    def closeFrame(): Unit =
+      finalizeBuffer()
+      val closed = topFrame
+      stack = stack.tail
+      topFrame.messagesAccum = topFrame.messagesAccum :+ buildMessageExpr(closed)
+
+    def appendSub(idx: Int, subListRef: Expr[List[Message]]): Unit =
+      finalizeBuffer()
+      topFrame.messagesAccum =
+        topFrame.messagesAccum :+ '{ $subListRef(${Expr(idx)}) }
+
+    def parseUnicode(part: String, cur: Int): Char =
+      if cur + 4 > part.length
+      then report.errorAndAbort("the unicode escape is incomplete")
+      else
+        try Integer.parseInt(part.substring(cur, cur + 4), 16).toChar
+        catch case _: NumberFormatException =>
+          report.errorAndAbort(s"invalid unicode escape: \\u${part.substring(cur, cur + 4)}")
+
+    def walkPart(part: String): Unit =
+      var cur = 0
+      var esc = false
+      while cur < part.length do
+        val ch = part.charAt(cur)
+        if ch == '`' && !esc then
+          if cur + 1 < part.length && part.charAt(cur + 1) == '`' then
+            topFrame.buffer.append('`')
+            cur += 2
+          else
+            if stack.size == 1 then openFrame() else closeFrame()
+            cur += 1
+        else if ch == '\\' && !esc then
+          esc = true
+          cur += 1
+        else if esc then
+          val decoded: Char = ch match
+            case 'n'  => '\n'
+            case 'r'  => '\r'
+            case 'f'  => '\f'
+            case 'b'  => '\b'
+            case 't'  => '\t'
+            case 'e'  => '\u001B'
+            case '\\' => '\\'
+            case '"'  => '"'
+            case '\'' => '\''
+            case 'u'  =>
+              val codePoint = parseUnicode(part, cur + 1)
+              cur += 4
+              codePoint
+            case other =>
+              report.errorAndAbort(s"the character $other should not be escaped")
+          topFrame.buffer.append(decoded)
+          esc = false
+          cur += 1
+        else
+          topFrame.buffer.append(ch)
+          cur += 1
+      if esc then
+        report.errorAndAbort("the final character of an m\"\" part cannot be an escape")
+
+    val subListRef: Expr[List[Message]] => Expr[Message] = { subListExpr =>
+      parts.iterator.zipWithIndex.foreach: (part, idx) =>
+        walkPart(part)
+        if idx < parts.size - 1 then appendSub(idx, subListExpr)
+
+      if stack.size != 1 then
+        report.errorAndAbort("the m\"\" interpolator has an unmatched backtick")
+
+      finalizeBuffer()
+      buildMessageExpr(topFrame)
+    }
+
+    '{
+      val subList: List[Message] = mSubMessages[param]($subs)
+      ${ subListRef('subList) }
+    }

--- a/lib/fulminate/src/core/fulminate_core.scala
+++ b/lib/fulminate/src/core/fulminate_core.scala
@@ -172,20 +172,7 @@ def warn(d: Int, reason: Clarification, message: Message, position: Matchable)
 
 extension (inline context: StringContext)
   transparent inline def m[param](inline subs: param = Zero): Message =
-    inline subs.asMatchable match
-      case tuple: Tuple =>
-        import unsafeExceptions.canThrowAny
-
-        Message
-          ( context.parts.map(_.tt).map(TextEscapes.escape(_)).to(List),
-            Message[tuple.type](tuple, Nil) )
-
-      case other =>
-        import unsafeExceptions.canThrowAny
-
-        Message
-          ( context.parts.map(_.tt).map(TextEscapes.escape(_)).to(List),
-            List(infer[(? >: other.type) is Communicable].message(other)) )
+    ${ fulminate.internal.mMacro[param]('context, 'subs) }
 
 extension (inline context: StringContext)
   inline def realm(): Realm = ${fulminate.internal.realm('context)}

--- a/lib/fulminate/src/test/fulminate_test.scala
+++ b/lib/fulminate/src/test/fulminate_test.scala
@@ -33,6 +33,7 @@
 package fulminate
 
 import gossamer.*
+import larceny.*
 import probably.*
 
 object Tests extends Suite(m"Fulminate Tests"):
@@ -118,3 +119,93 @@ object Tests extends Suite(m"Fulminate Tests"):
       test(m"backslash escape decodes to a literal backslash"):
         m"a\\b".texts.head
       . assert(_ == t"a\\b")
+
+    suite(m"Backtick-delimited nesting"):
+      test(m"single backtick pair produces an embedded message"):
+        val msg = m"hello `world` today"
+        (msg.texts, msg.messages.size, msg.messages.head.texts)
+      . assert(_ == ((List(t"hello ", t" today"), 1, List(t"world"))))
+
+      test(m"backticks render as nested italics in colorText"):
+        m"hello `world` today".colorText
+      . assert(_ == t"hello [3mworld[0m today")
+
+      test(m"backticks at start of string"):
+        m"`x` y".messages.head.texts
+      . assert(_ == List(t"x"))
+
+      test(m"backticks at end of string"):
+        m"y `x`".messages.head.texts
+      . assert(_ == List(t"x"))
+
+      test(m"substitution inside backtick region attaches to inner message"):
+        val name = t"y"
+        val msg = m"`x $name`"
+        (msg.texts, msg.messages.size, msg.messages.head.texts, msg.messages.head.messages.size)
+      . assert(_ == ((List(t"", t""), 1, List(t"x ", t""), 1)))
+
+      test(m"backticks across part boundaries"):
+        val n = 1
+        val msg = m"a `b $n c` d"
+        (msg.texts, msg.messages.head.texts, msg.messages.head.messages.size)
+      . assert(_ == ((List(t"a ", t" d"), List(t"b ", t" c"), 1)))
+
+      test(m"two adjacent backtick pairs produce two inner messages"):
+        m"`a` `b`".messages.size
+      . assert(_ == 2)
+
+      test(m"two adjacent backtick pairs preserve content"):
+        m"`a` `b`".messages.map(_.texts.head)
+      . assert(_ == List(t"a", t"b"))
+
+      test(m"depth 2 via substitution into a backtick region"):
+        val inner = m"b"
+        val msg = m"`a $inner c`"
+        msg.messages.head.messages.head.texts
+      . assert(_ == List(t"b"))
+
+      test(m"depth 2 renders with bold-italic ANSI in colorText"):
+        val inner = m"b"
+        m"`a $inner c`".colorText.s.contains("[3m[1mb[0m")
+      . assert(_ == true)
+
+      test(m"double backticks emit a literal backtick"):
+        m"a `` b".text
+      . assert(_ == t"a ` b")
+
+      test(m"double backticks alone produce a single literal backtick"):
+        m"``".text
+      . assert(_ == t"`")
+
+      test(m"double backticks inside a backtick region"):
+        val msg = m"`x `` y`"
+        msg.messages.head.texts.head
+      . assert(_ == t"x ` y")
+
+      test(m"three backticks: escape pair plus opener"):
+        val msg = m"```x`"
+        (msg.texts, msg.messages.head.texts)
+      . assert(_ == ((List(t"`", t""), List(t"x"))))
+
+      test(m"unclosed backtick is a compile error"):
+        demilitarize:
+          m"hello `world"
+        . map(_.message)
+      . assert(_.exists(_.contains("unmatched backtick")))
+
+      test(m"stray closing backtick is a compile error"):
+        demilitarize:
+          m"hello` world"
+        . map(_.message)
+      . assert(_.exists(_.contains("unmatched backtick")))
+
+      test(m"unclosed nested backtick is a compile error"):
+        demilitarize:
+          m"`a `b` c"
+        . map(_.message)
+      . assert(_.exists(_.contains("unmatched backtick")))
+
+      test(m"well-formed backticks compile without error"):
+        demilitarize:
+          m"hello `world`"
+      . assert(_.isEmpty)

--- a/lib/fulminate/src/test/fulminate_test.scala
+++ b/lib/fulminate/src/test/fulminate_test.scala
@@ -37,6 +37,84 @@ import probably.*
 
 object Tests extends Suite(m"Fulminate Tests"):
   def run(): Unit =
-    test(m"Whitespace in strings embedded into text should be quoted"):
-      m"This (${t" "}) should be quoted".text
-    . assert(_ == t"This (“ ”) should be quoted")
+    suite(m"Existing behaviour"):
+      test(m"Whitespace in strings embedded into text should be quoted"):
+        m"This (${t" "}) should be quoted".text
+      . assert(_ == t"This (“ ”) should be quoted")
+
+      test(m"Static text renders unchanged"):
+        m"hello".text
+      . assert(_ == t"hello")
+
+      test(m"Single substitution"):
+        val name = t"world"
+        m"hello $name".text
+      . assert(_ == t"hello world")
+
+      test(m"Multiple substitutions render in order"):
+        val a = t"foo"
+        val b = t"bar"
+        m"a=$a, b=$b".text
+      . assert(_ == t"a=foo, b=bar")
+
+      test(m"Substitution at start"):
+        val x = t"start"
+        m"${x}-end".text
+      . assert(_ == t"start-end")
+
+      test(m"Static text has texts.size 1"):
+        m"hello".texts.size
+      . assert(_ == 1)
+
+      test(m"Static text has messages.size 0"):
+        m"hello".messages.size
+      . assert(_ == 0)
+
+      test(m"Two substitutions yield 3 text segments and 2 messages"):
+        val msg = m"a ${1} b ${2} c"
+        (msg.texts.size, msg.messages.size)
+      . assert(_ == ((3, 2)))
+
+      test(m"Append concatenates texts at the boundary"):
+        (m"hello " + m"world").text
+      . assert(_ == t"hello world")
+
+      test(m"Append yields one continuous text segment when boundary merges"):
+        (m"hello " + m"world").texts.size
+      . assert(_ == 1)
+
+      test(m"Embedded message renders italics at depth 1 in colorText"):
+        val inner = m"world"
+        val outer = m"hello $inner end"
+        outer.colorText
+      . assert(_ == t"hello [3mworld[0m end")
+
+      test(m"Doubly-embedded message renders bold-italics at depth 2 in colorText"):
+        val deepest = m"deep"
+        val mid = m"mid $deepest mid"
+        val outer = m"start $mid end"
+        outer.colorText.s.contains("[3m[1mdeep[0m")
+      . assert(_ == true)
+
+      test(m"Int substitution renders as decimal"):
+        val n: Int = 42
+        m"value=$n".text
+      . assert(_ == t"value=42")
+
+      test(m"Char substitution renders as the character"):
+        val c: Char = 'X'
+        m"char=$c".text
+      . assert(_ == t"char=X")
+
+      test(m"segments interleaves texts and messages"):
+        val name = t"foo"
+        m"a $name b".segments.size
+      . assert(_ == 3)
+
+      test(m"newline escape decodes to a literal newline"):
+        m"line1\nline2".texts.head.s.indexOf('\n')
+      . assert(_ == 5)
+
+      test(m"backslash escape decodes to a literal backslash"):
+        m"a\\b".texts.head
+      . assert(_ == t"a\\b")

--- a/lib/kaleidoscope/src/core/kaleidoscope.RegexError.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.RegexError.scala
@@ -61,7 +61,7 @@ object RegexError:
         m"the pattern was invalid"
 
       case UnclosedEscape =>
-        m"nothing followed the escape character `\`"
+        m"nothing followed the escape character `\\`"
 
       case EmptyCharClass =>
         m"the character class is empty"


### PR DESCRIPTION
The \`m\"\"\` interpolator gains literal-syntax nesting: paired backticks delimit a region of the message that becomes an embedded \`Message\` rendered at one greater depth (italics → bold-italics in \`colorText\`), two adjacent backticks within a part are the literal-backtick escape, and an unmatched backtick is now a compile error rather than a runtime one.

\`\`\`scala
// Before: only achievable by introducing a separate Message via substitution.
val name = t\"alice\"
m\"could not find user \`\${name}\`\".colorText
// renders \"alice\" in italics

m\"the escape character \`\`\` (literal backtick) is reserved\".text
// → \"the escape character \` (literal backtick) is reserved\"

m\"hello \`world\".text
// → compile error: the m\"\" interpolator has an unmatched backtick
\`\`\`

Internally, \`m\"\"\` moves from a transparent-inline \`Message\` constructor to a quoted macro (\`fulminate.internal.mMacro\`), which walks each \`StringContext\` part character-by-character to decode escapes and balance backticks. The escape decoder is duplicated inline rather than reusing \`TextEscapes.escape\` because the latter's checked exception (\`EscapeError\`) is itself defined via \`m\"\"\`, which would create a macro-compilation cycle.

The kaleidoscope module's \`RegexError\` previously contained \`m\"… escape character \\\\\\\`\"\` — the prior \`\\\\\\\`\` form was a runtime error under the old implementation (\`TextEscapes.escape\` threw on it) and is updated here to the new escape syntax.