### PR TITLE
Expand Gossamer's Text extension method surface

### DIFF
--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -35,6 +35,7 @@ package gossamer
 import language.experimental.into
 import language.experimental.pureFunctions
 
+import java.lang as jl
 import java.net.{URLEncoder, URLDecoder}
 import java.util.regex as jur
 
@@ -191,6 +192,18 @@ extension [textual: Textual](text: textual)
     case Ltr => text.segment(Interval.initial(count))
     case Rtl => text.segment(text.limit - count till text.limit)
 
+  def skip(predicate: Char => Boolean): textual = text.skip(predicate, Ltr)
+
+  def skip(predicate: Char => Boolean, bidi: Bidi): textual = bidi match
+    case Ltr => text.where(!predicate(_)).lay(textual.empty)(text.from(_))
+    case Rtl => text.where(!predicate(_), bidi = Rtl).lay(textual.empty)(text.upto(_))
+
+  def keep(predicate: Char => Boolean): textual = text.keep(predicate, Ltr)
+
+  def keep(predicate: Char => Boolean, bidi: Bidi): textual = bidi match
+    case Ltr => text.where(!predicate(_)).lay(text)(text.before(_))
+    case Rtl => text.where(!predicate(_), bidi = Rtl).lay(text)(text.after(_))
+
   def capitalize: textual = textual.concat(text.keep(1).upper, text.after(Prim))
   def uncapitalize: textual = textual.concat(text.keep(1).lower, text.after(Prim))
 
@@ -230,12 +243,23 @@ extension [textual: Textual](text: textual)
         case _          => Stream()
 
   def seek(regex: Regex): Optional[textual] = regex.seek(textual.text(text)).let(text.segment(_))
-  def seek(substring: Text): Optional[Ordinal] = textual.indexOf(text, substring)
+
+  def seek(substring: Text, bidi: Bidi = Ltr): Optional[Ordinal] = bidi match
+    case Ltr => textual.indexOf(text, substring)
+    case Rtl =>
+      if substring.nil then Unset else
+        def recur(start: Ordinal, last: Optional[Ordinal]): Optional[Ordinal] =
+          textual.indexOf(text, substring, start).lay(last): found =>
+            recur(found + 1, found)
+
+        recur(Prim, Unset)
 
   inline def trim: textual =
     val start = text.where(!_.isWhitespace).or(text.limit - 1)
     val end = text.where(!_.isWhitespace, bidi = Rtl).or(Prim)
     text.segment(start thru end)
+
+  def trim(bidi: Bidi): textual = text.skip(_.isWhitespace, bidi)
 
   def where(predicate: Char => Boolean, start: Optional[Ordinal] = Unset, bidi: Bidi = Ltr)
   :   Optional[Ordinal] =
@@ -263,14 +287,6 @@ extension [textual: Textual](text: textual)
     val end: Ordinal = text.where(predicate).or(text.limit - 1)
     text.upto(end)
 
-  def dropWhile(predicate: Char => Boolean): textual =
-    text.where(!predicate(_)).lay(textual.empty): ordinal =>
-      text.segment(ordinal till text.limit)
-
-  def whilst(predicate: Char => Boolean): textual =
-    text.where(!predicate(_)).lay(textual.empty): ordinal =>
-      text.before(ordinal)
-
   def snip(predicate: Char => Boolean, index: Ordinal = Prim): Optional[(textual, textual)] =
     text.where(predicate, index).let(_.n0).let(text.snip(_))
 
@@ -289,6 +305,16 @@ extension [textual: Textual](text: textual)
       recur(index + 1, sum + increment)
 
     recur(Prim, 0)
+
+  def count(substring: Text): Int =
+    if substring.nil then 0 else
+      def recur(start: Ordinal, total: Int): Int =
+        textual.indexOf(text, substring, start).lay(total): found =>
+          recur(found + substring.length, total + 1)
+
+      recur(Prim, 0)
+
+  def blank: Boolean = text.where(!_.isWhitespace).absent
 
   def pad(length: Int, bidi: Bidi = Ltr, char: Char = ' ')(using Text is Measurable): textual =
     if text.plain.metrics >= length then text else
