### PR TITLE
Audit and patch soundness re-exports

### DIFF
--- a/lib/abacist/src/core/soundness_abacist_core.scala
+++ b/lib/abacist/src/core/soundness_abacist_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export abacist.{Quanta, quanta, UnitsNames}
+export abacist.{Quanta, quanta, TimeMinutes, TimeSeconds, UnitsNames}

--- a/lib/adversaria/src/core/soundness_adversaria_core.scala
+++ b/lib/adversaria/src/core/soundness_adversaria_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export adversaria.Annotated
+export adversaria.{Annotated, Dereferenceable}

--- a/lib/ambience/src/core/soundness_ambience_core.scala
+++ b/lib/ambience/src/core/soundness_ambience_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export
   ambience
-  . { Environment, EnvironmentError, HomeDirectory, homeDirectory, HomeDirectoryError, Property,
-      PropertyError, System, TemporaryDirectory, temporaryDirectory, Variable, variables,
-      WorkingDirectory, workingDirectory, WorkingDirectoryError, Xdg }
+  . { Architecture, Environment, EnvironmentError, HomeDirectory, homeDirectory, HomeDirectoryError,
+      Property, PropertyError, Protovariable, System, TemporaryDirectory, temporaryDirectory,
+      Variable, variables, WorkingDirectory, workingDirectory, WorkingDirectoryError, Xdg }
 
 package systems:
   export ambience.systems.{empty, java}

--- a/lib/anamnesis/src/core/soundness_anamnesis_core.scala
+++ b/lib/anamnesis/src/core/soundness_anamnesis_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export anamnesis.{Database, DataError, Entity, every, Listable, Referenceable}

--- a/lib/anthology/src/bundle/soundness_anthology_bundle.scala
+++ b/lib/anthology/src/bundle/soundness_anthology_bundle.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export anthology.{Bundler}

--- a/lib/anthology/src/kotlin/soundness_anthology_kotlin.scala
+++ b/lib/anthology/src/kotlin/soundness_anthology_kotlin.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anthology.Kotlinc
+export anthology.{Kotlinc, KotlinVersions}

--- a/lib/anticipation/src/codec/soundness_anticipation_codec.scala
+++ b/lib/anticipation/src/codec/soundness_anticipation_codec.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anticipation.{bytestream, Data, Encodable}
+export anticipation.{bytestream, Data, Encodable, Schema}

--- a/lib/anticipation/src/html/soundness_anticipation_html.scala
+++ b/lib/anticipation/src/html/soundness_anticipation_html.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anticipation.{GenericHtmlAttribute2, Sgml}
+export anticipation.{GenericHtmlAttribute2, HtmlContent, Sgml}

--- a/lib/anticipation/src/path/soundness_anticipation_path.scala
+++ b/lib/anticipation/src/path/soundness_anticipation_path.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anticipation.Paths
+export anticipation.{Nominable, Paths}

--- a/lib/austronesian/src/core/soundness_austronesian_core.scala
+++ b/lib/austronesian/src/core/soundness_austronesian_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export austronesian.{PojoError, Restorable}

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -34,14 +34,14 @@ package soundness
 
 export
   aviation
-  . { am, Anniversary, Apr, Aug, Base24, Base60, Calendar, Chronology, Clock, Clockface, Date,
-      DateNumerics, DateSeparation, Day, days, Dec, Duration, Endianness, Feb, Fri, Hebdomad,
-      Holiday, Holidays, Horology, hours, Instant, Jan, Jul, Jun, LeapSeconds, Mar, May, Meridiem,
-      minutes, Moment, Mon, Month, Months, months, Monthstamp, Nov, now, Oct, Period, pm,
-      RomanCalendar, Sat, seconds, Sep, StandardTime, Sun, Thu, TimeError, TimeEvent, TimeFormat,
-      TimeNumerics, TimeSeparation, Timespan, TimeSpecificity, Timestamp, TimestampError, Timezone,
-      TimezoneError, today, Tue, tz, Tzdb, TzdbError, Wed, Weekday, Weekdays, weeks, WorkingDays,
-      Year, Years, years }
+  . { am, Anniversary, Apr, Aug, Base24, base24Extractable, Base60, base60Extractable, Calendar,
+      Chronology, Clock, Clockface, Date, DateNumerics, DateSeparation, Day, days, Dec, Duration,
+      Endianness, Feb, Fri, Hebdomad, Holiday, Holidays, Horology, hours, Instant, Iso8601, Jan,
+      Jul, Jun, LeapSeconds, Mar, May, Meridiem, minutes, Moment, Mon, Month, Months, months,
+      Monthstamp, Nov, now, Oct, Period, pm, Rfc1123, RomanCalendar, Sat, seconds, Sep,
+      StandardTime, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics, TimeSeparation,
+      Timespan, TimeSpecificity, Timestamp, TimestampError, Timezone, TimezoneError, today, Tue, tz,
+      Tzdb, TzdbError, Wed, Weekday, Weekdays, weeks, WorkingDays, Year, Years, years }
 
 package calendars:
   export aviation.calendars.{gregorian, julian}

--- a/lib/baroque/src/core/soundness_baroque_core.scala
+++ b/lib/baroque/src/core/soundness_baroque_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export baroque.{Complex, i}

--- a/lib/bitumen/src/core/soundness_bitumen_core.scala
+++ b/lib/bitumen/src/core/soundness_bitumen_core.scala
@@ -32,6 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  bitumen
-  . { Tar, TarEntry, TarError, TarRef, TypeFlag, UnixGroup, UnixMode, UnixUser }
+export bitumen.{Pax, Tar, TarEntry, TarError, TarRef, TypeFlag, UnixGroup, UnixMode, UnixUser}

--- a/lib/burdock/src/core/soundness_burdock_core.scala
+++ b/lib/burdock/src/core/soundness_burdock_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export burdock.{Bootstrapper}

--- a/lib/cacophony/src/core/cacophony.Configuration.scala
+++ b/lib/cacophony/src/core/cacophony.Configuration.scala
@@ -39,5 +39,5 @@ case class Configuration
   ( channels:      Int,
     sampleRate:    Optional[Quantity[Seconds[-1]]],
     bitsPerSample: Int,
-    encoding:      Encoding,
+    encoding:      Sonation,
     bigEndian:     Boolean )

--- a/lib/cacophony/src/core/cacophony.Feed.scala
+++ b/lib/cacophony/src/core/cacophony.Feed.scala
@@ -69,8 +69,8 @@ case class Feed(private[cacophony] val mixerInfo: jss.Mixer.Info):
           val f = f0.nn
 
           val encoding =
-            if f.getEncoding == jss.AudioFormat.Encoding.PCM_UNSIGNED then Encoding.PcmUnsigned
-            else Encoding.PcmSigned
+            if f.getEncoding == jss.AudioFormat.Encoding.PCM_UNSIGNED then Sonation.PcmUnsigned
+            else Sonation.PcmSigned
 
           val rate: Optional[Quantity[Seconds[-1]]] =
             if f.getSampleRate < 0 then Unset else f.getSampleRate.toDouble*Hertz

--- a/lib/cacophony/src/core/cacophony.Outlet.scala
+++ b/lib/cacophony/src/core/cacophony.Outlet.scala
@@ -66,8 +66,8 @@ case class Outlet(private[cacophony] val mixerInfo: jss.Mixer.Info):
           val f = f0.nn
 
           val encoding =
-            if f.getEncoding == jss.AudioFormat.Encoding.PCM_UNSIGNED then Encoding.PcmUnsigned
-            else Encoding.PcmSigned
+            if f.getEncoding == jss.AudioFormat.Encoding.PCM_UNSIGNED then Sonation.PcmUnsigned
+            else Sonation.PcmSigned
 
           val rate: Optional[Quantity[Seconds[-1]]] =
             if f.getSampleRate < 0 then Unset else f.getSampleRate.toDouble*Hertz

--- a/lib/cacophony/src/core/cacophony.Sonation.scala
+++ b/lib/cacophony/src/core/cacophony.Sonation.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package cacophony
 
-enum Encoding:
+enum Sonation:
   case PcmSigned, PcmUnsigned

--- a/lib/cacophony/src/core/soundness_cacophony_core.scala
+++ b/lib/cacophony/src/core/soundness_cacophony_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export cacophony
 . { Audio, Audible, AudioError, Wave, Aiff, Aifc, Au, Snd, ChannelLayout, Monaural, Stereo,
-    Surround, Encoding, Configuration, Feed, FeedError, Recording, Outlet, OutletError,
+    Surround, Sonation, Configuration, Feed, FeedError, Recording, Outlet, OutletError,
     Playback }

--- a/lib/caduceus/src/core/soundness_caduceus_core.scala
+++ b/lib/caduceus/src/core/soundness_caduceus_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export caduceus.{Courier, CourierError, Email, Envelope, send, Sendable, Sender}
+export caduceus.{Attachable, Courier, CourierError, Email, Envelope, send, Sendable, Sender}

