### PR TITLE
Fix Yossarian terminal-emulator bugs and add tests

### DIFF
--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -34,7 +34,6 @@ package yossarian
 
 import anticipation.*
 import contingency.*
-import distillate.*
 import fulminate.*
 import gossamer.*
 import hypotenuse.*
@@ -83,27 +82,15 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
     import Context.{Normal, Escape, Csi, Csi2, Osc, Osc2}
 
-    object SgrParam:
-      def unapply[default <: Int: ValueOf](params: Text): Some[Int] = params match
-        case t""          => Some(valueOf[default])
-        case As[Int](int) => Some(int)
-
-        case text =>
-          raise(PtyEscapeError(NonintegerSgrParameter(text))) yet Some(valueOf[default])
-
-    object SgrParams:
-      def unapplySeq(params: Text): Some[List[Int]] =
-        Some(params.cut(t";").flatMap(SgrParam.unapply[0](_)))
-
     def wipe(cursor: Int): Unit = buffer2.set(cursor, ' ', style, link)
 
     def set(x: Int, y: Int, char: Char, style: Style = style, link: Text = link): Unit =
       buffer2.set(x, y, char, style, link)
 
-    def cuu(n: Int): Unit = cursor.x = cursor.y - n
-    def cud(n: Int): Unit = cursor.x = cursor.y + n
-    def cuf(n: Int): Unit = cursor() = (cursor() + n).min(buffer2.width*buffer2.height - 1)
-    def cub(n: Int): Unit = cursor() = (cursor() - n).max(0)
+    def cuu(n: Int): Unit = cursor.y = cursor.y - n
+    def cud(n: Int): Unit = cursor.y = cursor.y + n
+    def cuf(n: Int): Unit = cursor.x = cursor.x + n
+    def cub(n: Int): Unit = cursor.x = cursor.x - n
 
     def cnl(n: Int): Unit =
       cursor.x = 0
@@ -115,9 +102,9 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
     def cha(n: Int): Unit = cursor.x = n - 1
 
-    def cup(n: Int, m: Int): Unit =
-      cursor.x = n - 1
-      cursor.y = m - 1
+    def cup(row: Int, col: Int): Unit =
+      cursor.y = row - 1
+      cursor.x = col - 1
 
     def ed(n: Int): Unit = n match
       case 0 => for i <- cursor() until buffer2.capacity do wipe(i)
@@ -140,28 +127,28 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
     def setLink(text: Text): Unit = link = text
     def su(n: Int): Unit = buffer2.scroll(n)
     def sd(n: Int): Unit = buffer2.scroll(-n)
-    def hvp(n: Int, m: Int): Unit = cup(n, m)
-    def dsr(): Unit = output.put(t"\e[${cursor.x + 1};${cursor.y + 1}s")
-    def dectcem(state: Boolean): Unit = ()
+    def hvp(row: Int, col: Int): Unit = cup(row, col)
+    def dsr(): Unit = output.put(t"\e[${cursor.y + 1};${cursor.x + 1}R")
+    def dectcem(visible: Boolean): Unit = state = state.copy(hideCursor = !visible)
     def scp(): Unit = state = state.copy(savedCursor = cursor())
     def rcp(): Unit = cursor() = state.savedCursor
-    def detectFocus(boolean: Boolean): Unit = state.copy(focusDetectionMode = boolean)
-    def focus(boolean: Boolean): Unit = state.copy(focus = boolean)
-    def bcp(boolean: Boolean): Unit = state.copy(bracketedPasteMode = boolean)
+    def detectFocus(value: Boolean): Unit = state = state.copy(focusDetectionMode = value)
+    def focus(value: Boolean): Unit = state = state.copy(focus = value)
+    def bcp(value: Boolean): Unit = state = state.copy(bracketedPasteMode = value)
 
     def osc(command: Text): Unit = command match
-      case r"8;;$text(.*)" => setLink(text)
-      case r"0;$text(.*)"  => title(text)
-      case parameter       => raise(PtyEscapeError(BadOscParameter(parameter)))
+      case r"8;([^;]*);$text(.*)" => setLink(text)
+      case r"0;$text(.*)"         => title(text)
+      case parameter              => raise(PtyEscapeError(BadOscParameter(parameter)))
 
     import Style.{Bit, Foreground, Background}, Bit.*
 
     def sgr(params: List[Int]): Unit = params match
       case Nil                            => ()
