### PR TITLE
Expose daemon started/uptime measured from JVM invocation

### DIFF
--- a/lib/ethereal/src/core/ethereal.DaemonService.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonService.scala
@@ -34,6 +34,8 @@ package ethereal
 
 import language.experimental.pureFunctions
 
+import java.lang as jl
+
 import anticipation.*
 import exoskeleton.*
 import guillotine.*
@@ -48,6 +50,13 @@ case class DaemonService[bus <: Matchable]
     executable: Path on Local,
     deliver:    bus => Unit,
     bus:        Stream[bus],
-    script:     Text )
+    script:     Text,
+    startTime:  Long )
 extends Entrypoint:
   def broadcast(message: bus): Unit = deliver(message)
+
+  def started[instant: Instantiable across Instants from Long]: instant =
+    instant(startTime)
+
+  def uptime[duration: Instantiable across Durations from Long]: duration =
+    duration((jl.System.currentTimeMillis() - startTime).max(0L)*1_000_000L)

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -209,6 +209,8 @@ def cli[bus <: Matchable](using executive: Executive)
 
   val userId: Optional[Int] = safely(System.properties.ethereal.user.id[Int]())
   val userName: Optional[Text] = safely(System.properties.ethereal.user.name[Text]())
+  val startTime: Long =
+    safely(System.properties.ethereal.startTime[Long]()).or(jl.System.currentTimeMillis())
 
   val runtimeDir: Optional[Path on Local] = Xdg.runtimeDir
   val stateHome: Path on Local = Xdg.stateHome
@@ -387,7 +389,8 @@ def cli[bus <: Matchable](using executive: Executive)
                 script.decode[Path on Local],
                 deliver(pid, _),
                 connection.bus.stream,
-                name )
+                name,
+                startTime )
 
           Log.fine(DaemonLogEvent.NewCli)
 

--- a/lib/ethereal/src/runner/src/launch.rs
+++ b/lib/ethereal/src/runner/src/launch.rs
@@ -37,6 +37,11 @@ pub fn launch(
     let mut command = Command::new(&executable);
     command.arg(crate::WRAP_SENTINEL).arg(&java);
     for argument in build_java_arguments(script, name, config) { command.arg(argument); }
+    // Capture the JVM invocation time as late as possible — after the slow
+    // argument-building work (zsh probe, $fpath capture) — so `uptime` in the
+    // daemon measures from the moment java is actually spawned, not from when
+    // launch() was entered.
+    command.arg(format!("-Dethereal.startTime={}", crate::now_ms()));
     command.arg("-jar").arg(script);
     command.stdin(Stdio::null());
     command.stdout(Stdio::null());
@@ -98,7 +103,6 @@ pub fn launch(
 }
 
 fn build_java_arguments(script: &Path, name: &str, config: &BuildConfig) -> Vec<String> {
-    let start_time = crate::now_ms();
     let jar_size = std::fs::metadata(script).map(|metadata| metadata.len()).unwrap_or(0);
     let user_name = std::env::var("USER").or_else(|_| std::env::var("USERNAME")).unwrap_or_default();
     let uid: u32 = {
@@ -120,7 +124,6 @@ fn build_java_arguments(script: &Path, name: &str, config: &BuildConfig) -> Vec<
 
     vec![
         format!("-Dbuild.id={}", config.build_id),
-        format!("-Dethereal.startTime={}", start_time),
         format!("-Dethereal.name={}", name),
         format!("-Dethereal.user.id={}", uid),
         format!("-Dethereal.user.name={}", user_name),


### PR DESCRIPTION
The Ethereal launcher already passed `-Dethereal.startTime` into the daemon JVM, but the value was never read. This wires it through: the Rust launcher captures the timestamp as late as possible (after the zsh probe and other argument-building) so it represents the moment java is actually spawned, and the daemon reads it back. `DaemonService` exposes two polymorphic accessors so callers pick their own concrete time representation — ethereal stays free of a dependency on any specific time library.

```scala
@main
def run(): Unit = cli:
  execute:
    import anticipation.instantiables.durationIsInstantiable
    val nanos: Long = service.uptime[Long]
    Out.println(t"Daemon uptime: ${(nanos/1_000_000L).show}ms")
    Exit.Ok
```

`service.started[I]` returns the JVM invocation instant for any `I: Instantiable across Instants from Long` (millis since epoch), and `service.uptime[D]` returns elapsed time for any `D: Instantiable across Durations from Long` (nanoseconds). Both follow the same convention used by `guillotine.Process.startTime`/`cpuUsage`.

Cold-start measurements on this branch: ~480–533ms — that's the JVM startup overhead the new accessor lets you observe.