--- a/lib/caduceus/src/resend/soundness_caduceus_resend.scala
+++ b/lib/caduceus/src/resend/soundness_caduceus_resend.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package soundness
 
+export caduceus.{Resend}
+
 package couriers:
   export caduceus.couriers.resend

--- a/lib/capricious/src/core/soundness_capricious_core.scala
+++ b/lib/capricious/src/core/soundness_capricious_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   capricious
   . { arbitrary, Distribution, Gamma, Gaussian, PolarGaussian, Random, random, Randomizable,
-      Randomization, Seed, stochastic, UniformDistribution }
+      Randomization, RandomSize, Seed, stochastic, toss, UniformDistribution }
 
 package randomization:
   export capricious.randomization.{secureSeeded, secureUnseeded, seeded, stronglySecure, unseeded}

--- a/lib/cellulose/src/core/cellulose.Bcodl.scala
+++ b/lib/cellulose/src/core/cellulose.Bcodl.scala
@@ -78,7 +78,7 @@ object Bcodl:
         schema match
           case Field(_) =>
             val key = readText(reader)
-            CodlNode(Atom(key, IArray(), Layout.empty, CodlSchema.Free))
+            CodlNode(Atom(key, IArray(), Formation.empty, CodlSchema.Free))
 
           case schema =>
             val subschema = readNumber(reader) match
@@ -90,7 +90,7 @@ object Bcodl:
 
             val children = IArray.from(recur(subschema(1)))
 
-            CodlNode(Atom(key, children, Layout.empty, subschema(1)))
+            CodlNode(Atom(key, children, Formation.empty, subschema(1)))
 
     CodlDoc(IArray.from(recur(schema)), schema, 0)
 

--- a/lib/cellulose/src/core/cellulose.CodlDoc.scala
+++ b/lib/cellulose/src/core/cellulose.CodlDoc.scala
@@ -80,7 +80,7 @@ extends Indexed:
       false
 
   override def hashCode: Int = children.toSeq.hashCode ^ schema.hashCode ^ margin.hashCode
-  def layout: Layout = Layout.empty
+  def layout: Formation = Formation.empty
   def paramIndex: Map[Text, Int] = Map()
   def materialize(using Topic is Decodable in Codl): Topic raises CodlError = as[Topic]
 