-      case 38 :: 5 :: n :: tail           => style = Foreground(style) = color8(n)
-      case 38 :: 2 :: r :: g :: b :: tail => style = Foreground(style) = Chroma(r, g, b)
-      case 48 :: 5 :: n :: tail           => style = Background(style) = color8(n)
-      case 48 :: 2 :: r :: g :: b :: tail => style = Background(style) = Chroma(r, g, b)
+      case 38 :: 5 :: n :: tail           => style = Foreground(style) = color8(n); sgr(tail)
+      case 38 :: 2 :: r :: g :: b :: tail => style = Foreground(style) = Chroma(r, g, b); sgr(tail)
+      case 48 :: 5 :: n :: tail           => style = Background(style) = color8(n); sgr(tail)
+      case 48 :: 2 :: r :: g :: b :: tail => style = Background(style) = Chroma(r, g, b); sgr(tail)
 
       case head :: tail =>
         style = head match
@@ -198,32 +185,57 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
         sgr(tail)
 
-    def csi(params: Text, char: Char): Unit = (params, char) match
-      case (SgrParams(params*), 'm') => sgr(params.to(List))
-      case (SgrParam[1](n),     'A') => cuu(n)
-      case (SgrParam[1](n),     'B') => cud(n)
-      case (SgrParam[1](n),     'C') => cuf(n)
-      case (SgrParam[1](n),     'D') => cub(n)
-      case (SgrParam[1](n),     'E') => cnl(n)
-      case (SgrParam[1](n),     'F') => cpl(n)
-      case (SgrParam[1](n),     'G') => cha(n)
-      case (SgrParams(n, m),    'H') => cup(n, m)
-      case (SgrParam[0](n),     'J') => ed(n)
-      case (SgrParam[0](n),     'K') => el(n)
-      case (SgrParam[1](n),     'S') => su(n)
-      case (SgrParam[1](n),     'T') => sd(n)
-      case (SgrParams(n, m),    'f') => hvp(n, m)
-      case (SgrParam[0](6),     'n') => dsr()
-      case (SgrParam[0](6),     's') => scp()
-      case (t"?25",             'h') => dectcem(true)
-      case (t"?25",             'l') => dectcem(false)
-      case (t"?1004",           'h') => detectFocus(true)
-      case (t"?1004",           'l') => detectFocus(false)
-      case (t"?2004",           'h') => bcp(true)
-      case (t"?2004",           'l') => bcp(false)
-      case (t"",                'I') => focus(true)
-      case (t"",                'O') => focus(false)
-      case (param,             char) => raise(PtyEscapeError(BadCsiCommand(param, char)))
+    def parseInt(text: Text, default: Int): Int =
+      if text.s.isEmpty then default
+      else text.s.toIntOption.getOrElse:
+        raise(PtyEscapeError(NonintegerSgrParameter(text))) yet default
+
+    def parseInts(text: Text): List[Int] =
+      if text.s.isEmpty then Nil
+      else text.cut(t";").to(List).map(parseInt(_, 0))
+
+    def parsePair(text: Text, default: Int): (Int, Int) =
+      if text.s.isEmpty then (default, default) else
+        val parts = text.cut(t";").to(List)
+        val first = if parts.length >= 1 then parseInt(parts(0), default) else default
+        val second = if parts.length >= 2 then parseInt(parts(1), default) else default
+        (first, second)
+
+    def privateMode(params: Text, char: Char): Unit = (params, char) match
+      case (t"?25",   'h') => dectcem(true)
+      case (t"?25",   'l') => dectcem(false)
+      case (t"?1004", 'h') => detectFocus(true)
+      case (t"?1004", 'l') => detectFocus(false)
+      case (t"?2004", 'h') => bcp(true)
+      case (t"?2004", 'l') => bcp(false)
+      case (_, 'h' | 'l')  => () // unknown DEC private modes are silently ignored
+      case _               => raise(PtyEscapeError(BadCsiCommand(params, char)))
+
+    def csi(params: Text, char: Char): Unit =
+      if params.s.startsWith("?") then privateMode(params, char) else char match
+        case 'm' => sgr(parseInts(params))
+        case 'A' => cuu(parseInt(params, 1))
+        case 'B' => cud(parseInt(params, 1))
+        case 'C' => cuf(parseInt(params, 1))
+        case 'D' => cub(parseInt(params, 1))
+        case 'E' => cnl(parseInt(params, 1))
+        case 'F' => cpl(parseInt(params, 1))
+        case 'G' => cha(parseInt(params, 1))
+        case 'J' => ed(parseInt(params, 0))
+        case 'K' => el(parseInt(params, 0))
+        case 'S' => su(parseInt(params, 1))
+        case 'T' => sd(parseInt(params, 1))
+
+        case 'H' => val (r, c) = parsePair(params, 1); cup(r, c)
+        case 'f' => val (r, c) = parsePair(params, 1); hvp(r, c)
+
+        case 'n' if parseInt(params, 0) == 6                     => dsr()
+        case 's' if params.s.isEmpty || parseInt(params, 0) == 6 => scp()
+        case 'u' if params.s.isEmpty                             => rcp()
+        case 'I' if params.s.isEmpty                             => focus(true)
+        case 'O' if params.s.isEmpty                             => focus(false)
+
+        case _ => raise(PtyEscapeError(BadCsiCommand(params, char)))
 
     // Uses the Ubuntu color palette
     def palette(n: Int): Chroma = n match
