### PR TITLE
Use 16-core runner for CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
     - name: Install shells
       run: |

--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -73,6 +73,7 @@ import internetAccess.enabled
 import interpreters.posix
 import logging.silent
 import stdios.virtualMachine
+import systems.java
 import termcaps.environment
 import textSanitizers.skip
 import workingDirectories.system
@@ -102,9 +103,9 @@ object Bootstrapper:
         Exit.Fail(1)
 
     . within:
-        val jarfile: Path on Linux =
+        val jarfile: Path on Local =
           ClassRef(Class.forName("burdock.Bootstrap").nn).classpathEntry match
-            case ClasspathEntry.Jar(file) => file.decode[Path on Linux]
+            case ClasspathEntry.Jar(file) => file.decode[Path on Local]
 
             case other =>
               abort(UserError(m"Could not determine location of bootstrap class"))
@@ -113,12 +114,12 @@ object Bootstrapper:
 
         if !jarfile.exists() then abort(UserError(m"The file $jarfile does not exist"))
 
-        val classpath: List[Path on Linux] =
-          arguments.map(_()).map(workingDirectory[Path on Linux].resolve(_))
+        val classpath: List[Path on Local] =
+          arguments.map(_()).map(workingDirectory[Path on Local].resolve(_))
 
         val maven = url"https://repo1.maven.org/"
 
-        val paths: List[Optional[(Path on Linux, Relative on Linux)]] =
+        val paths: List[Optional[(Path on Local, Relative on Local)]] =
           classpath.map: entry =>
             entry.ancestors.find(_.name == t"repo1.maven.org").optional.let: base =>
               if base.parent.let(_.name) == t"https"

--- a/lib/ethereal/src/core/ethereal.DaemonService.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonService.scala
@@ -45,7 +45,7 @@ case class DaemonService[bus <: Matchable]
   ( pid:        Pid,
     shutdown:   () => Unit,
     cliInput:   Stdin,
-    executable: Path on Linux,
+    executable: Path on Local,
     deliver:    bus => Unit,
     bus:        Stream[bus],
     script:     Text )

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -384,7 +384,7 @@ def cli[bus <: Matchable](using executive: Executive)
               ( pid,
                 () => shutdown(pid),
                 shellInput,
-                script.decode[Path on Linux],
+                script.decode[Path on Local],
                 deliver(pid, _),
                 connection.bus.stream,
                 name )

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -210,12 +210,12 @@ def cli[bus <: Matchable](using executive: Executive)
   val userId: Optional[Int] = safely(System.properties.ethereal.user.id[Int]())
   val userName: Optional[Text] = safely(System.properties.ethereal.user.name[Text]())
 
-  val runtimeDir: Optional[Path on Linux] = Xdg.runtimeDir
-  val stateHome: Path on Linux = Xdg.stateHome
-  val baseDir: Path on Linux = runtimeDir.or(stateHome) //name
-  val buildFile: Path on Linux = baseDir/name/"build"
-  val pidFile: Path on Linux = baseDir/name/"pid"
-  val socketFile: Path on Linux = baseDir/name/"socket"
+  val runtimeDir: Optional[Path on Local] = Xdg.runtimeDir
+  val stateHome: Path on Local = Xdg.stateHome
+  val baseDir: Path on Local = runtimeDir.or(stateHome) //name
+  val buildFile: Path on Local = baseDir/name/"build"
+  val pidFile: Path on Local = baseDir/name/"pid"
+  val socketFile: Path on Local = baseDir/name/"socket"
   val clients: scc.TrieMap[Pid, Client of bus] = scc.TrieMap()
   val terminatePid: Promise[Pid] = Promise()
   val idleTimeout: Long = 6L*60L*60L*1_000_000_000L
@@ -452,7 +452,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
       task(t"pid-watcher"):
         safely:
-          List[Path on Linux](socketFile, buildFile, pidFile).watch: watcher =>
+          List[Path on Local](socketFile, buildFile, pidFile).watch: watcher =>
             watcher.stream.each:
               case Delete(_, _) | Modify(_, _) =>
                 Log.warn(DaemonLogEvent.Termination)

