### PR TITLE
Stop re-exporting `internal` objects to `soundness`

### DIFF
--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -36,7 +36,7 @@ export
   cataclysm
   . { &&, >>, AnimationFillMode, BackgroundRepeat, BorderStyle, ch, cm, Css, CssProperty, CssRule,
       CssStyle, CssStylesheet, Dir, Display, em, ex, Float, Font, FontFace, FontStyle, FontWeight,
-      From, Import, inches, Inherit, Initial, internal, Keyframe, Keyframes, Length, max, MediaRule,
+      From, Import, inches, Inherit, Initial, Keyframe, Keyframes, Length, max, MediaRule,
       min, MixBlendMode, mm, Overflow, pc, PointerEvents, Position, PropertyDef, PropertyValue, pt,
       px, rem, select, Selectable, Selector, ShowProperty, TextAlign, TextDecorationLine,
       TextDecorationStyle, To, Transparent, UserSelect, VerticalAlign, vh, vmax, ~~ }

--- a/lib/escapade/src/core/soundness_escapade_core.scala
+++ b/lib/escapade/src/core/soundness_escapade_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   escapade
-  . { Ansi, Ansi2, Bg, Bold, CharSpan, Colorable, Conceal, csi, e, Escape, escapes, Fg, internal,
-      Italic, Reverse, Ribbon, Strike, Stylize, Teletype, teletype, Teletypeable, TeletypeBuilder,
+  . { Ansi, Ansi2, Bg, Bold, CharSpan, Colorable, Conceal, csi, e, Escape, escapes, Fg, Italic,
+      Reverse, Ribbon, Strike, Stylize, Teletype, teletype, Teletypeable, TeletypeBuilder,
       TextStyle, Underline }
 
 package displayableTypes:

--- a/lib/phoenicia/src/core/soundness_phoenicia_core.scala
+++ b/lib/phoenicia/src/core/soundness_phoenicia_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export phoenicia.{Em, Ems, FontError, FontSize, Glyph, internal, OtfTag, TableTag, Ttf, TtfTag}
+export phoenicia.{Em, Ems, FontError, FontSize, Glyph, OtfTag, TableTag, Ttf, TtfTag}


### PR DESCRIPTION
The `cataclysm`, `escapade`, and `phoenicia` modules each defined an `internal` object holding macro implementations and incorrectly listed it in their `soundness_*.scala` re-exports. By the project's convention `internal` objects are not part of the public surface, and the three exports were also colliding with each other inside the `soundness` package. This PR removes those three names from the export lists; the objects themselves remain unchanged and continue to be available within their own modules.

No user-visible changes for code that was using the public APIs. Code that was reaching `soundness.internal.*` (which would have been ambiguous anyway) should import directly from the originating module — `cataclysm.internal.*`, `escapade.internal.*`, or `phoenicia.internal.*`.