--- a/lib/cellulose/src/core/cellulose.CodlNode.scala
+++ b/lib/cellulose/src/core/cellulose.CodlNode.scala
@@ -77,7 +77,7 @@ case class CodlNode(data: Optional[Atom] = Unset, extra: Optional[Extra] = Unset
   def nil: Boolean = unsafely(data.absent || data.assume.children.nil)
   def blank: Boolean = data.absent && extra.absent
   def schema: Optional[CodlSchema] = data.let(_.schema)
-  def layout: Optional[Layout] = data.let(_.layout)
+  def layout: Optional[Formation] = data.let(_.layout)
   def id: Optional[Text] = data.let(_.id)
   def uniqueId: Optional[Text] = data.let(_.uniqueId)
   def children: IArray[CodlNode] = data.let(_.children).or(IArray[CodlNode]())
@@ -107,7 +107,7 @@ case class CodlNode(data: Optional[Atom] = Unset, extra: Optional[Extra] = Unset
 
   def uncommented: CodlNode =
     val data2 = data.let: data =>
-      Atom(data.key, children = data.children.map(_.uncommented), Layout.empty, data.schema)
+      Atom(data.key, children = data.children.map(_.uncommented), Formation.empty, data.schema)
 
     CodlNode(data2, Unset)
 

--- a/lib/cellulose/src/core/cellulose.Data.scala
+++ b/lib/cellulose/src/core/cellulose.Data.scala
@@ -50,7 +50,7 @@ object Atom:
 
   given inspectable: Atom is Inspectable = data => t"Atom(${data.key}, ${data.children.length})"
 
-case class Atom(key: Text, children: IArray[CodlNode] = IArray(), layout: Layout = Layout.empty,
+case class Atom(key: Text, children: IArray[CodlNode] = IArray(), layout: Formation = Formation.empty,
                     schema: CodlSchema = CodlSchema.Free)
 extends Indexed:
 

--- a/lib/cellulose/src/core/cellulose.Formation.scala
+++ b/lib/cellulose/src/core/cellulose.Formation.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package cellulose
 
-object Layout:
-  final val empty = Layout(0, false, 0)
+object Formation:
+  final val empty = Formation(0, false, 0)
 
-case class Layout(params: Int, multiline: Boolean, col: Int)
+case class Formation(params: Int, multiline: Boolean, col: Int)

--- a/lib/cellulose/src/core/cellulose.Indexed.scala
+++ b/lib/cellulose/src/core/cellulose.Indexed.scala
@@ -51,7 +51,7 @@ trait Codllike:
 trait Indexed extends Codllike, Dynamic:
   def children: IArray[CodlNode]
   def schema: CodlSchema
-  def layout: Layout
+  def layout: Formation
   def paramIndex: Map[Text, Int]
 
   lazy val index: Map[Text, List[Int]] =
@@ -89,7 +89,7 @@ trait Indexed extends Codllike, Dynamic:
 
       case Some(index) =>
         List.range(index, layout.params).map: index =>
-          Atom(key, IArray(unsafely(children(index))), Layout.empty, CodlSchema.Free)
+          Atom(key, IArray(unsafely(children(index))), Formation.empty, CodlSchema.Free)
 
   def selectDynamic(key: String)(using erased DynamicCodlEnabler): List[Atom] raises CodlError =
     index(key.show).map(children(_).data).collect:

--- a/lib/cellulose/src/core/cellulose.internal.scala
+++ b/lib/cellulose/src/core/cellulose.internal.scala
@@ -276,7 +276,7 @@ object internal extends protointernal:
                 Atom
                   ( key,
                     IArray.from(children.reverse),
-                    Layout(params, multiline, col - margin),
+                    Formation(params, multiline, col - margin),
                     schema )
 
               val node = CodlNode(data, extra2)

--- a/lib/cellulose/src/core/cellulose.protointernal.scala
+++ b/lib/cellulose/src/core/cellulose.protointernal.scala
@@ -64,7 +64,7 @@ trait protointernal:
                   val schematic = infer[field is CodlSchematic]
 
                   contextual.encoded(field).list.map: value =>
-                    CodlNode(Atom(label2, value.children, Layout.empty, schemata(index).schema))
+                    CodlNode(Atom(label2, value.children, Formation.empty, schemata(index).schema))
 
                   . filter(!_.nil)
 

--- a/lib/cellulose/src/core/soundness_cellulose_core.scala
+++ b/lib/cellulose/src/core/soundness_cellulose_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export
   cellulose
-  . { Arity, Atom, Bcodl, BcodlError, Character, Codl, codl, CodlDoc, CodlError, CodlNode,
-      CodlPrinter, CodlRelabelling, CodlSchema, CodlToken, DynamicCodlEnabler, Extra, Indexed,
-      Formation, PositionReader, Printer }
+  . { Arity, Atom, Bcodl, BcodlError, Character, Codl, codl, CodlDoc, CodlError, Codllike, CodlNode,
+      CodlPrinter, CodlRelabelling, CodlSchema, CodlSchematic, CodlSchematicDerivation, CodlToken,
+      DynamicCodlEnabler, Extra, Formation, Indexed, PositionReader, Printer, Struct }
 
 package codlPrinters:
   export cellulose.codlPrinters.standard

--- a/lib/cellulose/src/core/soundness_cellulose_core.scala
+++ b/lib/cellulose/src/core/soundness_cellulose_core.scala
@@ -36,7 +36,7 @@ export
   cellulose
   . { Arity, Atom, Bcodl, BcodlError, Character, Codl, codl, CodlDoc, CodlError, CodlNode,
       CodlPrinter, CodlRelabelling, CodlSchema, CodlToken, DynamicCodlEnabler, Extra, Indexed,
-      Layout, PositionReader, Printer }
+      Formation, PositionReader, Printer }
 
 package codlPrinters:
   export cellulose.codlPrinters.standard

--- a/lib/cellulose/src/test/cellulose_test.scala
+++ b/lib/cellulose/src/test/cellulose_test.scala
@@ -797,7 +797,7 @@ object Tests extends Suite(m"Cellulose tests (Part 1)"):
 
       test(m"Access parameters by name"):
         childWithTwoParams(One, One).parse(t"root\n  child first second").root().child().beta()
-      . assert(_ == Atom(t"second", IArray(), schema = Field(One), layout = Layout(0, false, 14)))
+      . assert(_ == Atom(t"second", IArray(), schema = Field(One), layout = Formation(0, false, 14)))
 
       test(m"Surplus parameters"):
         capture(childWithTwoParams(One, One).parse(t"root\n  child one two three"))
@@ -979,16 +979,16 @@ object Tests extends Suite(m"Cellulose tests (Part 1)"):
       . assert(_ == t"root\n  child\n")
 
       test(m"Serialize a node and a child with params layout"):
-        CodlDoc(CodlNode(Atom(t"root", IArray(CodlNode(Atom(t"child"))), Layout(1, false, 0))))
+        CodlDoc(CodlNode(Atom(t"root", IArray(CodlNode(Atom(t"child"))), Formation(1, false, 0))))
         . write
       . assert(_ == t"root child\n")
 
       test(m"Serialize a node and a child with block param"):
-        CodlDoc(CodlNode(Atom(t"root", IArray(CodlNode(Atom(t"child")), CodlNode(Atom(t"Hello World"))), Layout(2, true, 0)))).write
+        CodlDoc(CodlNode(Atom(t"root", IArray(CodlNode(Atom(t"child")), CodlNode(Atom(t"Hello World"))), Formation(2, true, 0)))).write
       . assert(_ == t"root child\n    Hello World\n")
 
       test(m"Serialize a node and a child with multiline block param"):
-        CodlDoc(CodlNode(Atom(t"root", IArray(CodlNode(Atom(t"child")), CodlNode(Atom(t"Hello\nWorld"))), Layout(2, true, 0)))).write
+        CodlDoc(CodlNode(Atom(t"root", IArray(CodlNode(Atom(t"child")), CodlNode(Atom(t"Hello\nWorld"))), Formation(2, true, 0)))).write
       . assert(_ == t"root child\n    Hello\n    World\n")
 
       test(m"Serialize a node and a child with comment"):

--- a/lib/chiaroscuro/src/core/soundness_chiaroscuro_core.scala
+++ b/lib/chiaroscuro/src/core/soundness_chiaroscuro_core.scala
@@ -34,4 +34,5 @@ package soundness
 
 export
   chiaroscuro
-  . { contrast, Contrastable, Decomposable, decompose, Decomposition, Juxtaposition, Similarity }
+  . { contrast, Contrastable, Decomposable, Decomposable2, Decomposable3, decompose, Decomposition,
+      Juxtaposition, Similarity }

--- a/lib/coaxial/src/core/soundness_coaxial_core.scala
+++ b/lib/coaxial/src/core/soundness_coaxial_core.scala
@@ -34,5 +34,6 @@ package soundness
 
 export
   coaxial
-  . { Bindable, BindError, Connection, Control, DomainSocket, exchange, Ingressive, listen, Packet,
-      Routable, Serviceable, SocketService, Transmissible, transmit, UdpResponse }
+  . { Bindable, BindError, Connection, Control, DomainSocket, DomainSocketEndpoint, exchange,
+      Ingressive, listen, Packet, Routable, Serviceable, SocketService, Transmissible, transmit,
+      UdpResponse }

--- a/lib/contextual/src/core/soundness_contextual_core.scala
+++ b/lib/contextual/src/core/soundness_contextual_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   contextual
-  . { Embeddable, Extrapolable, Insertion, Interpolable, InterpolationError, Interpolator,
-      Substitution, Verifier }
+  . { Embeddable, Extrapolable, Extrapolation, Insertion, Interpolable, Interpolation,
+      interpolation, InterpolationError, Interpolator, Substitution, Verifier }

--- a/lib/contingency/src/core/soundness_contingency_core.scala
+++ b/lib/contingency/src/core/soundness_contingency_core.scala
@@ -34,9 +34,12 @@ package soundness
 
 export
   contingency
-  . { abort, abortive, accrue, Attempt, attempt, capture, certify, dare, Errors, ExpectationError,
-      Fatal, Foci, focus, lest, mitigate, Pointer, raise, raises, recover, Recoverable, safely,
-      survive, Tactic, throwErrors, track, Unchecked, unsafely, validate, Validation }
+  . { abort, abortive, Accrue, accrue, AccrueTactic, amalgamate, AmalgamateTactic, Attempt, attempt,
+      AttemptTactic, Break, capture, certify, dare, EitherTactic, Errors, EscapeTactic,
+      ExpectationError, Fatal, Foci, focus, HaltTactic, lest, Mitigable, mitigate, Mitigation,
+      OptionalTactic, Pointer, raise, raises, recover, Recoverable, Recovery, safely, survive,
+      Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, TrackTactic, Unchecked,
+      unsafely, Validate, validate, Validation }
 
 package strategies:
   export

--- a/lib/decorum/src/plugin/soundness_decorum_plugin.scala
+++ b/lib/decorum/src/plugin/soundness_decorum_plugin.scala
@@ -32,4 +32,6 @@
                                                                                                   */
 package soundness
 
-export decorum.{Checker, Kind, Phase, Token, Tokenizer, Violation}
+export
+  decorum
+  . { Checker, DecorumPhase, DecorumPlugin, Kind, Phase, ScanAll, Token, Tokenizer, Violation }

--- a/lib/distillate/src/core/soundness_distillate_core.scala
+++ b/lib/distillate/src/core/soundness_distillate_core.scala
@@ -34,4 +34,5 @@ package soundness
 
 export
   distillate
-  . { As, as, Decodable, decode, Enumerable, Extractable, Identifiable, Irrefutable, NumberError }
+  . { As, as, Decodable, Decodable2, decode, Enumerable, Extractable, Identifiable, Irrefutable,
+      NumberError, Requirable }

--- a/lib/diuretic/src/core/soundness_diuretic_core.scala
+++ b/lib/diuretic/src/core/soundness_diuretic_core.scala
@@ -32,6 +32,11 @@
                                                                                                   */
 package soundness
 
+export
+  diuretic
+  . { JavaIoFile, JavaLongDuration, JavaLongInstant, JavaNetUrl, JavaNioPath, JavaTimeInstant,
+      JavaUtilDate }
+
 package interfaces:
   package instants:
     export anticipation.interfaces.instants.{javaLong, javaTimeInstant, javaUtilDate}

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -35,4 +35,4 @@ package soundness
 export
   enigmatic
   . { Aes, Cipher, CryptoError, Divulgence, Dsa, Encryption, Hmac, hmac, Pem, PemError, PemLabel,
-      PrivateKey, Rsa, Signature, Signing, Symmetric, SymmetricKey }
+      PrivateKey, PublicKey, Rsa, Signature, Signing, Symmetric, SymmetricKey }

--- a/lib/escapade/src/core/soundness_escapade_core.scala
+++ b/lib/escapade/src/core/soundness_escapade_core.scala
@@ -34,8 +34,9 @@ package soundness
 
 export
   escapade
-  . { Ansi, Bg, Bold, CharSpan, Colorable, Conceal, csi, e, Escape, escapes, Fg, internal, Italic,
-      Reverse, Ribbon, Strike, Stylize, Teletype, teletype, Teletypeable, TextStyle, Underline }
+  . { Ansi, Ansi2, Bg, Bold, CharSpan, Colorable, Conceal, csi, e, Escape, escapes, Fg, internal,
+      Italic, Reverse, Ribbon, Strike, Stylize, Teletype, teletype, Teletypeable, TeletypeBuilder,
+      TextStyle, Underline }
 
 package displayableTypes:
   export escapade.displayableTypes.message

--- a/lib/escritoire/src/core/soundness_escritoire_core.scala
+++ b/lib/escritoire/src/core/soundness_escritoire_core.scala
@@ -36,7 +36,7 @@ export
   escritoire
   . { Attenuation, BoxDrawing, BoxLine, Column, ColumnAlignment, Columnar, Grid, LineCharset,
       Scaffold, TableCell, TableError, TableRelabelling, TableRow, TableSection, TableStyle,
-      Tabulable, Tabulation, tabulation, TextAlignment, VerticalAlignment }
+      Tabulable, Tabular, Tabulation, tabulation, TextAlignment, VerticalAlignment }
 
 package columnAttenuation:
   export escritoire.columnAttenuation.{fail, ignore}

--- a/lib/ethereal/src/core/soundness_ethereal_core.scala
+++ b/lib/ethereal/src/core/soundness_ethereal_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   ethereal
-  . { cli, Client, DaemonEvent, DaemonLogEvent, DaemonService, Installer, LazyEnvironment, service,
-      Stdin }
+  . { cli, Client, DaemonEvent, DaemonLogEvent, daemonLogEvent, DaemonService, Installer,
+      LazyEnvironment, service, Stdin }
 
 package workingDirectories:
   export ambience.workingDirectories.daemonClient

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -67,7 +67,7 @@ object Tests extends Suite(m"Ethereal Tests"):
     snooze(0.2*Second)
     sh"rm -f $stateDir/pid $stateDir/build $stateDir/socket $stateDir/fail".exec[Unit]()
 
-    val launcher = Sandbox("abcde").dispatch:
+    val launcher = Enclave("abcde").dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -177,7 +177,7 @@ object Tests extends Suite(m"Ethereal Tests"):
     sh"rm -f $stateDir/fail".exec[Unit]()
 
     launcher.sandbox:
-        val tool = summon[Sandbox.Tool].path
+        val tool = summon[Enclave.Tool].path
         suite(m"Basic invocation"):
           test(m"first invocation prints expected output"):
             sh"$tool echo hello".exec[Text]()