--- a/lib/ethereal/src/example/ethereal_testfixture.scala
+++ b/lib/ethereal/src/example/ethereal_testfixture.scala
@@ -97,7 +97,8 @@ def fixture(): Unit = cli:
 
     case Argument("version") :: Nil =>
       execute:
-        val id: Text = safely((Classpath/"build.id").read[Text].trim).or(t"unknown")
+        val id: Text = safely(System.properties.build.id[Text]()).or:
+          safely((Classpath/"build.id").read[Text].trim).or(t"unknown")
         Out.print(t"v$id") yet Exit.Ok
 
     case Argument("signal") :: Nil =>

--- a/lib/ethereal/src/example/ethereal_testfixture.scala
+++ b/lib/ethereal/src/example/ethereal_testfixture.scala
@@ -33,6 +33,7 @@
 package ethereal
 
 import java.io as ji
+import java.lang as jl
 import java.util.concurrent as juc
 
 import soundness.*
@@ -43,6 +44,7 @@ import classloaders.threadContext
 import environments.daemonClient
 import executives.completions
 import interpreters.posix
+import systems.java
 import textSanitizers.strict
 import threading.platform
 import workingDirectories.system
@@ -84,7 +86,7 @@ def fixture(): Unit = cli:
     case Argument("pwd") :: Nil =>
       execute:
         val cwd: Text = safely(workingDirectory[Path on Local].encode).or:
-          java.lang.System.getProperty("user.dir").nn.tt
+          jl.System.getProperty("user.dir").nn.tt
         Out.print(cwd) yet Exit.Ok
 
     case Argument("cat") :: Nil =>

--- a/lib/ethereal/src/example/ethereal_testfixture.scala
+++ b/lib/ethereal/src/example/ethereal_testfixture.scala
@@ -83,7 +83,7 @@ def fixture(): Unit = cli:
 
     case Argument("pwd") :: Nil =>
       execute:
-        val cwd: Text = safely(workingDirectory[Path on Linux].encode).or:
+        val cwd: Text = safely(workingDirectory[Path on Local].encode).or:
           java.lang.System.getProperty("user.dir").nn.tt
         Out.print(cwd) yet Exit.Ok
 