@@ -327,8 +353,14 @@ extension [textual: Textual](text: textual)
 
   def ends(suffix: Text): Boolean = text.keep(suffix.length, Rtl) == suffix
 
+  def strip(affix: Text, bidi: Bidi = Ltr): textual = bidi match
+    case Ltr => if text.starts(affix) then text.skip(affix.length) else text
+    case Rtl => if text.ends(affix) then text.skip(affix.length, Rtl) else text
+
   inline def tr(from: Char, to: Char): textual =
     textual.map(text)(char => if char == from then to else char)
+
+  inline def ossify: textual = text.tr(' ', ' ')
 
   // Extension method is applied explicitly because it appears ambiguous otherwise
   inline def subscripts: textual = textual.map(text)(_.subscript.or(' '))
@@ -417,10 +449,28 @@ package proximities:
     (left, right) => levenshteinDistance.distance(left, right)/left.length.max(right.length)
 
 extension (text: Text)
-  inline def sub(from: Text, to: Text): Text =
-    text.s.replaceAll(jur.Pattern.quote(from.s).nn, to.s).nn.tt
+  def sub(from: Text, to: Text): Text =
+    text.subPattern(jur.Pattern.compile(jur.Pattern.quote(from.s)).nn, to, Int.MaxValue)
 
-  inline def sub(from: Regex, to: Text): Text = text.s.replaceAll(from.pattern.s, to.s).nn.tt
+  def sub(from: Text, to: Text, count: Int): Text =
+    text.subPattern(jur.Pattern.compile(jur.Pattern.quote(from.s)).nn, to, count)
+
+  def sub(from: Regex, to: Text): Text =
+    text.subPattern(jur.Pattern.compile(from.pattern.s).nn, to, Int.MaxValue)
+
+  def sub(from: Regex, to: Text, count: Int): Text =
+    text.subPattern(jur.Pattern.compile(from.pattern.s).nn, to, count)
+
+  private def subPattern(pattern: jur.Pattern, to: Text, count: Int): Text =
+    if count <= 0 then text else
+      val matcher = pattern.matcher(text.s).nn
+      val builder = jl.StringBuilder()
+      var n = 0
+      while n < count && matcher.find() do
+        matcher.appendReplacement(builder, to.s)
+        n += 1
+      matcher.appendTail(builder)
+      builder.toString.nn.tt
 
   inline def urlEncode: Text = URLEncoder.encode(text.s, "UTF-8").nn.tt
   inline def urlDecode: Text = URLDecoder.decode(text.s, "UTF-8").nn.tt

--- a/lib/gossamer/src/core/soundness_gossamer_core.scala
+++ b/lib/gossamer/src/core/soundness_gossamer_core.scala
@@ -34,14 +34,14 @@ package soundness
 
 export
   gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, BoundsError, broken,
-      build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains, count,
-      cut, Cuttable, data, Decimalizer, Dictionary, dropWhile, ends, erase, fill, fit, from, init,
-      join, Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, pad, pascal, plain,
-      Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
-      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, sub, subscripts, superscripts,
-      sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel, uncapitalize,
-      unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
+  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, blank, BoundsError,
+      broken, build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains,
+      count, cut, Cuttable, data, Decimalizer, Dictionary, ends, erase, fill, fit, from, init, join,
+      Joinable, kebab, keep, length, Lexicon, lines, lower, Ltr, Numerous, ossify, pad, pascal,
+      plain, Proximity, proximity, Pue, pue, punycode, RangeError, reverse, Rtl, search, seek,
+      SimpleTExtractor, skip, slices, snake, snip, spaced, starts, strip, sub, subscripts,
+      superscripts, sysData, t, tail, text, TextBuilder, Textual, tr, translate, trim, txt, uncamel,
+      uncapitalize, unkebab, unsnake, upper, upto, urlDecode, urlEncode, utf16, utf8, where, words }
 
 package decimalFormatters:
   export gossamer.decimalFormatters.java

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -510,17 +510,17 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == 10.z)
 
       test(m"Take characters while predicate is true"):