@@ -494,7 +494,7 @@ object Tests extends Suite(m"Ethereal Tests"):
     safely(sh"pkill upgrd".exec[Exit]())
     snooze(0.2*Second)
 
-    val launcherV1 = Sandbox("upgrd", buildId = 1).dispatch:
+    val launcherV1 = Enclave("upgrd", buildId = 1).dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -512,7 +512,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
     val toolV1 = launcherV1.path
 
-    val launcherV2 = Sandbox("upgrd", buildId = 2).dispatch:
+    val launcherV2 = Enclave("upgrd", buildId = 2).dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -563,7 +563,7 @@ object Tests extends Suite(m"Ethereal Tests"):
     safely(sh"pkill selfu".exec[Exit]())
     snooze(0.1*Second)
 
-    val selfuV1 = Sandbox("selfu", buildId = 1).dispatch:
+    val selfuV1 = Enclave("selfu", buildId = 1).dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -579,7 +579,7 @@ object Tests extends Suite(m"Ethereal Tests"):
           t"finished"
         }
 
-    val selfuV2 = Sandbox("selfu", buildId = 2).dispatch:
+    val selfuV2 = Enclave("selfu", buildId = 2).dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -614,7 +614,7 @@ object Tests extends Suite(m"Ethereal Tests"):
     val brokenStateDir: Path on Linux =
       Xdg.runtimeDir[Path on Linux].or(Xdg.stateHome[Path on Linux]) / t"brokn"
 
-    val brokenExe: Path on Linux = Sandbox("brokn").dispatch:
+    val brokenExe: Path on Linux = Enclave("brokn").dispatch:
       ' {
           import executives.completions
           import interpreters.posix

--- a/lib/eucalyptus/src/ansi/soundness_eucalyptus_ansi.scala
+++ b/lib/eucalyptus/src/ansi/soundness_eucalyptus_ansi.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package soundness
 
+export eucalyptus.{LogPalette}
+
 package logFormats:
   export eucalyptus.logFormats.ansiStandard

--- a/lib/eucalyptus/src/gcp/soundness_eucalyptus_gcp.scala
+++ b/lib/eucalyptus/src/gcp/soundness_eucalyptus_gcp.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package soundness
 
+export eucalyptus.{EucalyptusGcp}
+
 package logFormats:
   export eucalyptus.logFormats.googleCloudPlatform

--- a/lib/exegesis/src/core/soundness_exegesis_core.scala
+++ b/lib/exegesis/src/core/soundness_exegesis_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export exegesis.{Lsp}

--- a/lib/exoskeleton/src/args/soundness_exoskeleton_args.scala
+++ b/lib/exoskeleton/src/args/soundness_exoskeleton_args.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   exoskeleton
-  . { Argument, arguments, Cli, Commandline, Discoverable, Flag, Interpretable, Interpreter, Shell,
-      Subcommand, Suggestible, Suggestion, Switch }
+  . { Argument, arguments, Cli, Commandline, Discoverable, Flag, Interpretable, Interpreter, Login,
+      Shell, Subcommand, Suggestible, Suggestion, Switch }
 
 package interpreters:
   export exoskeleton.interpreters.{posix, posixClustering, simple}

--- a/lib/exoskeleton/src/completions/soundness_exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/soundness_exoskeleton_completions.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export exoskeleton.{Completion, Completions, execute, Execution, explain, Pathname}
+export exoskeleton.{CliEvent, Completion, Completions, execute, Execution, explain, Pathname}
 
 package executives:
   export exoskeleton.executives.completions

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -59,7 +59,7 @@ import logging.silent
 import workingDirectories.java
 
 
-object Sandbox:
+object Enclave:
   case class Tool(path: Path on Linux, pid: Pid):
     def command: Text = path.name
 
@@ -85,9 +85,9 @@ object Sandbox:
             safely(item.delete())
 
 
-case class Sandbox(name: Text, buildId: Optional[Int] = Unset)(using Classloader, Environment)
+case class Enclave(name: Text, buildId: Optional[Int] = Unset)(using Classloader, Environment)
 extends Rig:
-  type Result[output] = Sandbox.Launcher
+  type Result[output] = Enclave.Launcher
   type Form = Text
   type Target = Path on Linux
   type Transport = Json
@@ -112,7 +112,7 @@ extends Rig:
 
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux])
-  :   Sandbox.Launcher =
+  :   Enclave.Launcher =
 
     stage.remote: input =>
       unsafely:
@@ -121,4 +121,4 @@ extends Rig:
 
       t"""[""]"""
 
-    Sandbox.Launcher(stage.target)
+    Enclave.Launcher(stage.target)

--- a/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
@@ -68,7 +68,7 @@ object Tmux:
       while init === screenshot().screen && count < 60 do delay(0.01*Second) yet (count += 1)
 
 
-  def completions(text: Text)(using tool: Sandbox.Tool, tmux: Tmux)(using Monitor, WorkingDirectory)
+  def completions(text: Text)(using tool: Enclave.Tool, tmux: Tmux)(using Monitor, WorkingDirectory)
   :   Text raises TmuxError =
 
     tmux.shell match
@@ -100,7 +100,7 @@ object Tmux:
 
 
   def progress(text: Text, decorate: Char => Text = char => t"^")
-    ( using tool: Sandbox.Tool, tmux: Tmux )
+    ( using tool: Enclave.Tool, tmux: Tmux )
     ( using Monitor, WorkingDirectory )
   :   Text raises TmuxError =
 

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -39,7 +39,7 @@ import interfaces.paths.pathOnLinux
 
 extension (shell: Shell)
   def tmux(width: Int = 80, height: Int = 24)[result](action: (tmux: Tmux) ?=> result)
-    ( using WorkingDirectory, Sandbox.Tool, Monitor, TemporaryDirectory )
+    ( using WorkingDirectory, Enclave.Tool, Monitor, TemporaryDirectory )
   :   result raises TmuxError logs ExecEvent =
 
     mitigate:
@@ -49,7 +49,7 @@ extension (shell: Shell)
     . within:
         given tmux: Tmux = Tmux(Uuid().show, summon[WorkingDirectory], width, height, shell)
 
-        val path = summon[Sandbox.Tool].path.parent.vouch.encode
+        val path = summon[Enclave.Tool].path.parent.vouch.encode
 
         val shellInvocation = shell match
           case Shell.Zsh        => t"zsh -l"
@@ -57,7 +57,7 @@ extension (shell: Shell)
           case Shell.Bash       => t"bash -l"
 
           case Shell.Powershell =>
