### PR TITLE
Rename Ethereal daemon process via self-reinvoked wrapper

### DIFF
--- a/lib/ethereal/src/runner/src/launch.rs
+++ b/lib/ethereal/src/runner/src/launch.rs
@@ -28,7 +28,12 @@ pub fn launch(
         }
     };
 
-    let mut command = Command::new(&java);
+    // Re-invoke ourselves in wrapper mode so the daemon process appears under
+    // the client's name (the launcher binary is this runner with the JAR
+    // appended). The wrapper exec's java synchronously and forwards signals.
+    let executable = std::env::current_exe().unwrap_or_else(|_| script.to_path_buf());
+    let mut command = Command::new(&executable);
+    command.arg(crate::WRAP_SENTINEL).arg(&java);
     for argument in build_java_arguments(script, name, config) { command.arg(argument); }
     command.arg("-jar").arg(script);
     command.stdin(Stdio::null());

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -15,6 +15,7 @@ mod signals;
 mod tty;
 mod uds;
 mod update;
+mod wrapper;
 
 use protocol::ClientInfo;
 use uds::UnixStream;
@@ -22,8 +23,18 @@ use uds::UnixStream;
 const FORWARD_BUFFER_SIZE: usize = 4096;
 const TERMINATION_POLL: Duration = Duration::from_millis(50);
 const STARTUP_FAILURE_EXIT_CODE: i32 = 2;
+pub const WRAP_SENTINEL: &str = "{wrap-java}";
 
 fn main() {
+    // The runner re-invokes itself with this sentinel as argv[1] when launching
+    // the daemon, so the JVM runs as a child of a process whose name matches the
+    // client (since this binary IS the renamed launcher). Dispatch before any
+    // other parsing — the wrapper has its own minimal argv contract.
+    let raw: Vec<String> = env::args().collect();
+    if raw.get(1).is_some_and(|arg| arg == WRAP_SENTINEL) {
+        wrapper::run(&raw[2..]);
+    }
+
     let (script, args, download) = parse_arguments();
     let name = script.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_default();
     let build_config = config::read_config();

--- a/lib/ethereal/src/runner/src/wrapper.rs
+++ b/lib/ethereal/src/runner/src/wrapper.rs
@@ -1,0 +1,62 @@
+use std::process::Command;
+use std::sync::atomic::{AtomicI32, Ordering};
+
+// The wrapper mode: spawn java synchronously, forwarding TERM/INT/HUP to it.
+// The runner re-invokes itself in this mode so the daemon process appears in
+// `ps` under the client's name (since the launcher binary IS this runner with
+// the JAR appended), making `killall <client>` target only this daemon.
+//
+// `args[0]` is the resolved java path; `args[1..]` are the java args.
+
+#[cfg(unix)]
+static CHILD_PID: AtomicI32 = AtomicI32::new(0);
+
+#[cfg(unix)]
+pub fn run(args: &[String]) -> ! {
+    if args.is_empty() { std::process::exit(1); }
+    let java = &args[0];
+    let java_args = &args[1..];
+
+    let mut child = match Command::new(java).args(java_args).spawn() {
+        Ok(child) => child,
+        Err(_)    => std::process::exit(1),
+    };
+    CHILD_PID.store(child.id() as i32, Ordering::SeqCst);
+
+    install_handlers();
+
+    // SIGKILL on the wrapper bypasses these handlers and orphans java; this
+    // is an accepted limitation. SIGTERM via `killall` is the supported path.
+    let status = child.wait().ok();
+    let code = status.and_then(|status| status.code()).unwrap_or(1);
+    std::process::exit(code);
+}
+
+#[cfg(unix)]
+fn install_handlers() {
+    let signals = [libc::SIGTERM, libc::SIGINT, libc::SIGHUP];
+    unsafe {
+        for signal in signals {
+            libc::signal(signal, forward as *const () as libc::sighandler_t);
+        }
+    }
+}
+
+#[cfg(unix)]
+extern "C" fn forward(signal: libc::c_int) {
+    let pid = CHILD_PID.load(Ordering::SeqCst);
+    if pid > 0 { unsafe { libc::kill(pid, signal); } }
+}
+
+#[cfg(windows)]
+pub fn run(args: &[String]) -> ! {
+    if args.is_empty() { std::process::exit(1); }
+    let java = &args[0];
+    let java_args = &args[1..];
+    let mut child = match Command::new(java).args(java_args).spawn() {
+        Ok(child) => child,
+        Err(_)    => std::process::exit(1),
+    };
+    let status = child.wait().ok();
+    std::process::exit(status.and_then(|status| status.code()).unwrap_or(1));
+}

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -464,6 +464,29 @@ object Tests extends Suite(m"Ethereal Tests"):
 
           . assert(_ == t"piped input")
 
+        suite(m"Process renaming"):
+          // The JVM is still named `java`; the killable process is its parent
+          // wrapper, which the runner re-invoked under the client name.
+          test(m"daemon JVM's parent process is reported under the client name"):
+            sh"$tool".exec[Unit]()
+            val jvmPid = sh"$tool '{admin}' pid".exec[Text]().trim
+            val parent = sh"ps -p $jvmPid -o ppid=".exec[Text]().trim
+            sh"ps -p $parent -o comm=".exec[Text]().trim.cut(t"/").last
+
+          . assert(_ == t"abcde")
+
+          test(m"killall on the client name terminates the daemon"):
+            sh"$tool".exec[Unit]()
+            val jvmPid = sh"$tool '{admin}' pid".exec[Text]().trim.decode[Pid]
+            sh"killall abcde".exec[Exit]()
+            val deadline = jl.System.currentTimeMillis + 3000
+            while safely(Process(jvmPid).alive).or(false)
+              && jl.System.currentTimeMillis < deadline
+            do snooze(0.05*Second)
+            safely(Process(jvmPid).alive).or(false)
+
+          . assert(_ == false)
+
     val upgradeStateDir: Path on Linux =
       Xdg.runtimeDir[Path on Linux].or(Xdg.stateHome[Path on Linux]) / t"upgrd"
 


### PR DESCRIPTION
The Ethereal runner now spawns its daemon by re-invoking itself in a wrapper mode, so the JVM runs as a child of a process whose name matches the client (e.g. `abcde`); this means `killall abcde` targets that one daemon instead of every `java` process on the box.

When you build a tool with Ethereal (say `abcde`), the daemon JVM is now supervised by a parent process that also shows up under the client's name in `ps`, `htop`, `pgrep`, and so on. Killing the daemon is now ergonomic:

```sh
killall abcde       # SIGTERM: forwarded to the JVM, both die
pgrep abcde         # finds the wrapper
ps -o comm= -p $(cat ~/.local/state/abcde/pid)    # still "java"
ps -o comm= -p $(ps -o ppid= -p $(cat ~/.local/state/abcde/pid))    # "abcde"
```

`killall -9 abcde` cannot be intercepted and will orphan the JVM — use a regular `killall` (or `kill -TERM`) when you want a clean shutdown. The change is transparent to anything using Ethereal — no API changes, no new configuration.