-        t"HELLOworld".whilst(_.isUpper)
+        t"HELLOworld".keep(_.isUpper)
 
       . assert(_ == t"HELLO")
 
       test(m"Take chars when predicate is never true"):
-        t"hello world".whilst(_.isUpper)
+        t"hello world".keep(_.isUpper)
 
       . assert(_ == t"")
 
       test(m"Take chars when predicate isn't initially true"):
-        t"Helloworld".whilst(_.isLower)
+        t"Helloworld".keep(_.isLower)
 
       . assert(_ == t"")
 

--- a/lib/hyperbole/src/core/hyperbole.TastyTree.scala
+++ b/lib/hyperbole/src/core/hyperbole.TastyTree.scala
@@ -77,7 +77,7 @@ object TastyTree:
       val expansions = expand(tastyTree)
 
       val indents =
-        expansions.filter(!_.source.nil).map(_.source.plain.whilst(_ == ' ').length)
+        expansions.filter(!_.source.nil).map(_.source.plain.keep(_ == ' ').length)
 
       val crop = indents.min
 

--- a/lib/profanity/src/core/profanity.LineEditor.scala
+++ b/lib/profanity/src/core/profanity.LineEditor.scala
@@ -57,7 +57,7 @@ case class LineEditor(value: Text = t"", position0: Optional[Int] = Unset) exten
     case Right       => copy(position0 = (position + 1) `min` value.length)
 
     case Ctrl('W') =>
-      val prefix = value.keep(0 max (position - 1)).reverse.dropWhile(_ != ' ').reverse
+      val prefix = value.keep(0 max (position - 1)).skip(_ != ' ', Rtl)
       copy(t"$prefix${value.skip(position)}", prefix.length)
 
     case Backspace =>


### PR DESCRIPTION
Adds a small set of `Text` extension methods in Gossamer that close common gaps in the API and unifies a couple of point-solutions behind bidi-parametric primitives. The `dropWhile` and `whilst` methods are subsumed by new predicate overloads of `skip` and `keep`, and the `whilst` migration silently fixes a latent bug where it returned empty text when the predicate matched every character.

### New methods

- `blank: Boolean` — true when the text is empty or all whitespace.
- `count(substring: Text): Int` — non-overlapping occurrence count, alongside the existing `count(predicate)`.
- `strip(affix: Text, bidi: Bidi = Ltr): Text` — removes the given affix if present at the chosen end.
- `ossify: Text` — replaces ordinary spaces with non-breaking spaces.

### Bidi-symmetric overloads

- `seek(substring: Text, bidi: Bidi = Ltr): Optional[Ordinal]` — `Rtl` finds the last occurrence.
- `trim(bidi: Bidi): Text` — strips whitespace from one side only.
- `skip(predicate: Char => Boolean, bidi: Bidi = Ltr): Text` (replaces `dropWhile`).
- `keep(predicate: Char => Boolean, bidi: Bidi = Ltr): Text` (replaces `whilst`).

### Substitution count

`sub(from, to)` is unchanged for the existing two-arg form. A new three-arg overload `sub(from, to, count)` limits the number of substitutions:

```scala
t"a-b-c-d".sub(t"-", t"_", 1)   // t"a_b-c-d"
```

### Examples

```scala
t"   ".blank                            // true
t"hello hello".count(t"hello")          // 2
t"prefix-name".strip(t"prefix-")        // t"name"
t"name.txt".strip(t".txt", Rtl)         // t"name"
t"abcabc".seek(t"abc", Rtl)             // last occurrence ordinal
t"   hello".trim(Ltr)                   // t"hello"
t"hello world".ossify                   // t"hello world" (with NBSP)
```