--- a/lib/ethereal/src/runner/src/launch.rs
+++ b/lib/ethereal/src/runner/src/launch.rs
@@ -19,9 +19,11 @@ pub fn launch(
     config: &BuildConfig,
     download: bool,
 ) {
+    crate::debug!("launch: start name={} script={}", name, script.display());
     let java = match crate::java::find_java(config.java_min, config.java_pref, config.bundle, download) {
-        Some(path) => path,
+        Some(path) => { crate::debug!("launch: java found at {}", path.display()); path },
         None => {
+            crate::debug!("launch: java not found");
             crate::java::java_not_found_message(config.java_min, &script.to_string_lossy());
             crate::state::abort(fail_file);
             std::process::exit(1);
@@ -44,14 +46,27 @@ pub fn launch(
     }
 
     detach(&mut command);
+    // On Windows, `Command::spawn` calls `CreateProcessW` with
+    // `bInheritHandles=TRUE`, which propagates *every* inheritable handle in
+    // the parent — not just the configured stdio. The launcher's own
+    // stdin/stdout/stderr were inheritable when our caller (e.g. PowerShell's
+    // `Process` API) created them, so they would otherwise leak into the
+    // daemon and stay open for as long as the daemon runs, blocking the
+    // caller's `ReadToEndAsync` long after the launcher itself has exited.
+    // Mark them non-inheritable just before the spawn; the launcher continues
+    // to use them normally afterwards.
+    mark_stdio_non_inheritable();
+    crate::debug!("launch: spawning daemon: {} (wrapper)", executable.display());
 
     let child = match command.spawn() {
         Ok(child) => child,
-        Err(_) => {
+        Err(e) => {
+            crate::debug!("launch: spawn failed: {}", e);
             crate::state::abort(fail_file);
             std::process::exit(1);
         }
     };
+    crate::debug!("launch: spawned, child pid={}", child.id());
 
     let _ = std::fs::write(pid_file, format!("{}\n", child.id()));
 
@@ -63,8 +78,11 @@ pub fn launch(
         std::thread::sleep(STARTUP_POLL);
         attempts += 1;
     }
+    crate::debug!("launch: post-poll attempts={} socket_ready={} fail_exists={}",
+        attempts, crate::state::socket_ready(socket_file), fail_file.exists());
 
     if !crate::state::socket_ready(socket_file) {
+        crate::debug!("launch: socket never appeared, aborting");
         crate::state::abort(fail_file);
         crate::state::backout(fail_file, pid_file, name);
         std::process::exit(1);
@@ -73,8 +91,10 @@ pub fn launch(
     // The daemon writes the build-id file shortly after binding the socket.
     // We don't need it to connect, but staleness checks on later invocations do.
     let _ = crate::state::await_file(build_file, BUILD_FILE_GRACE_ATTEMPTS);
+    crate::debug!("launch: build_file ready={}", crate::state::file_has_content(build_file));
 
     crate::state::backout(fail_file, pid_file, name);
+    crate::debug!("launch: returning");
 }
 
 fn build_java_arguments(script: &Path, name: &str, config: &BuildConfig) -> Vec<String> {
@@ -120,6 +140,25 @@ fn detach(command: &mut Command) {
             libc::setsid();
             Ok(())
         });
+    }
+}
+
+#[cfg(unix)]
+fn mark_stdio_non_inheritable() {}
+
+#[cfg(windows)]
+fn mark_stdio_non_inheritable() {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{HANDLE, SetHandleInformation, HANDLE_FLAG_INHERIT};
+    let handles: [HANDLE; 3] = [
+        std::io::stdin().as_raw_handle() as HANDLE,
+        std::io::stdout().as_raw_handle() as HANDLE,
+        std::io::stderr().as_raw_handle() as HANDLE,
+    ];
+    for handle in handles {
+        if !handle.is_null() {
+            unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0); }
+        }
     }
 }
 

--- a/lib/ethereal/src/runner/src/launch.rs
+++ b/lib/ethereal/src/runner/src/launch.rs
@@ -144,10 +144,10 @@ fn detach(command: &mut Command) {
 }
 
 #[cfg(unix)]
-fn mark_stdio_non_inheritable() {}
+pub(crate) fn mark_stdio_non_inheritable() {}
 
 #[cfg(windows)]
-fn mark_stdio_non_inheritable() {
+pub(crate) fn mark_stdio_non_inheritable() {
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Foundation::{HANDLE, SetHandleInformation, HANDLE_FLAG_INHERIT};
     let handles: [HANDLE; 3] = [

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -17,6 +17,22 @@ mod uds;
 mod update;
 mod wrapper;
 
+// Debug-trace helper: when `ETHEREAL_DEBUG=1` is set, writes a timestamped
+// line to stderr from the launcher. Intentionally lazy — avoids any cost
+// when the env var isn't set.
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {{
+        if std::env::var_os("ETHEREAL_DEBUG").is_some_and(|v| !v.is_empty() && v != "0") {
+            let ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0);
+            eprintln!("[eth +{ms}] {}", format!($($arg)*));
+        }
+    }};
+}
+
 use protocol::ClientInfo;
 use uds::UnixStream;
 
@@ -31,15 +47,20 @@ fn main() {
     // client (since this binary IS the renamed launcher). Dispatch before any
     // other parsing — the wrapper has its own minimal argv contract.
     let raw: Vec<String> = env::args().collect();
+    debug!("main: argv={:?}", raw);
     if raw.get(1).is_some_and(|arg| arg == WRAP_SENTINEL) {
+        debug!("main: dispatching to wrapper");
         wrapper::run(&raw[2..]);
     }
 
     let (script, args, download) = parse_arguments();
     let name = script.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_default();
+    debug!("main: script={} name={} args={:?}", script.display(), name, args);
     let build_config = config::read_config();
+    debug!("main: build_id={} java_min={} java_pref={}", build_config.build_id, build_config.java_min, build_config.java_pref);
 
     update::check_updates(&script, &args, &name);
+    debug!("main: post-update-check");
 
     let base_dir = state::base_dir(&name);
     let _ = std::fs::create_dir_all(&base_dir);
@@ -47,28 +68,35 @@ fn main() {
     let pid_file    = base_dir.join("pid");
     let socket_file = base_dir.join("socket");
     let fail_file   = base_dir.join("fail");
+    debug!("main: base_dir={}", base_dir.display());
 
     // Non-interactive invocations (completions, admin) must not touch the TTY,
     // fork a stdin-forwarding thread, or install signal handlers — doing so
     // can steal input from the parent shell or trigger SIGTTOU when the
     // process runs in a background process group (e.g. under `< <(...)`).
     let interactive = !args.first().is_some_and(|arg| arg == "{completions}" || arg == "{admin}");
+    debug!("main: interactive={}", interactive);
 
     state::backout(&fail_file, &pid_file, &name);
     state::check_state(&pid_file, &build_file, &socket_file, build_config.build_id);
+    debug!("main: post check_state, pid_file_has_content={}", state::file_has_content(&pid_file));
 
     if !state::file_has_content(&pid_file) {
         let lock_path = base_dir.join("lock");
         match state::try_exclusive_lock(&lock_path) {
             Some(_lock) => {
+                debug!("main: acquired lock, launching daemon");
                 launch::launch(
                     &script, &name, &base_dir,
                     &build_file, &pid_file, &socket_file, &fail_file,
                     &build_config, download,
                 );
+                debug!("main: launch::launch returned");
             }
             None => {
+                debug!("main: another launcher holds the lock; awaiting socket");
                 if !state::await_socket(&socket_file, 40) {
+                    debug!("main: socket did not appear");
                     state::abort(&fail_file);
                     state::backout(&fail_file, &pid_file, &name);
                     std::process::exit(1);
@@ -78,7 +106,11 @@ fn main() {
     }
     state::backout(&fail_file, &pid_file, &name);
 
-    if !state::socket_alive(&socket_file) { std::process::exit(STARTUP_FAILURE_EXIT_CODE); }
+    if !state::socket_alive(&socket_file) {
+        debug!("main: socket not alive, exiting STARTUP_FAILURE");
+        std::process::exit(STARTUP_FAILURE_EXIT_CODE);
+    }
+    debug!("main: socket is alive");
 
     if !interactive {
         std::process::exit(run_non_interactive(&socket_file, &script, &args));
@@ -88,9 +120,11 @@ fn main() {
     tty::set_raw_mode();
 
     let info = ClientInfo::collect(&script, &args, tty::stdin_is_tty());
+    debug!("main: connecting to daemon (pid={})", info.pid);
     let (main_socket, stderr_socket) = match connect_to_daemon(&socket_file, &info) {
-        Ok(connections) => connections,
-        Err(_) => {
+        Ok(connections) => { debug!("main: connected to daemon"); connections },
+        Err(e) => {
+            debug!("main: connect failed: {}", e);
             tty::restore_tty_state(&saved_tty);
             std::process::exit(STARTUP_FAILURE_EXIT_CODE);
         }

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -139,7 +139,27 @@ fn parse_arguments() -> (PathBuf, Vec<String>, bool) {
     let script = std::fs::canonicalize(&executable)
         .or_else(|_| std::env::current_exe())
         .unwrap_or_else(|_| PathBuf::from(&executable));
-    (script, args, download)
+    (strip_extended_prefix(script), args, download)
+}
+
+// On Windows, `std::fs::canonicalize` returns the extended-length form
+// (`\\?\C:\…`). Java's JAR loader can read the manifest of a JAR opened via
+// `\\?\…` but cannot load class entries from it, so the daemon launches with
+// `Could not find or load main class …` even though the class is in the JAR.
+// Strip the prefix back to a conventional drive-letter path on Windows; on
+// Unix this is a no-op.
+fn strip_extended_prefix(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy();
+        if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{}", rest));
+        }
+        if let Some(rest) = s.strip_prefix(r"\\?\") {
+            return PathBuf::from(rest);
+        }
+    }
+    path
 }
 
 fn connect_to_daemon(socket_path: &Path, info: &ClientInfo)

--- a/lib/ethereal/src/runner/src/update.rs
+++ b/lib/ethereal/src/runner/src/update.rs
@@ -3,10 +3,12 @@ use std::path::Path;
 pub fn check_updates(script: &Path, args: &[String], name: &str) {
     let data_home = crate::state::data_home();
     let pending = data_home.join(name).join(".pending");
+    crate::debug!("update: pending={}", pending.display());
     let metadata = match std::fs::metadata(&pending) {
         Ok(m) => m,
-        Err(_) => return,
+        Err(e) => { crate::debug!("update: pending metadata err: {}", e); return; },
     };
+    crate::debug!("update: pending size={}", metadata.len());
     if metadata.len() == 0 { return; }
 
     #[cfg(unix)]
@@ -18,12 +20,20 @@ pub fn check_updates(script: &Path, args: &[String], name: &str) {
     }
 
     let old = data_home.join(format!("{}.old", name));
+    crate::debug!("update: removing prior old={}", old.display());
     let _ = std::fs::remove_file(&old);
-    if std::fs::rename(script, &old).is_err() { return; }
-    if std::fs::rename(&pending, script).is_err() {
+    crate::debug!("update: renaming script={} -> old={}", script.display(), old.display());
+    if let Err(e) = std::fs::rename(script, &old) {
+        crate::debug!("update: rename(script -> old) failed: {}", e);
+        return;
+    }
+    crate::debug!("update: renaming pending={} -> script={}", pending.display(), script.display());
+    if let Err(e) = std::fs::rename(&pending, script) {
+        crate::debug!("update: rename(pending -> script) failed: {}", e);
         let _ = std::fs::rename(&old, script);
         return;
     }
+    crate::debug!("update: swap complete; re-execing");
 
     #[cfg(unix)]
     unsafe {
@@ -42,6 +52,13 @@ pub fn check_updates(script: &Path, args: &[String], name: &str) {
     #[cfg(windows)]
     {
         use std::process::Command;
+        // Same handle-leak prevention as in `launch.rs::launch` — without
+        // this, the re-exec'd new binary inherits the launcher's
+        // stdin/stdout/stderr pipe handles and keeps them open even after
+        // the launcher exits, so any caller reading our output (e.g.
+        // PowerShell's `Process.StandardOutput.ReadToEndAsync`) blocks
+        // indefinitely.
+        crate::launch::mark_stdio_non_inheritable();
         let status = Command::new(script).args(args).status();
         match status {
             Ok(s) => std::process::exit(s.code().unwrap_or(1)),

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -57,8 +57,8 @@ object Tests extends Suite(m"Ethereal Tests"):
     safely(sh"pkill abcde".exec[Exit]())
     snooze(0.1*Second)
 
-    val stateDir: Path on Linux =
-      Xdg.runtimeDir[Path on Linux].or(Xdg.stateHome[Path on Linux]) / t"abcde"
+    val stateDir: Path on Local =
+      Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"abcde"
 
     safely:
       val oldPid = sh"cat $stateDir/pid".exec[Text]().trim.decode[Pid]
@@ -108,7 +108,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
               case Argument("pwd") :: Nil =>
                 execute:
-                  Out.print(workingDirectory[Path on Linux].encode) yet Exit.Ok
+                  Out.print(workingDirectory[Path on Local].encode) yet Exit.Ok
 
               case Argument("cat") :: Nil =>
                 execute:
@@ -486,8 +486,8 @@ object Tests extends Suite(m"Ethereal Tests"):
 
           . assert(_ == false)
 
-    val upgradeStateDir: Path on Linux =
-      Xdg.runtimeDir[Path on Linux].or(Xdg.stateHome[Path on Linux]) / t"upgrd"
+    val upgradeStateDir: Path on Local =
+      Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"upgrd"
 
     sh"rm -f $upgradeStateDir/pid $upgradeStateDir/build $upgradeStateDir/socket $upgradeStateDir/fail".exec[Unit]()
     safely(sh"pkill upgrd".exec[Exit]())
@@ -555,9 +555,9 @@ object Tests extends Suite(m"Ethereal Tests"):
     safely(sh"pkill upgrd".exec[Exit]())
     sh"rm -rf $upgradeStateDir".exec[Unit]()
 
-    val selfuStateDir: Path on Linux =
-      Xdg.runtimeDir[Path on Linux].or(Xdg.stateHome[Path on Linux]) / t"selfu"
-    val selfuDataDir: Path on Linux = Xdg.dataHome[Path on Linux] / t"selfu"
+    val selfuStateDir: Path on Local =
+      Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"selfu"
+    val selfuDataDir: Path on Local = Xdg.dataHome[Path on Local] / t"selfu"
     sh"rm -rf $selfuStateDir $selfuDataDir".exec[Unit]()
     safely(sh"pkill selfu".exec[Exit]())
     snooze(0.1*Second)
@@ -603,15 +603,15 @@ object Tests extends Suite(m"Ethereal Tests"):
       .assert(_ == t"v2")
 
       test(m"old binary is preserved after upgrade"):
-        sh"test -f ${Xdg.dataHome[Path on Linux]}/selfu.old".exec[Exit]()
+        sh"test -f ${Xdg.dataHome[Path on Local]}/selfu.old".exec[Exit]()
 
       .assert(_ == Exit.Ok)
 
     safely(sh"pkill selfu".exec[Exit]())
     sh"rm -rf $selfuStateDir $selfuDataDir".exec[Unit]()
 
-    val brokenStateDir: Path on Linux =
-      Xdg.runtimeDir[Path on Linux].or(Xdg.stateHome[Path on Linux]) / t"brokn"
+    val brokenStateDir: Path on Local =
+      Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"brokn"
 
     val brokenExe: Path on Linux = Enclave("brokn").dispatch:
       ' {

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -71,6 +71,7 @@ object Tests extends Suite(m"Ethereal Tests"):
           import executives.completions
           import interpreters.posix
           import environments.daemonClient
+          import systems.java
 
           cli:
             arguments match

--- a/lib/ethereal/windows-test/Run-EtherealTests.ps1
+++ b/lib/ethereal/windows-test/Run-EtherealTests.ps1
@@ -267,7 +267,12 @@ function Stop-DaemonHard {
   if ($id) {
     try { Stop-Process -Id $id -Force -ErrorAction SilentlyContinue } catch { }
   }
-  Get-Process -Name $Name -ErrorAction SilentlyContinue |
+  # Windows' Get-Process strips the `.exe` extension implicitly, so passing a
+  # name like 'abcde.exe' matches nothing. Strip it ourselves so leftover
+  # launcher / wrapper processes get killed too — without this the wrapper
+  # keeps the launcher binary file locked, blocking self-update's rename.
+  $procName = $Name -replace '\.exe$',''
+  Get-Process -Name $procName -ErrorAction SilentlyContinue |
     Stop-Process -Force -ErrorAction SilentlyContinue
   if (Test-Path -LiteralPath $script:StateDir) {
     Get-ChildItem -LiteralPath $script:StateDir -Force -ErrorAction SilentlyContinue |
@@ -283,41 +288,47 @@ $script:Fail         = 0
 $script:Skipped      = 0
 $script:Failures     = New-Object System.Collections.Generic.List[object]
 
-function Suite([string] $name, [scriptblock] $body) {
-  $script:CurrentSuite = $name
-  if ($Only -and ($Only -notcontains $name)) {
+function Suite([string] $SuiteName, [scriptblock] $Body) {
+  # Renamed from $name/$body to avoid shadowing the script-level $Name and the
+  # body-block's own `body` references; PowerShell uses dynamic scoping for
+  # script-block variables, so any `$Name` reference inside the body would
+  # otherwise resolve to the suite name rather than the daemon name.
+  $script:CurrentSuite = $SuiteName
+  if ($Only -and ($Only -notcontains $SuiteName)) {
     Write-Host ""
-    Write-Host "[$name] (skipped)" -ForegroundColor DarkGray
+    Write-Host "[$SuiteName] (skipped)" -ForegroundColor DarkGray
     return
   }
   Write-Host ""
-  Write-Host "[$name]" -ForegroundColor Cyan
-  & $body
+  Write-Host "[$SuiteName]" -ForegroundColor Cyan
+  & $Body
 }
 
 function It {
   param(
-    [Parameter(Mandatory)] [string] $Name,
+    # Renamed from $Name to avoid shadowing the script-level $Name parameter
+    # (the daemon name) when test bodies reference $Name from the outer scope.
+    [Parameter(Mandatory)] [string] $TestName,
     [Parameter(Mandatory)] [scriptblock] $Body
   )
-  $key = "$($script:CurrentSuite) :: $Name"
+  $key = "$($script:CurrentSuite) :: $TestName"
   if ($Skip -and (($Skip -contains $script:CurrentSuite) -or ($Skip -contains $key))) {
     $script:Skipped++
-    Write-Host "  - skip  $Name" -ForegroundColor DarkGray
+    Write-Host "  - skip  $TestName" -ForegroundColor DarkGray
     return
   }
   try {
     & $Body
     $script:Pass++
-    Write-Host "  + pass  $Name" -ForegroundColor Green
+    Write-Host "  + pass  $TestName" -ForegroundColor Green
   } catch {
     $script:Fail++
     [void]$script:Failures.Add([pscustomobject]@{
       Suite = $script:CurrentSuite
-      Name  = $Name
+      Name  = $TestName
       Error = $_.Exception.Message
     })
-    Write-Host "  ! FAIL  $Name" -ForegroundColor Red
+    Write-Host "  ! FAIL  $TestName" -ForegroundColor Red
     Write-Host "         $($_.Exception.Message)" -ForegroundColor Red
   }
 }
@@ -485,11 +496,13 @@ Suite 'Concurrent invocations' {
     $r1 = Wait-Tool $p1
     $r2 = Wait-Tool $p2
     $r3 = Wait-Tool $p3
-    $unique = @($r1.Stdout.Trim(), $r2.Stdout.Trim(), $r3.Stdout.Trim()) | Sort-Object -Unique
+    # Wrap in @(...) so that even a one-element result (all PIDs identical)
+    # exposes a `.Count` property; bare singletons in PS 5.1 do not.
+    $unique = @(@($r1.Stdout.Trim(), $r2.Stdout.Trim(), $r3.Stdout.Trim()) | Sort-Object -Unique)
     Should-Equal $unique.Count 1 'unique daemon-pid count'
   }
   It 'rapid sequential invocations succeed' {
-    $results = 1..5 | ForEach-Object { (Invoke-Tool -ToolArgs 'echo',[string]$_).Stdout.Trim() }
+    $results = 1..5 | ForEach-Object { (Invoke-Tool -ToolArgs 'echo',$_.ToString()).Stdout.Trim() }
     Should-Equal ($results -join ',') ((1..5) -join ',') 'echoed values'
   }
 }

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -45,10 +45,10 @@ import symbolism.*
 import vacuous.*
 
 import filesystemOptions.dereferenceSymlinks.enabled
-import interfaces.paths.pathOnLinux
+import interfaces.paths.pathOnLocal
 
 object Pathname:
-  def unapply(argument: Argument)(using WorkingDirectory, Cli): Option[Path on Linux] =
+  def unapply(argument: Argument)(using WorkingDirectory, Cli, System): Option[Path on Local] =
     safely:
       def suggest(path: Text): Suggestion =
         val point = path.s.lastIndexOf('/', path.length - 2) + 1
@@ -57,7 +57,7 @@ object Pathname:
         Suggestion(core, Unset, incomplete = path != argument(), prefix = prefix)
 
       if argument() == t"." then argument.suggest:
-        val wd: Path on Linux = workingDirectory
+        val wd: Path on Local = workingDirectory
         suggest(t"../")
         :: workingDirectory.children.to(List).filter(_.name.starts(t".")).map: path =>
           val directory = safely(path.entry() == galilei.Directory).or(false)
@@ -83,7 +83,7 @@ object Pathname:
         val directory = argument().ends(t"/")
         val prototype = workingDirectory.resolve(argument())
         val showAll = argument.tab.or(Prim) > Prim || prototype.name.starts(t".")
-        val base: Optional[Path on Linux] = if directory then prototype else prototype.parent
+        val base: Optional[Path on Local] = if directory then prototype else prototype.parent
         val children0 = base.lay(Nil)(_.children.to(List))
 
         val children =

--- a/lib/exoskeleton/src/core/exoskeleton.Application.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Application.scala
@@ -39,6 +39,7 @@ abstract class Application:
   import executives.direct
   import backstops.genericErrorMessage
   import interpreters.posix
+  import ambience.systems.java
 
   def invoke(using Cli): Exit
   def main(textArguments: IArray[Text]): Unit = application(textArguments)(invoke)

--- a/lib/exoskeleton/src/core/exoskeleton.Entrypoint.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Entrypoint.scala
@@ -38,4 +38,4 @@ import serpentine.*
 
 trait Entrypoint:
   def script: Text
-  def executable: Path on Linux
+  def executable: Path on Local

--- a/lib/exoskeleton/src/core/exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton_core.scala
@@ -129,14 +129,14 @@ inline def trap(handler: PartialFunction[UnixSignal | WindowsSignal, SignalRespo
 
   cli.trap(handler)
 
-def application(using executive: Executive, interpreter: Interpreter)
+def application(using executive: Executive, interpreter: Interpreter, system: System)
   ( arguments: Iterable[Text], signals: List[UnixSignal] = Nil )
   ( block: Cli ?=> executive.Return )
 :   Unit =
 
   val entrypoint = new Entrypoint:
-    def executable: Path on Linux =
-      safely(ProcessHandle.current.nn.info.nn.command.nn.get.nn.tt.decode[Path on Linux])
+    def executable: Path on Local =
+      safely(ProcessHandle.current.nn.info.nn.command.nn.get.nn.tt.decode[Path on Local])
       . or(panic(m"cannot determine java invocation"))
 
     def script: Text = executable.name

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -346,7 +346,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             val output = sh"$tool '{admin}' install".exec[Text]()
             val paths = output.trim.lines.filter(_.length > 0)
             paths.forall: path =>
-              safely(path.decode[Path on Linux]).let(_.exists()).or(false)
+              safely(path.decode[Path on Local]).let(_.exists()).or(false)
           .assert(_ == true)
 
           test(m"'{admin}' kill terminates the daemon"):

--- a/lib/galilei/src/core/galilei.Explorable.scala
+++ b/lib/galilei/src/core/galilei.Explorable.scala
@@ -87,5 +87,16 @@ object Explorable:
         . map(_.toString.tt.decode[Path on MacOs])
         . to(Stream)
 
+  given local: ambience.System => Local is Explorable:
+    def children(path: Path on Local): Stream[Path on Local] =
+      given tactic: Tactic[PathError] = strategies.throwUnsafely
+
+      if !jnf.Files.isDirectory(jnf.Path.of(path.show.s).nn) then Stream() else
+        jnf.Files.list(jnf.Path.of(path.show.s).nn).nn
+        . iterator().nn
+        . asScala
+        . map(_.toString.tt.decode[Path on Local])
+        . to(Stream)
+
 trait Explorable extends Typeclass:
   def children(path: Path on Self): Stream[Path on Self]

--- a/lib/serpentine/src/core/serpentine.Local.scala
+++ b/lib/serpentine/src/core/serpentine.Local.scala
@@ -50,7 +50,7 @@ object Local:
     type UniqueRoot = false
 
     val name: Text = System.properties.os.name().show
-    val separator: Text = System.properties.path.separator().show
+    val separator: Text = System.properties.file.separator().show
     val self: Text = t"."
     val parent: Text = t".."
 


### PR DESCRIPTION
Switches the main CI build workflow to a 16-core GitHub-hosted larger runner (`ubuntu-latest-16-cores`) for faster builds. The publish and release-mirror workflows continue to use the default `ubuntu-latest` runner.

CI builds now run on a `ubuntu-latest-16-cores` larger runner. This requires the `ubuntu-latest-16-cores` label to be configured under the repository or organization's larger-runner settings.