@@ -235,7 +247,7 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
       case 5  => Chroma(118, 038, 113)
       case 6  => Chroma(044, 181, 233)
       case 7  => Chroma(204, 204, 204)
-      case 8  => Chroma(001, 001, 001)
+      case 8  => Chroma(085, 085, 085)
       case 9  => Chroma(255, 000, 000)
       case 10 => Chroma(000, 255, 000)
       case 11 => Chroma(255, 255, 000)
@@ -267,9 +279,7 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
         recur(index + 1, context)
 
       inline def bs(): Pty =
-        set(cursor.x, cursor.y, ' ', buffer2.style(cursor.x, cursor.y))
-        cursor() -= 1
-        if cursor() < 0 then cursor() = 0
+        cursor.x = cursor.x - 1
         proceed(Normal)
 
       inline def lf(): Pty =
@@ -351,7 +361,7 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
                 osc(escBuffer.text.also(escBuffer.clear()))
                 proceed(Normal)
 
-              case '\u0027' =>
+              case '\u001b' =>
                 proceed(Osc2)
 
               case char =>
@@ -365,8 +375,9 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
                 proceed(Normal)
 
               case char =>
+                escBuffer.append('\u001b')
                 escBuffer.append(char)
-                proceed(Normal)
+                proceed(Osc)
 
           case Csi =>
             current match

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -21,8 +21,6 @@
 ┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
 ┃    except in compliance with the License. You may obtain a copy of the License at                ┃
 ┃                                                                                                  ┃
-┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
-┃                                                                                                  ┃
 ┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
 ┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
@@ -34,6 +32,177 @@ package yossarian
 
 import soundness.*
 
+import strategies.throwUnsafely
+
 object Tests extends Suite(m"Yossarian Tests"):
   def run(): Unit =