-            val cmd = summon[Sandbox.Tool].command
+            val cmd = summon[Enclave.Tool].command
 
             val psScript =
               s"""function global:prompt { '> ' }

--- a/lib/exoskeleton/src/rig/soundness_exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/soundness_exoskeleton_rig.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export exoskeleton.{Sandbox, Tmux, tmux}
+export exoskeleton.{Enclave, Tmux, tmux}

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -52,7 +52,7 @@ import Shell.*
 object Tests extends Suite(m"Exoskeleton Tests"):
   def run(): Unit =
     val foo: Text = "hello"
-    Sandbox(t"abcd").dispatch:
+    Enclave(t"abcd").dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -183,7 +183,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
         . assert(_ == t"--one   -- the first one\n--two   -- the second one")
 
         test(m"Test capture 1"):
-          summon[Sandbox.Tool].completions:
+          summon[Enclave.Tool].completions:
             Zsh.tmux()(Tmux.completions(t"distribution ubuntu "))
 
         . assert()
@@ -322,7 +322,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
         . assert(_ == t"distribution gentoo -fblue ^")
 
         suite(m"Admin commands"):
-          val tool = summon[Sandbox.Tool].path
+          val tool = summon[Enclave.Tool].path
 
           test(m"'{admin}' pid returns a positive integer"):
             sh"$tool '{admin}' pid".exec[Text]().trim.decode[Int]
@@ -357,7 +357,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           .assert(_ == Exit.Fail(1))
 
         suite(m"Raw completion invocation"):
-          val tool = summon[Sandbox.Tool].path
+          val tool = summon[Enclave.Tool].path
 
           test(m"completion with bash args returns alpha"):
             sh"$tool '{completions}' bash 1 0 /dev/null -- abcd ''".exec[Text]()

--- a/lib/fulminate/src/core/soundness_fulminate_core.scala
+++ b/lib/fulminate/src/core/soundness_fulminate_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   fulminate
-  . { Communicable, communicate, Diagnostics, Error, EscapeError, halt, m, Message, Panic, panic,
-      realm, TextEscapes, warn }
+  . { Clarification, Communicable, communicate, Diagnostics, Error, EscapeError, halt, m, Message,
+      Panic, panic, realm, TextEscapes, UncheckedError, warn }
 
 package errorDiagnostics:
   export fulminate.errorDiagnostics.{empty, stackTraces}

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -36,11 +36,12 @@ export
   galilei
   . { accessed, BlockDevice, C, CharDevice, children, CopyAttributes, copyInto, copyTo, Creatable,
       create, created, CreateNonexistent, CreateNonexistentParents, D, delete, DeleteRecursively,
-      DereferenceSymlinks, descendants, Directory, Entry, entry, executable, exists, Fifo, File,
-      FilesystemAttribute, Handle, hardLinks, hardLinkTo, hidden, IoError, IoEvent, javaFile,
-      javaPath, modified, MoveAtomically, moveInto, moveTo, open, Openable, OverwritePreexisting,
-      readable, ReadAccess, size, Socket, Symlink, symlinkInto, symlinkTo, touch, TraversalOrder,
-      UnixEntry, Volume, volume, WindowsEntry, wipe, writable, WriteAccess, WriteSynchronously }
+      DereferenceSymlinks, descendants, Directory, Entry, entry, executable, exists, Explorable,
+      Fifo, File, FilesystemAttribute, Handle, hardLinks, hardLinkTo, hidden, IoError, IoEvent,
+      javaFile, javaPath, modified, MoveAtomically, moveInto, moveTo, open, Openable,
+      OverwritePreexisting, readable, ReadAccess, size, Socket, Substantiable, Symlink, symlinkInto,
+      symlinkTo, touch, TraversalOrder, UnixEntry, Volume, volume, WindowsEntry, wipe, writable,
+      WriteAccess, WriteSynchronously }
 
 package filesystemOptions:
   export

--- a/lib/geodesy/src/core/soundness_geodesy_core.scala
+++ b/lib/geodesy/src/core/soundness_geodesy_core.scala
@@ -35,9 +35,9 @@ package soundness
 export
   geodesy
   . { Angle, ArcMinute, ArcSecond, CardinalWind, Compass, deg, Degree, Directional, East,
-      EastNortheast, EastSoutheast, Geolocation, HalfWind, IntercardinalWind, Locatable, Location,
-      North, Northeast, NorthNortheast, NorthNorthwest, Northwest, rad, South, Southeast,
-      SouthSoutheast, SouthSouthwest, Southwest, West, WestNorthwest, WestSouthwest }
+      EastNortheast, EastSoutheast, Geolocation, GeolocationError, HalfWind, IntercardinalWind,
+      Locatable, Location, North, Northeast, NorthNortheast, NorthNorthwest, Northwest, rad, South,
+      Southeast, SouthSoutheast, SouthSouthwest, Southwest, West, WestNorthwest, WestSouthwest }
 
 package compassBearings:
   export

--- a/lib/gigantism/src/core/soundness_gigantism_core.scala
+++ b/lib/gigantism/src/core/soundness_gigantism_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export gigantism.{Macro, Metaprogramming, metaprogramming}

--- a/lib/guillotine/src/core/soundness_guillotine_core.scala
+++ b/lib/guillotine/src/core/soundness_guillotine_core.scala
@@ -35,4 +35,4 @@ package soundness
 export
   guillotine
   . { Command, Computable, ExecError, ExecEvent, Executable, Intelligible, Job, Parameterizable,
-      Pid, PidError, Pipeline, Process, ProcessRef, sh, Stderr }
+      Pid, PidError, Pipeline, PosixCommands, Process, ProcessRef, Sh, sh, Stderr }

--- a/lib/hallucination/src/core/soundness_hallucination_core.scala
+++ b/lib/hallucination/src/core/soundness_hallucination_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export hallucination.{Bmp, Gif, Jpeg, Png, Raster, Rasterizable}
+export hallucination.{Bmp, Gif, Jpeg, Png, Raster, RasterError, Rasterizable}

--- a/lib/harlequin/src/ansi/soundness_harlequin_ansi.scala
+++ b/lib/harlequin/src/ansi/soundness_harlequin_ansi.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package soundness
 
+export harlequin.{ScalaSyntaxPalette}
+
 package syntaxHighlighting:
   export harlequin.syntaxHighlighting.{numbered, unnumbered}

--- a/lib/harlequin/src/md/soundness_harlequin_md.scala
+++ b/lib/harlequin/src/md/soundness_harlequin_md.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package soundness
 
+export harlequin.{CommonFormattable}
+
 package formattables:
   export punctuation.formattables.{java, scala}

--- a/lib/hellenism/src/core/soundness_hellenism_core.scala
+++ b/lib/hellenism/src/core/soundness_hellenism_core.scala
@@ -34,7 +34,8 @@ package soundness
 
 export
   hellenism
-  . { Classloader, Classpath, ClasspathEntry, ClasspathError, cp, LocalClasspath, OnlineClasspath }
+  . { Classloader, Classpath, ClasspathEntry, ClasspathError, cp, LocalClasspath, OnlineClasspath,
+      Resource }
 
 package classloaders:
   export hellenism.classloaders.{platform, scala, system, threadContext}

--- a/lib/honeycomb/src/core/soundness_honeycomb_core.scala
+++ b/lib/honeycomb/src/core/soundness_honeycomb_core.scala
@@ -34,9 +34,10 @@ package soundness
 
 export
   honeycomb
-  . { Attribute, Attributive, Autocomplete, Capture, Comment, Crossorigin, Doctype, DomId, Element,
-      Fragment, h, HDir, Html, html, HttpEquiv, Kind, Method, Node, Preload, Rel, Renderable, Rev,
-      Sandbox, Shape, Stylesheet, Tag, Target, TextNode, Wrap }
+  . { Attribute, Attributive, Autocomplete, Capture, Comment, Crossorigin, Doctype, Dom, DomId,
+      Element, Fragment, h, HDir, Honeycomb, Html, html, Html4Transitional, HttpEquiv, Kind, Method,
+      Node, Preload, Rel, Renderable, Rev, Sandbox, Shape, Stylesheet, Tag, Target, TextNode,
+      Unattributive, Whatwg, Wrap }
 
 package doms.html:
   export honeycomb.doms.html.whatwg

--- a/lib/hyperbole/src/core/soundness_hyperbole_core.scala
+++ b/lib/hyperbole/src/core/soundness_hyperbole_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export hyperbole.{Introspect, semantics, syntax, TastySymbol, TastyTree}
+export hyperbole.{Introspect, semantics, syntax, TastyPalette, TastySymbol, TastyTree}

--- a/lib/iridescence/src/core/iridescence.Brightness.scala
+++ b/lib/iridescence/src/core/iridescence.Brightness.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package iridescence
 
-enum Luminosity:
+enum Brightness:
   case Dark, Light

--- a/lib/iridescence/src/core/iridescence.Theme.scala
+++ b/lib/iridescence/src/core/iridescence.Theme.scala
@@ -36,7 +36,7 @@ import prepositional.*
 
 trait Theme:
   type Form <: Color: Perceptual in Srgb
-  def luminosity: Luminosity
+  def luminosity: Brightness
   def background: Color in Form
   def foreground: Color in Form
   def colors: List[Color in Form]

--- a/lib/iridescence/src/core/iridescence_core.scala
+++ b/lib/iridescence/src/core/iridescence_core.scala
@@ -41,18 +41,18 @@ extension (inline context: StringContext)
 
 private[iridescence] inline def unitary(d: Double): Double = d - d.toInt + (if d < 0 then 1 else 0)
 
-inline def dark(using luminosity: Luminosity): Boolean = luminosity == Luminosity.Dark
-inline def light(using luminosity: Luminosity): Boolean = luminosity != Luminosity.Dark
+inline def dark(using luminosity: Brightness): Boolean = luminosity == Brightness.Dark
+inline def light(using luminosity: Brightness): Boolean = luminosity != Brightness.Dark
 
 package themes:
-  given solarized: Luminosity => Theme = new Theme with Solarized:
-    val luminosity = summon[Luminosity]
+  given solarized: Brightness => Theme = new Theme with Solarized:
+    val luminosity = summon[Brightness]
     val background = if dark then base03 else base3
     val foreground = if dark then base3 else base03
 
 package luminosity:
-  given dark: Luminosity = Luminosity.Dark
-  given light: Luminosity = Luminosity.Light
+  given dark: Brightness = Brightness.Dark
+  given light: Brightness = Brightness.Light
 
 package colorimetry:
   given incandescentTungsten: Colorimetry = Colorimetry(109.850, 100, 35.585, 111.144, 100, 35.2)

--- a/lib/iridescence/src/core/soundness_iridescence_core.scala
+++ b/lib/iridescence/src/core/soundness_iridescence_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   iridescence
-  . { Cielab, Cmy, Cmyk, Color, Colorimetry, dark, Hsl, Hsv, light, Luminosity, Palette, Perceptual,
+  . { Brightness, Cielab, Cmy, Cmyk, Color, Colorimetry, dark, Hsl, Hsv, light, Palette, Perceptual,
       rgb, Rgb12, Rgb32, Solarized, Spectrum, Srgb, Theme, WebColors, Xyz }
 
 package colorimetry:

--- a/lib/iridescence/src/core/soundness_iridescence_core.scala
+++ b/lib/iridescence/src/core/soundness_iridescence_core.scala
@@ -35,7 +35,8 @@ package soundness
 export
   iridescence
   . { Brightness, Cielab, Cmy, Cmyk, Color, Colorimetry, dark, Hsl, Hsv, light, Palette, Perceptual,
-      rgb, Rgb12, Rgb32, Solarized, Spectrum, Srgb, Theme, WebColors, Xyz }
+      rgb, Rgb12, Rgb12Opaque, Rgb32, Rgb32Opaque, Solarized, Spectrum, Srgb, Theme, WebColors,
+      Xyz }
 
 package colorimetry:
   export

--- a/lib/jacinta/src/core/soundness_jacinta_core.scala
+++ b/lib/jacinta/src/core/soundness_jacinta_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   jacinta
-  . { dynamicJsonAccess, DynamicJsonEnabler, Json, json, JsonError, JsonPointer, JsonPrimitive,
-      JsonPrinter, Ndjson }
+  . { dynamicJsonAccess, DynamicJsonEnabler, Json, json, Json2, JsonError, JsonPointer,
+      JsonPrimitive, JsonPrinter, Ndjson, showable }
 
 package jsonPrinters:
   export jacinta.jsonPrinters.{indented, minimal}

--- a/lib/kaleidoscope/src/core/soundness_kaleidoscope_core.scala
+++ b/lib/kaleidoscope/src/core/soundness_kaleidoscope_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export kaleidoscope.{g, Glob, GlobToken, r, Regex, RegexError}
+export kaleidoscope.{g, Glob, GlobToken, r, Regex, RegexError, Scanner}

--- a/lib/larceny/src/plugin/soundness_larceny_plugin.scala
+++ b/lib/larceny/src/plugin/soundness_larceny_plugin.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export larceny.{CompileError, CompileErrorId, demilitarize, procrastinate}
+export
+  larceny
+  . { CompileError, CompileErrorId, demilitarize, LarcenyPlugin, LarcenyTransformer, procrastinate,
+      Subcompiler }

--- a/lib/legerdemain/src/core/soundness_legerdemain_core.scala
+++ b/lib/legerdemain/src/core/soundness_legerdemain_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   legerdemain
-  . { Checkbox, Combobox, Dropdown, edit, elicit, Elicitable, Field, Formulaic, Formulation,
-      Parametric, Query, QueryError, RadioGroup, Widget }
+  . { Checkbox, Combobox, Dropdown, edit, elicit, Elicitable, Elicitable2, Field, Formulaic,
+      Formulation, Parametric, Query, QueryError, RadioGroup, Widget }
 
 package formulations:
   export legerdemain.formulations.default

--- a/lib/mandible/src/core/soundness_mandible_core.scala
+++ b/lib/mandible/src/core/soundness_mandible_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export mandible.{Bytecode, Classfile, disassemble}
+export mandible.{Bytecode, BytecodePalette, Classfile, ClassfileError, disassemble}

--- a/lib/mercator/src/core/soundness_mercator_core.scala
+++ b/lib/mercator/src/core/soundness_mercator_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export mercator.{bind, Functor, Identity, map, Monad, sequence, traverse}
+export mercator.{bind, Cofunctor, Functor, Identity, map, Monad, sequence, traverse}

--- a/lib/monotonous/src/core/soundness_monotonous_core.scala
+++ b/lib/monotonous/src/core/soundness_monotonous_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   monotonous
-  . { Alphabet, Base32, Base64, Binary, Deserializable, deserialize, Hex, Octal, Quaternary,
-      Serializable, Serialization, SerializationError, serialize }
+  . { Alphabet, Base256, Base32, Base64, Binary, Deserializable, deserialize, Hex, Octal,
+      Quaternary, Serializable, Serialization, SerializationError, serialize }
 
 package alphabets:
   package binary:

--- a/lib/nomenclature/src/core/soundness_nomenclature_core.scala
+++ b/lib/nomenclature/src/core/soundness_nomenclature_core.scala
@@ -34,6 +34,6 @@ package soundness
 
 export
   nomenclature
-  . { Check, MustContain, MustEnd, MustMatch, MustNotContain, MustNotEnd, MustNotEqual,
-      MustNotMatch, MustNotStart, MustStart, n, Name, NameError, NameExtractor, Nominative,
-      Required, Rule }
+  . { Check, disintersect, MustContain, MustEnd, MustMatch, MustNotContain, MustNotEnd,
+      MustNotEqual, MustNotMatch, MustNotStart, MustStart, n, Name, NameError, NameExtractor,
+      Nominative, Required, Rule, staticCompanion }

--- a/lib/obligatory/src/core/soundness_obligatory_core.scala
+++ b/lib/obligatory/src/core/soundness_obligatory_core.scala
@@ -35,4 +35,4 @@ package soundness
 export
   obligatory
   . { Associable, CarriageReturn, ContentLength, CrLf, Framable, FrameError, frames, JsonRpc,
-      LengthPrefix, Linefeed, remote, rpc, RpcError, Sse, SseError, SseSource }
+      JsonRpcError, LengthPrefix, Linefeed, remote, rpc, RpcError, Sse, SseError, SseSource }

--- a/lib/panopticon/src/core/soundness_panopticon_core.scala
+++ b/lib/panopticon/src/core/soundness_panopticon_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export panopticon.{Composable, Each, Filter, Lens, lens, Optic}
+export panopticon.{Composable, Each, Filter, Lens, lens, Optic, Optical}

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -34,10 +34,11 @@ package soundness
 
 export
   parasite
-  . { async, AsyncError, cancel, Chain, Codicil, Daemon, daemon, delay, Destruction, Fulfillment,
-      GarbageCollection, Heap, hibernate, Hook, intercept, Interceptable, Monitor, monitor,
-      Observation, Os, Promise, relent, retry, Shutdown, sleep, snooze, supervise, Task, task,
-      Tenacity, Threading, Timeout, Transgression }
+  . { AdaptiveSupervisor, async, AsyncError, cancel, Chain, Codicil, Daemon, daemon, delay,
+      Destruction, Fault, Fulfillment, GarbageCollection, Heap, hibernate, Hook, intercept,
+      Interceptable, Monitor, monitor, Observation, Os, Perseverance, PlatformSupervisor, Promise,
+      relent, retry, RetryError, Shutdown, sleep, snooze, supervise, Supervisor, Task, task,
+      Tenacity, Threading, Timeout, Transgression, VirtualSupervisor, Worker }
 
 package threading:
   export parasite.threading.{adaptive, platform, virtual}

--- a/lib/phoenicia/src/core/soundness_phoenicia_core.scala
+++ b/lib/phoenicia/src/core/soundness_phoenicia_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export phoenicia.{Em, Ems, FontError, FontSize, Glyph, internal, TableTag, Ttf}
+export phoenicia.{Em, Ems, FontError, FontSize, Glyph, internal, OtfTag, TableTag, Ttf, TtfTag}

--- a/lib/plutocrat/src/core/soundness_plutocrat_core.scala
+++ b/lib/plutocrat/src/core/soundness_plutocrat_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export plutocrat.{Currency, CurrencyStyle, Money, Price}
+export plutocrat.{Currency, CurrencyStyle, IsinError, Luhn, Money, Price}
 
 package currencyStyles:
   export plutocrat.currencyStyles.{generic, local}

--- a/lib/prepositional/src/core/soundness_prepositional_core.scala
+++ b/lib/prepositional/src/core/soundness_prepositional_core.scala
@@ -35,4 +35,5 @@ package soundness
 export
   prepositional
   . { across, against, by, Contrastive, Domainal, Formal, from, in, Limited, of, on, onto, Operable,
-      Original, over, Planar, Resultant, Targetable, to, Topical, Transportive, Typeclass, under }
+      Original, over, Planar, Prepositional, Resultant, Targetable, to, Topical, Transportive,
+      Typeclass, under }

--- a/lib/probably/src/core/soundness_probably_core.scala
+++ b/lib/probably/src/core/soundness_probably_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export
   probably
-  . { Baseline, Benchmark, Inclusion, Verdict, Runner, Test, Harness, TestId, Report, Reporter,
-      Trial, Testable, Tolerance, Min, Mean, Max, Cadential, ===, !==, Temporal, Geometric, Arithmetic,
-      +/-, ±, test, suite, debug, Checkable, Ci, GithubActions }
+  . { !==, +/-, ===, Arithmetic, Autopsy, Baseline, Benchmark, Cadential, Checkable, Ci, debug,
+      Geometric, GithubActions, Harness, Inclusion, Max, Mean, Min, Report, Reporter, Runner, suite,
+      Temporal, Test, test, Testable, TestId, TestPalette, Tolerance, Trial, Verdict, ± }
 
 package harnesses:
   export probably.harnesses.threadLocal

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -61,7 +61,7 @@ extends Interactivity[TerminalEvent]:
   val rows0: Promise[Int] = Promise()
   val columns0: Promise[Int] = Promise()
 
-  var mode: Optional[Luminosity] = Unset
+  var mode: Optional[Brightness] = Unset
   var rows: Optional[Int] = Unset
   var columns: Optional[Int] = Unset
 
@@ -106,7 +106,7 @@ extends Interactivity[TerminalEvent]:
         events.put(resize)
 
       case bgColor@TerminalInfo.BgColor(red, green, blue) =>
-        mode = if dark(red, green, blue) then Luminosity.Dark else Luminosity.Light
+        mode = if dark(red, green, blue) then Brightness.Dark else Brightness.Light
         events.put(bgColor)
 
       case other =>

--- a/lib/profanity/src/core/soundness_profanity_core.scala
+++ b/lib/profanity/src/core/soundness_profanity_core.scala
@@ -34,10 +34,10 @@ package soundness
 
 export
   profanity
-  . { BracketedPasteMode, Console, DismissError, Interaction, interactive, Interactivity, Keyboard,
-      Keypress, LineEditor, LuminosityDetection, Question, SelectMenu, Signal, SignalResponse,
-      Terminal, TerminalError, TerminalEvent, TerminalFocusDetection, TerminalSizeDetection,
-      UnixSignal, WindowsSignal }
+  . { BracketedPasteMode, Console, CtrlChar, DismissError, Interaction, interactive, Interactivity,
+      Keyboard, Keypress, LineEditor, LuminosityDetection, Question, SelectMenu, Signal,
+      SignalResponse, stdio, Terminal, TerminalError, TerminalEvent, TerminalFocusDetection,
+      TerminalInfo, TerminalSizeDetection, UnixSignal, WindowsSignal }
 
 package keyboards:
   export profanity.keyboards.{numeric, raw, standard}

--- a/lib/quantitative/src/core/soundness_quantitative_core.scala
+++ b/lib/quantitative/src/core/soundness_quantitative_core.scala
@@ -35,11 +35,12 @@ package soundness
 export
   quantitative
   . { Amount, AmountOfSubstance, Amperes, Atto, Candelas, Celsius, Centi, Current, Deci, Deka,
-      Designation, Distance, Exa, Exbi, Fahrenheit, Femto, Gibi, Giga, Hecto, Kelvins, Kibi, Kilo,
-      Kilograms, Luminosity, Mass, Measure, Mebi, Mega, Metres, Metric, MetricUnit, Micro, Milli,
-      Moles, Nano, NoPrefix, Normalizable, Pebi, Peta, Pico, Principal, Quantifiable, Quantity,
-      Quecto, Quetta, Rankine, Redesignation, Ronna, Ronto, Seconds, Tebi, Temperature, Tera, Time,
-      Units, Yobi, Yocto, Yotta, Zebi, Zepto, Zetta }
+      Designation, Dimension, Distance, Distributive, Exa, Exbi, Fahrenheit, Femto, Gibi, Giga,
+      Heat, Hecto, Kelvins, Kibi, Kilo, Kilograms, Luminosity, Mass, Measure, Mebi, Mega, Metres,
+      Metric, MetricUnit, Micro, Milli, Moles, Nano, NoPrefix, Normalizable, Pebi, Peta, Pico,
+      Principal, Quantifiable, Quantity, Quecto, Quetta, Rankine, Ratio, Redesignation, Ronna,
+      Ronto, Seconds, Tebi, Temperature, TemperatureScale, Tera, Time, Units, Yobi, Yocto, Yotta,
+      Zebi, Zepto, Zetta }
 
 package temperatureScales:
   export quantitative.temperatureScales.{celsius, fahrenheit, kelvin, rankine}

--- a/lib/revolution/src/core/soundness_revolution_core.scala
+++ b/lib/revolution/src/core/soundness_revolution_core.scala
@@ -34,7 +34,8 @@ package soundness
 
 export
   revolution
-  . { DecodableManifest, EncodableManifest, Manifest, ManifestAttribute, ManifestEntry, Semver, v }
+  . { Compatibility, DecodableManifest, EncodableManifest, Manifest, ManifestAttribute,
+      ManifestEntry, Semver, SemverError, v }
 
 package manifestAttributes:
   export

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -35,9 +35,9 @@ package soundness
 export
   rudiments
   . { !!, &, all, also, annex, at, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,
-      DecimalConverter, Defaulting, Digit, each, establish, Exit, fuse, gib, give, has, immutable,
-      Indexable, indexBy, intercalate, javaInputStream, kib, longestTrain, Loop, loop, matchable,
-      mean, mib, mutable, next, occupied, ordinal, pipe, place, plus, prim, prior, product, repeat,
-      runs, runsBy, sec, segment, Segmentable, sift, snapshot, state, std, sumBy, tap, ter, that,
-      tib, to, total, tri, triple, tuple, twin, typed, unit, unwind, upsert, variance, waive, weave,
-      when, yet }
+      DecimalConverter, Defaulting, Defaulting2, Digit, each, establish, Exit, fixpoint, fuse, gib,
+      give, has, immutable, Indexable, indexBy, intercalate, javaInputStream, kib, longestTrain,
+      Loop, loop, matchable, mean, mib, mutable, next, occupied, ordinal, pipe, place, plus, prim,
+      prior, probe, product, reflectClass, repeat, runs, runsBy, sec, segment, Segmentable, sift,
+      snapshot, state, std, sumBy, tap, ter, that, tib, to, total, tri, triple, tuple, twin, typed,
+      typeName, unit, unwind, upsert, variance, waive, weave, when, yet }

--- a/lib/satirical/src/core/soundness_satirical_core.scala
+++ b/lib/satirical/src/core/soundness_satirical_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export satirical.{Export, Func, Ident, Interface, Package, Primitive, Use, Wit, World}

--- a/lib/scintillate/src/server/soundness_scintillate_server.scala
+++ b/lib/scintillate/src/server/soundness_scintillate_server.scala
@@ -35,7 +35,7 @@ package soundness
 export
   scintillate
   . { Acceptable, basicAuth, cookie, HttpConnection, HttpServer, HttpServerEvent, NoCache, NotFound,
-      Redirect, request, RequestServable, Responder, ServerError, Unfulfilled }
+      Redirect, request, RequestServable, Responder, ServerError, Unfulfilled, WebserverErrorPage }
 
 package httpServers:
   export scintillate.httpServers.{stdlib, stdlibPublic}

--- a/lib/scintillate/src/servlet/soundness_scintillate_servlet.scala
+++ b/lib/scintillate/src/servlet/soundness_scintillate_servlet.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export scintillate.{JavaServlet, JavaServletFn}
+export scintillate.{JavaServlet, JavaServletFn, servlet}

--- a/lib/serpentine/src/core/soundness_serpentine_core.scala
+++ b/lib/serpentine/src/core/soundness_serpentine_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   serpentine
-  . { %, ?, ^, Admissible, Ascent, Case, Dos, Drive, Filesystem, Linux, MacOs, Navigable, p, Path,
-      PathError, Posix, Radical, Relative, Root, Submissible, Windows }
+  . { %, ?, ^, Admissible, Ascent, Case, Compliant, Dos, Drive, Filesystem, Linux, Local, MacOs,
+      Navigable, p, Path, PathError, Posix, Radical, Relative, Root, Submissible, Windows }
 
 package interfaces.paths:
   export

--- a/lib/spectacular/src/core/soundness_spectacular_core.scala
+++ b/lib/spectacular/src/core/soundness_spectacular_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export spectacular.{Affirmation, inspect, Inspectable, show, Showable}
+export spectacular.{Affirmation, inspect, Inspectable, Inspectable2, show, Showable}
 
 package affirmations:
   export spectacular.affirmations.{oneZero, onOff, trueFalse, yesNo}

--- a/lib/superlunary/src/core/soundness_superlunary_core.scala
+++ b/lib/superlunary/src/core/soundness_superlunary_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export superlunary.{embeddings, References, Rig, Stage, Stageable}
+export superlunary.{embeddings, Executor2, References, RemoteError, Rig, Stage, Stageable}

--- a/lib/superlunary/src/jvm/soundness_superlunary_jvm.scala
+++ b/lib/superlunary/src/jvm/soundness_superlunary_jvm.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export superlunary.{Executor, Jvm}
+export superlunary.{Executor, Isolation, Jvm}

--- a/lib/symbolism/src/core/soundness_symbolism_core.scala
+++ b/lib/symbolism/src/core/soundness_symbolism_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   symbolism
-  . { +, -, /, /:, `*`, Addable, cbrt, Concatenable, Divisible, Multiplicable, Negatable, Rootable,
-      sqrt, Subtractable, Unital, zero, Zeroic }
+  . { +, -, /, /:, `*`, Addable, cbrt, Concatenable, Divisible, Multiplicable, Negatable, Quotient,
+      Rootable, sqrt, Subtractable, Unital, zero, Zeroic }

--- a/lib/synesthesia/src/core/soundness_synesthesia_core.scala
+++ b/lib/synesthesia/src/core/soundness_synesthesia_core.scala
@@ -33,31 +33,6 @@
 package soundness
 
 export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+  synesthesia
+  . { about, Agent, Discourse, Human, Mcp, McpClient, McpError, McpServer, McpSession,
+      McpSpecification, prompt, resource, title, tool, ui }

--- a/lib/telekinesis/src/core/soundness_telekinesis_core.scala
+++ b/lib/telekinesis/src/core/soundness_telekinesis_core.scala
@@ -34,9 +34,10 @@ package soundness
 
 export
   telekinesis
-  . { Auth, ConnectError, Context, Cookie, Directive, fetch, Fetchable, Http, HttpClient, HttpError,
-      HttpEvent, orchestrate, Parameter, Postable, query, Receivable, Servable, Session,
-      Submission, submit }
+  . { Acceptance, Auth, AuthError, ConnectError, Context, Cookie, Directive, fetch, Fetchable, Http,
+      HttpClient, HttpError, HttpEvent, HttpResponseError, Orchestrate, orchestrate, Parameter,
+      Postable, query, Receivable, Receivable2, Servable, Session, Submission, submit,
+      TransferEncoding }
 
 package queryParameters:
   export telekinesis.queryParameters.arbitrary

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -35,10 +35,11 @@ package soundness
 export
   turbulence
   . { Aggregable, chunked, cluster, compress, Compression, Compressor, decompress, deduplicate,
-      defer, discard, Document, Documentary, Eof, Err, gunzip, Gzip, gzip, In, inputStream, Io,
-      Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer, multiplexer,
-      Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool, Stdio, stream,
-      Streamable, StreamError, StreamOutputStream, strict, take, Tap, Writable, writeTo, Zlib }
+      defer, Deflate, discard, Document, Documentary, Eof, Err, gunzip, Gzip, gzip, In, inputStream,
+      Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
+      multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool,
+      Stdio, stream, Streamable, StreamError, StreamOutputStream, strict, take, Tap, Writable,
+      writeTo, Zlib }
 
 package stdios:
   export turbulence.stdios.{mute, system, virtualMachine}

--- a/lib/ulysses/src/core/soundness_ulysses_core.scala
+++ b/lib/ulysses/src/core/soundness_ulysses_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export ulysses.BloomFilter
+export ulysses.{Bibliography, BloomFilter, Palimpsest}

--- a/lib/umbrageous/src/plugin/soundness_umbrageous_plugin.scala
+++ b/lib/umbrageous/src/plugin/soundness_umbrageous_plugin.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export umbrageous.{Shader, ShaderPlugin}

--- a/lib/urticose/src/core/soundness_urticose_core.scala
+++ b/lib/urticose/src/core/soundness_urticose_core.scala
@@ -34,9 +34,10 @@ package soundness
 
 export
   urticose
-  . { Connectable, EmailAddress, EmailAddressError, Endpoint, Hostname, HostnameError, Internet,
-      internet, ip, IpAddressError, LocalPart, mac, MacAddressError, OfflineError, Online, online,
-      Port, PortError, serve, Service, tcp, TcpPort, udp, UdpPort, via }
+  . { Connectable, EmailAddress, EmailAddressError, Endpoint, Host, Hostname, HostnameError,
+      Internet, internet, ip, IpAddressError, Localhost, LocalPart, mac, MacAddressError,
+      OfflineError, Online, online, Port, PortError, Protocolic, serve, Service, tcp, TcpPort, udp,
+      UdpPort, via }
 
 package internetAccess:
   export urticose.internetAccess.{disabled, enabled}

--- a/lib/urticose/src/url/soundness_urticose_url.scala
+++ b/lib/urticose/src/url/soundness_urticose_url.scala
@@ -34,4 +34,5 @@ package soundness
 
 export
   urticose
-  . { Authority, email, host, HttpUrl, Origin, Scheme, Url, url, UrlError, UrlFragment, Www }
+  . { Authority, email, host, HttpUrl, Origin, Scheme, Url, url, UrlError, UrlFragment,
+      UrlInterpolator, UrlPalette, Www }

--- a/lib/vacuous/src/core/soundness_vacuous_core.scala
+++ b/lib/vacuous/src/core/soundness_vacuous_core.scala
@@ -34,6 +34,7 @@ package soundness
 
 export
   vacuous
-  . { absent, assume, compact, Concrete, Default, default, Distinct, Extractor, javaOptional, lay,
-      layGiven, let, letGiven, mask, only, option, Optional, optional, or, present, presume,
-      puncture, unless, Unsafe, Unset, UnsetError, vouch }
+  . { absent, assume, compact, Concrete, Default, default, Distinct, Extractor, invite,
+      javaOptional, lay, layGiven, let, letGiven, Mandatable, mask, only, optimizable, option,
+      Optional, optional, Optionality, or, present, presume, puncture, unless, Unsafe, Unset,
+      UnsetError, vouch }

--- a/lib/vexillology/src/core/soundness_vexillology_core.scala
+++ b/lib/vexillology/src/core/soundness_vexillology_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export vexillology.{Vexillology}

--- a/lib/vicarious/src/core/soundness_vicarious_core.scala
+++ b/lib/vicarious/src/core/soundness_vicarious_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export vicarious.{Catalog, Proxy}
+export vicarious.{Catalog, catalog, Proxy}

--- a/lib/wisteria/src/core/soundness_wisteria_core.scala
+++ b/lib/wisteria/src/core/soundness_wisteria_core.scala
@@ -36,7 +36,7 @@ export
   wisteria
   . { arithmetic, ContextRequirement, contextual, dereference, Derivable, Derivation, Discriminable,
       FieldIndex, index, label, ProductDerivable, ProductDerivation, ProductReflection, Reflection,
-      SumReflection, variant, VariantError, VariantIndex }
+      SumDerivation, SumReflection, variant, VariantError, VariantIndex }
 
 package derivationContext:
   export wisteria.derivationContext.{relaxed, required}

--- a/lib/xylophone/src/core/soundness_xylophone_core.scala
+++ b/lib/xylophone/src/core/soundness_xylophone_core.scala
@@ -32,32 +32,4 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
-
-package decimalFormatters:
-  export gossamer.decimalFormatters.java
-
-package enumIdentification:
-  export gossamer.enumIdentification.kebabCase
-  export gossamer.enumIdentification.pascalCase
-  export gossamer.enumIdentification.snakeCase
-  export gossamer.enumIdentification.camelCase
-
-package proximities:
-  export gossamer.proximities.jaroDistance
-  export gossamer.proximities.jaroWinklerDistance
-  export gossamer.proximities.prefixMatch
-  export gossamer.proximities.levenshteinDistance
-  export gossamer.proximities.normalizedLevenshteinDistance
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{insensitive, sensitive, smart}
+export xylophone.{Xml, XmlError, XmlSchema}

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Cursor, Format, ParseError}
+export zephyrine.{Addressable, Cursor, Emittable, Emitter, Format, Lineation, ParseError}


### PR DESCRIPTION
Brings the `soundness` aggregate package into closer alignment with what each module actually defines: it renames four types whose simple names collided across modules, and adds re-exports for ~85 module-package definitions that weren't previously surfaced in `soundness` (including new `soundness_*.scala` files for twelve modules that had none).

## Renames

| Before | After | Collided with |
| --- | --- | --- |
| `cacophony.Encoding` | `cacophony.Sonation` | `hieroglyph.Encoding` |
| `cellulose.Layout` | `cellulose.Formation` | `punctuation.Layout` |
| `iridescence.Luminosity` | `iridescence.Brightness` | `quantitative.Luminosity` (an SI dimension) |
| `exoskeleton.Sandbox` | `exoskeleton.Enclave` | `honeycomb.Sandbox` (the HTML iframe attribute) |

```scala
// before
val s: cacophony.Encoding     = cacophony.Encoding.PcmSigned
val l: cellulose.Layout       = cellulose.Layout.empty
val b: iridescence.Luminosity = iridescence.Luminosity.Dark
val box                       = exoskeleton.Sandbox(t"name")

// after
val s: cacophony.Sonation     = cacophony.Sonation.PcmSigned
val l: cellulose.Formation    = cellulose.Formation.empty
val b: iridescence.Brightness = iridescence.Brightness.Dark
val box                       = exoskeleton.Enclave(t"name")
```

## New `soundness` exports

New `soundness_*.scala` files added for: `anamnesis`, `anthology/bundle`, `austronesian`, `baroque`, `burdock`, `exegesis`, `gigantism`, `satirical`, `synesthesia`, `umbrageous`, `vexillology`, `xylophone`.

Existing `soundness_*.scala` files extended to surface previously-defined-but-not-exported names across ~70 other modules — for example `fulminate.Clarification` and `fulminate.UncheckedError`, `parasite.Supervisor` and friends, `contingency.Tactic` variants, the `diuretic.Java*` interface types, and so on.

The following names are deliberately **not** added because they would create new collisions; they're left for a follow-up:

`Cursor`, `decimalizer`, `Field`, `JsonPointerError`, `Rankines`, `Import`, `Proxy`, `Attributive`, `Renderable`, `Tag`.

Two further skips: `proscenium.infer` (already defined directly in the `soundness` package as a top-level `transparent inline def`) and `anthology.scalacOptions` (would clash with the existing nested `package scalacOptions:`).