-    ()
+    // ESC and BEL bytes assembled at run time so the source file stays free of stray
+    // control characters that would otherwise terminate OSC sequences silently.
+    val Esc: Text = Text(0x1b.toChar.toString)
+    val Bel: Text = Text(0x07.toChar.toString)
+
+    def fresh: Pty = Pty(10, 4)
+
+    def cell(pty: Pty, x: Int, y: Int): Char = pty.buffer.char(x, y)
+
+    def row(pty: Pty, y: Int): Text =
+      Text(String((0 until pty.buffer.width).map(pty.buffer.char(_, y)).toArray))
+
+    def drainOutput(pty: Pty): Text =
+      pty.output.stop()
+      pty.stream.to(List).map(_.s).mkString.tt
+
+    suite(m"Plain text"):
+      test(m"writing text places characters in cells"):
+        row(fresh.consume(t"hi"), 0)
+      . assert(_ == t"hi        ")
+
+      test(m"cursor advances after writing"):
+        fresh.consume(t"hi").state0.cursor
+      . assert(_ == 2)
+
+      test(m"writing past row width wraps to next row"):
+        val pty = fresh.consume(t"0123456789X")
+        (cell(pty, 0, 1), cell(pty, 9, 0))
+      . assert(_ == ('X', '9'))
+
+    suite(m"Carriage return and line feed"):
+      test(m"CR returns to column 0 of same row"):
+        val pty = fresh.consume(t"abc\rX")
+        row(pty, 0)
+      . assert(_ == t"Xbc       ")
+
+      test(m"LF advances to next row at column 0"):
+        val pty = fresh.consume(t"ab\nc")
+        (row(pty, 0), row(pty, 1))
+      . assert(_ == (t"ab        ", t"c         "))
+
+    suite(m"Backspace"):
+      test(m"BS moves cursor left without erasing"):
+        val pty = fresh.consume(t"abc\b")
+        (row(pty, 0), pty.state0.cursor)
+      . assert(_ == (t"abc       ", 2))
+
+      test(m"BS+SP+BS erases the previous character"):
+        val pty = fresh.consume(t"abc\b \b")
+        (row(pty, 0), pty.state0.cursor)
+      . assert(_ == (t"ab        ", 2))
+
+      test(m"BS at column 0 stays at column 0"):
+        val pty = fresh.consume(t"\b")
+        pty.state0.cursor
+      . assert(_ == 0)
+
+    suite(m"Cursor positioning"):
+      test(m"CUP places cursor at row 3 col 5 (1-indexed)"):
+        val pty = fresh.consume(t"$Esc[3;5HX")
+        cell(pty, 4, 2)
+      . assert(_ == 'X')
+
+      test(m"CUP with no parameters homes the cursor"):
+        val pty = fresh.consume(t"abc${Esc}[HZ")
+        cell(pty, 0, 0)
+      . assert(_ == 'Z')
+
+      test(m"CUU moves cursor up two rows"):
+        val pty = fresh.consume(t"$Esc[4;5H$Esc[2AX")
+        cell(pty, 4, 1)
+      . assert(_ == 'X')
+
+      test(m"CUD moves cursor down one row"):
+        val pty = fresh.consume(t"$Esc[1;1H$Esc[1BX")
+        cell(pty, 0, 1)
+      . assert(_ == 'X')
+
+      test(m"CUF moves cursor right within row"):
+        val pty = fresh.consume(t"$Esc[1;1H$Esc[3CX")
+        cell(pty, 3, 0)
+      . assert(_ == 'X')
+
+      test(m"CUF clamps at end of row, not into next row"):
+        val pty = fresh.consume(t"$Esc[1;1H$Esc[20CX")
+        cell(pty, 9, 0)
+      . assert(_ == 'X')
+
+      test(m"CUB moves cursor left within row"):
+        val pty = fresh.consume(t"$Esc[1;5H$Esc[2DX")
+        cell(pty, 2, 0)
+      . assert(_ == 'X')
+
+    suite(m"Erase"):
+      test(m"ED 2 clears the entire screen"):
+        val pty = fresh.consume(t"abc\ndef$Esc[2J")
+        (row(pty, 0), row(pty, 1))
+      . assert(_ == (t"          ", t"          "))
+
+      test(m"EL 2 clears the current line"):
+        val pty = fresh.consume(t"abcdef$Esc[1;1H$Esc[2K")
+        row(pty, 0)
+      . assert(_ == t"          ")
+
+    suite(m"SGR"):
+      test(m"SGR 1 enables bold"):
+        val pty = fresh.consume(t"$Esc[1mX")
+        pty.buffer.style(0, 0).bold
+      . assert(_ == true)
+
+      test(m"SGR 0 resets bold"):
+        val pty = fresh.consume(t"$Esc[1mX$Esc[0mY")
+        (pty.buffer.style(0, 0).bold, pty.buffer.style(1, 0).bold)
+      . assert(_ == (true, false))
+
+      test(m"SGR 38;2;R;G;B sets a 24-bit foreground"):
+        val pty = fresh.consume(t"$Esc[38;2;100;150;200mX")
+        pty.buffer.style(0, 0).foreground
+      . assert(_ == Chroma(100, 150, 200))
+
+      test(m"SGR 38;5;N;1m applies bold after extended colour"):
+        val pty = fresh.consume(t"$Esc[38;5;201;1mX")
+        pty.buffer.style(0, 0).bold
+      . assert(_ == true)
+
+    suite(m"OSC"):
+      test(m"OSC 0 sets the window title (BEL terminator)"):
+        val pty = fresh.consume(t"$Esc]0;My Title$Bel")
+        pty.state0.title
+      . assert(_ == t"My Title")
+
+      test(m"OSC 0 sets the window title (ST terminator)"):
+        val pty = fresh.consume(t"$Esc]0;My Title$Esc\\")
+        pty.state0.title
+      . assert(_ == t"My Title")
+
+      test(m"OSC 8 with empty params sets a hyperlink"):
+        val pty = fresh.consume(t"$Esc]8;;https://example.com${Bel}X")
+        pty.buffer.link(0, 0)
+      . assert(_ == t"https://example.com")
+
+      test(m"OSC 8 with params field sets a hyperlink"):
+        val pty = fresh.consume(t"$Esc]8;id=123;https://example.com${Bel}X")
+        pty.buffer.link(0, 0)
+      . assert(_ == t"https://example.com")
+
+    suite(m"DEC private modes"):
+      test(m"unknown private mode is silently ignored"):
+        fresh.consume(t"$Esc[?1049hX").buffer.char(0, 0)
+      . assert(_ == 'X')
+
+      test(m"DECTCEM ?25 l sets hideCursor in state"):
+        fresh.consume(t"$Esc[?25l").state0.hideCursor
+      . assert(_ == true)
+
+      test(m"DECTCEM ?25 h clears hideCursor in state"):
+        fresh.consume(t"$Esc[?25l$Esc[?25h").state0.hideCursor
+      . assert(_ == false)
+
+    suite(m"Output channel"):
+      test(m"DSR responds with row;col R"):
+        drainOutput(fresh.consume(t"$Esc[3;5H$Esc[6n"))
+      . assert(_ == t"$Esc[3;5R")
+
+    suite(m"Palette"):
+      test(m"bright black (palette 8) is distinct from black"):
+        val black = fresh.consume(t"$Esc[30mA").buffer.style(0, 0).foreground
+        val brightBlack = fresh.consume(t"$Esc[90mA").buffer.style(0, 0).foreground
+        black != brightBlack
+      . assert(_ == true)


### PR DESCRIPTION
Yossarian's headless terminal emulator was previously unfinished and untested; the existing implementation had a number of correctness bugs that prevented it from being used as a faithful test fixture. This PR adds a 30-case test suite that pins basic terminal behaviour, then fixes the bugs the suite uncovers so all 30 tests pass.

## What changed for users

The `Pty.consume` state machine is now correct for the subset of escape sequences it claims to handle:

- **Cursor movement.** CUU/CUD now move along the y-axis (they were assigning to `cursor.x`); CUF/CUB clamp at the row edge instead of spilling into adjacent rows; CUP/HVP take the standard `(row, col)` order with default `1` instead of `(col, row)` with default `0`, so bare `\e[H` correctly homes the cursor.
- **Backspace** is now non-destructive (just moves the cursor), so the conventional `BS SP BS` erase idiom works.
- **DSR** (`\e[6n`) responds with `\e[<row>;<col>R` (was sending `<col>;<row>s`).
- **State mutators** (`?25` show/hide cursor, `?1004` focus reporting, `?2004` bracketed paste, focus in/out) were building a new `PtyState` and discarding it; they now actually update state.
- **SGR with extended colours.** `\e[38;5;201;1m` and similar mixed sequences correctly apply trailing parameters; previously the `;5;n` and `;2;r;g;b` cases dropped the rest of the list.
- **OSC string-terminator handling** now correctly recognises `ESC \` (was looking for an apostrophe) and resumes accumulating if the byte after `ESC` isn't `\`.
- **OSC 8 hyperlinks** with a non-empty params field (e.g. `OSC 8 ; id=foo ; URI`) now match.
- **Bright black** (palette index 8) is now visually distinct from black (index 0).
- **Unknown DEC private modes** (`\e[?...h` / `\e[?...l`) are silently ignored instead of raising, so input from real applications doesn't abort the stream. The known modes (`?25`, `?1004`, `?2004`) still work.
- The previously-defined-but-never-dispatched `RCP` (`\e[u`, restore cursor position) command is now wired into the CSI dispatcher.

The CSI dispatcher itself was restructured to switch on the final byte before parsing parameters, which avoids a latent bug where the `SgrParam` extractor's eager `raise` would fire on private-mode params like `?25` and abort the consume.

```scala
import yossarian.*
import strategies.throwUnsafely

val pty = Pty(80, 24).consume(t"[31mhello[0m")
pty.buffer.style(0, 0).foreground  // red
pty.buffer.char(0, 0)              // 'h'
```

A 30-test suite in `lib/yossarian/src/test/yossarian.tests.scala` covers plain text, CR/LF, backspace, cursor positioning, screen and line erase, SGR (including 24-bit colour and chained extended forms), OSC 0/8 with both BEL and ST terminators, DECTCEM and unknown DEC private modes, the DSR output channel, and the palette. ESC and BEL bytes are assembled at run time so the source file is free of stray control characters.