### PR TITLE
Migrate Yossarian's terminal positions from Int to Ordinal

### DIFF
--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -34,6 +34,7 @@ package yossarian
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import fulminate.*
 import gossamer.*
 import hypotenuse.*
@@ -41,6 +42,7 @@ import kaleidoscope.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 import turbulence.*
 
 import PtyEscapeError.Reason, Reason.*
@@ -64,14 +66,29 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
     val buffer2: Screen = buffer.copy()
 
     object cursor:
-      private var index: Int = state0.cursor
+      private var index: Ordinal = state0.cursor
 
-      def apply(): Int = index
-      def update(value: Int): Unit = index = value
-      def x: Int = index%buffer2.width
-      def y: Int = index/buffer2.width
-      def x_=(x2: Int): Unit = index = y*buffer2.width + x2.min(buffer2.width - 1).max(0)
-      def y_=(y2: Int): Unit = index = y2.min(buffer2.height - 1).max(0)*buffer2.width + x
+      def apply(): Ordinal = index
+      def update(value: Ordinal): Unit = index = value
+
+      def x: Ordinal = (index.n0%buffer2.width).z
+      def y: Ordinal = (index.n0/buffer2.width).z
+
+      def x_=(x2: Ordinal): Unit =
+        val clamped: Ordinal =
+          if x2 < Prim then Prim
+          else if x2 >= buffer2.width.z then (buffer2.width - 1).z
+          else x2
+
+        index = (y.n0*buffer2.width + clamped.n0).z
+
+      def y_=(y2: Ordinal): Unit =
+        val clamped: Ordinal =
+          if y2 < Prim then Prim
+          else if y2 >= buffer2.height.z then (buffer2.height - 1).z
+          else y2
+
+        index = (clamped.n0*buffer2.width + x.n0).z
 
     var style = state0.style
     var state = state0
@@ -82,9 +99,9 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
     import Context.{Normal, Escape, Csi, Csi2, Osc, Osc2}
 
-    def wipe(cursor: Int): Unit = buffer2.set(cursor, ' ', style, link)
+    def wipe(cursor: Ordinal): Unit = buffer2.set(cursor, ' ', style, link)
 
-    def set(x: Int, y: Int, char: Char, style: Style = style, link: Text = link): Unit =
+    def set(x: Ordinal, y: Ordinal, char: Char, style: Style = style, link: Text = link): Unit =
       buffer2.set(x, y, char, style, link)
 
     def cuu(n: Int): Unit = cursor.y = cursor.y - n
@@ -93,42 +110,42 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
     def cub(n: Int): Unit = cursor.x = cursor.x - n
 
     def cnl(n: Int): Unit =
-      cursor.x = 0
+      cursor.x = Prim
       cursor.y = cursor.y + n
 
     def cpl(n: Int): Unit =
-      cursor.x = 0
+      cursor.x = Prim
       cursor.y = cursor.y - n
 
-    def cha(n: Int): Unit = cursor.x = n - 1
+    def cha(col: Ordinal): Unit = cursor.x = col
 
-    def cup(row: Int, col: Int): Unit =
-      cursor.y = row - 1
-      cursor.x = col - 1
+    def cup(row: Ordinal, col: Ordinal): Unit =
+      cursor.y = row
+      cursor.x = col
 
     def ed(n: Int): Unit = n match
-      case 0 => for i <- cursor() until buffer2.capacity do wipe(i)
-      case 1 => for i <- 0 until cursor() do wipe(i)
+      case 0 => for i <- cursor().n0 until buffer2.capacity do wipe(i.z)
+      case 1 => for i <- 0 until cursor().n0 do wipe(i.z)
 
       case 2 | 3 =>
-        for i <- 0 until buffer2.capacity do wipe(i)
-        cursor() = 0
+        for i <- 0 until buffer2.capacity do wipe(i.z)
+        cursor() = Prim
 
       case n =>
         raise(PtyEscapeError(BadCsiParameter(n, t"ED")))
 
     def el(n: Int): Unit = n match
-      case 0 => for x <- cursor.x until buffer2.width do set(x, cursor.y, ' ')
-      case 1 => for x <- 0 to cursor.x do set(x, cursor.y, ' ')
-      case 2 => for x <- 0 until buffer2.width do set(x, cursor.y, ' ')
+      case 0 => for x <- cursor.x.n0 until buffer2.width do set(x.z, cursor.y, ' ')
+      case 1 => for x <- 0 to cursor.x.n0 do set(x.z, cursor.y, ' ')
+      case 2 => for x <- 0 until buffer2.width do set(x.z, cursor.y, ' ')
       case n => raise(PtyEscapeError(BadCsiParameter(n, t"EL")))
 
     def title(text: Text): Unit = state = state.copy(title = text)
     def setLink(text: Text): Unit = link = text
     def su(n: Int): Unit = buffer2.scroll(n)
     def sd(n: Int): Unit = buffer2.scroll(-n)
-    def hvp(row: Int, col: Int): Unit = cup(row, col)
-    def dsr(): Unit = output.put(t"\e[${cursor.y + 1};${cursor.x + 1}R")
+    def hvp(row: Ordinal, col: Ordinal): Unit = cup(row, col)
+    def dsr(): Unit = output.put(t"\e[${cursor.y.n1};${cursor.x.n1}R")
     def dectcem(visible: Boolean): Unit = state = state.copy(hideCursor = !visible)
     def scp(): Unit = state = state.copy(savedCursor = cursor())
     def rcp(): Unit = cursor() = state.savedCursor
@@ -220,14 +237,14 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
         case 'D' => cub(parseInt(params, 1))
         case 'E' => cnl(parseInt(params, 1))
         case 'F' => cpl(parseInt(params, 1))
-        case 'G' => cha(parseInt(params, 1))
+        case 'G' => cha(parseInt(params, 1).u)
         case 'J' => ed(parseInt(params, 0))
         case 'K' => el(parseInt(params, 0))
         case 'S' => su(parseInt(params, 1))
         case 'T' => sd(parseInt(params, 1))
 
-        case 'H' => val (r, c) = parsePair(params, 1); cup(r, c)
-        case 'f' => val (r, c) = parsePair(params, 1); hvp(r, c)
+        case 'H' => val (r, c) = parsePair(params, 1); cup(r.u, c.u)
+        case 'f' => val (r, c) = parsePair(params, 1); hvp(r.u, c.u)
 
         case 'n' if parseInt(params, 0) == 6                     => dsr()
         case 's' if params.s.isEmpty || parseInt(params, 0) == 6 => scp()
@@ -283,21 +300,21 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
         proceed(Normal)
 
       inline def lf(): Pty =
-        cursor.x = 0
+        cursor.x = Prim
         ff()
 
       inline def ff(): Pty =
-        if cursor.y < buffer2.height - 1 then cursor.y = cursor.y + 1 else su(1)
+        if cursor.y.n0 < buffer2.height - 1 then cursor.y = cursor.y + 1 else su(1)
         proceed(Normal)
 
       inline def cr(): Pty =
-        cursor.x = 0
+        cursor.x = Prim
         proceed(Normal)
 
       inline def put(char: Char): Pty =
         set(cursor.x, cursor.y, char)
         cursor() += 1
-        if cursor() == buffer2.capacity then
+        if cursor().n0 == buffer2.capacity then
           buffer2.scroll(1)
           cursor() -= buffer2.width
 

--- a/lib/yossarian/src/core/yossarian.PtyState.scala
+++ b/lib/yossarian/src/core/yossarian.PtyState.scala
@@ -33,11 +33,12 @@
 package yossarian
 
 import anticipation.*
+import denominative.*
 import gossamer.*
 
 case class PtyState
-  ( cursor:             Int     = 0,
-    savedCursor:        Int     = 0,
+  ( cursor:             Ordinal = Prim,
+    savedCursor:        Ordinal = Prim,
     style:              Style   = Style(),
     focusDetectionMode: Boolean = false,
     focus:              Boolean = true,

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -33,6 +33,7 @@
 package yossarian
 
 import anticipation.*
+import denominative.*
 import gossamer.*
 import rudiments.*
 import spectacular.*
@@ -51,10 +52,10 @@ object internal:
     def linkBuffer: Array[Text] = buffer(3)
     def capacity: Int = charBuffer.length
     def height: Int = capacity/width
-    def offset(x: Int, y: Int): Int = y*width + x
-    def style(x: Int, y: Int): Style = styleBuffer(offset(x, y))
-    def char(x: Int, y: Int): Char = charBuffer(offset(x, y))
-    def link(x: Int, y: Int): Text = linkBuffer(offset(x, y))
+    def offset(x: Ordinal, y: Ordinal): Int = y.n0*width + x.n0
+    def style(x: Ordinal, y: Ordinal): Style = styleBuffer(offset(x, y))
+    def char(x: Ordinal, y: Ordinal): Char = charBuffer(offset(x, y))
+    def link(x: Ordinal, y: Ordinal): Text = linkBuffer(offset(x, y))
     def line: Screen = (charBuffer.length, styleBuffer, charBuffer, linkBuffer)
     def render: Text = String(charBuffer).grouped(width).to(List).map(_.tt).join(t"\n")
 
@@ -85,15 +86,15 @@ object internal:
         charBuffer(start + i) = ' '
         linkBuffer(start + i) = t""
 
-    def set(x: Int, y: Int, char: Char, style: Style, link: Text): Unit =
+    def set(x: Ordinal, y: Ordinal, char: Char, style: Style, link: Text): Unit =
       styleBuffer(offset(x, y)) = style
       charBuffer(offset(x, y)) = char
       linkBuffer(offset(x, y)) = link
 
-    def set(cursor: Int, char: Char, style: Style, link: Text): Unit =
-      styleBuffer(cursor) = style
-      charBuffer(cursor) = char
-      linkBuffer(cursor) = link
+    def set(cursor: Ordinal, char: Char, style: Style, link: Text): Unit =
+      styleBuffer(cursor.n0) = style
+      charBuffer(cursor.n0) = char
+      linkBuffer(cursor.n0) = link
 
     def copy(): Screen =
       val styles = new Array[Style](capacity)

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -43,10 +43,10 @@ object Tests extends Suite(m"Yossarian Tests"):
 
     def fresh: Pty = Pty(10, 4)
 
-    def cell(pty: Pty, x: Int, y: Int): Char = pty.buffer.char(x, y)
+    def cell(pty: Pty, x: Ordinal, y: Ordinal): Char = pty.buffer.char(x, y)
 
-    def row(pty: Pty, y: Int): Text =
-      Text(String((0 until pty.buffer.width).map(pty.buffer.char(_, y)).toArray))
+    def row(pty: Pty, y: Ordinal): Text =
+      Text(String((0 until pty.buffer.width).map(i => pty.buffer.char(i.z, y)).toArray))
 
     def drainOutput(pty: Pty): Text =
       pty.output.stop()
@@ -54,111 +54,111 @@ object Tests extends Suite(m"Yossarian Tests"):
 
     suite(m"Plain text"):
       test(m"writing text places characters in cells"):
-        row(fresh.consume(t"hi"), 0)
+        row(fresh.consume(t"hi"), Prim)
       . assert(_ == t"hi        ")
 
       test(m"cursor advances after writing"):
         fresh.consume(t"hi").state0.cursor
-      . assert(_ == 2)
+      . assert(_ == Ter)
 
       test(m"writing past row width wraps to next row"):
         val pty = fresh.consume(t"0123456789X")
-        (cell(pty, 0, 1), cell(pty, 9, 0))
+        (cell(pty, Prim, Sec), cell(pty, 9.z, Prim))
       . assert(_ == ('X', '9'))
 
     suite(m"Carriage return and line feed"):
       test(m"CR returns to column 0 of same row"):
         val pty = fresh.consume(t"abc\rX")
-        row(pty, 0)
+        row(pty, Prim)
       . assert(_ == t"Xbc       ")
 
       test(m"LF advances to next row at column 0"):
         val pty = fresh.consume(t"ab\nc")
-        (row(pty, 0), row(pty, 1))
+        (row(pty, Prim), row(pty, Sec))
       . assert(_ == (t"ab        ", t"c         "))
 
     suite(m"Backspace"):
       test(m"BS moves cursor left without erasing"):
         val pty = fresh.consume(t"abc\b")
-        (row(pty, 0), pty.state0.cursor)
-      . assert(_ == (t"abc       ", 2))
+        (row(pty, Prim), pty.state0.cursor)
+      . assert(_ == (t"abc       ", Ter))
 
       test(m"BS+SP+BS erases the previous character"):
         val pty = fresh.consume(t"abc\b \b")
-        (row(pty, 0), pty.state0.cursor)
-      . assert(_ == (t"ab        ", 2))
+        (row(pty, Prim), pty.state0.cursor)
+      . assert(_ == (t"ab        ", Ter))
 
       test(m"BS at column 0 stays at column 0"):
         val pty = fresh.consume(t"\b")
         pty.state0.cursor
-      . assert(_ == 0)
+      . assert(_ == Prim)
 
     suite(m"Cursor positioning"):
       test(m"CUP places cursor at row 3 col 5 (1-indexed)"):
         val pty = fresh.consume(t"$Esc[3;5HX")
-        cell(pty, 4, 2)
+        cell(pty, Quin, Ter)
       . assert(_ == 'X')
 
       test(m"CUP with no parameters homes the cursor"):
         val pty = fresh.consume(t"abc${Esc}[HZ")
-        cell(pty, 0, 0)
+        cell(pty, Prim, Prim)
       . assert(_ == 'Z')
 
       test(m"CUU moves cursor up two rows"):
         val pty = fresh.consume(t"$Esc[4;5H$Esc[2AX")
-        cell(pty, 4, 1)
+        cell(pty, Quin, Sec)
       . assert(_ == 'X')
 
       test(m"CUD moves cursor down one row"):
         val pty = fresh.consume(t"$Esc[1;1H$Esc[1BX")
-        cell(pty, 0, 1)
+        cell(pty, Prim, Sec)
       . assert(_ == 'X')
 
       test(m"CUF moves cursor right within row"):
         val pty = fresh.consume(t"$Esc[1;1H$Esc[3CX")
-        cell(pty, 3, 0)
+        cell(pty, Quat, Prim)
       . assert(_ == 'X')
 
       test(m"CUF clamps at end of row, not into next row"):
         val pty = fresh.consume(t"$Esc[1;1H$Esc[20CX")
-        cell(pty, 9, 0)
+        cell(pty, 9.z, Prim)
       . assert(_ == 'X')
 
       test(m"CUB moves cursor left within row"):
         val pty = fresh.consume(t"$Esc[1;5H$Esc[2DX")
-        cell(pty, 2, 0)
+        cell(pty, Ter, Prim)
       . assert(_ == 'X')
 
     suite(m"Erase"):
       test(m"ED 2 clears the entire screen"):
         val pty = fresh.consume(t"abc\ndef$Esc[2J")
-        (row(pty, 0), row(pty, 1))
+        (row(pty, Prim), row(pty, Sec))
       . assert(_ == (t"          ", t"          "))
 
       test(m"EL 2 clears the current line"):
         val pty = fresh.consume(t"abcdef$Esc[1;1H$Esc[2K")
-        row(pty, 0)
+        row(pty, Prim)
       . assert(_ == t"          ")
 
     suite(m"SGR"):
       test(m"SGR 1 enables bold"):
         val pty = fresh.consume(t"$Esc[1mX")
-        pty.buffer.style(0, 0).bold
+        pty.buffer.style(Prim, Prim).bold
       . assert(_ == true)
 
       test(m"SGR 0 resets bold"):
         val pty = fresh.consume(t"$Esc[1mX$Esc[0mY")
-        (pty.buffer.style(0, 0).bold, pty.buffer.style(1, 0).bold)
+        (pty.buffer.style(Prim, Prim).bold, pty.buffer.style(Sec, Prim).bold)
       . assert(_ == (true, false))
 
       test(m"SGR 38;2;R;G;B sets a 24-bit foreground"):
         val pty = fresh.consume(t"$Esc[38;2;100;150;200mX")
-        pty.buffer.style(0, 0).foreground
+        pty.buffer.style(Prim, Prim).foreground
       . assert(_ == Chroma(100, 150, 200))
 
       test(m"SGR 38;5;N;1m applies bold after extended colour"):
         val pty = fresh.consume(t"$Esc[38;5;201;1mX")
-        pty.buffer.style(0, 0).bold
+        pty.buffer.style(Prim, Prim).bold
       . assert(_ == true)
 
     suite(m"OSC"):
@@ -174,17 +174,17 @@ object Tests extends Suite(m"Yossarian Tests"):
 
       test(m"OSC 8 with empty params sets a hyperlink"):
         val pty = fresh.consume(t"$Esc]8;;https://example.com${Bel}X")
-        pty.buffer.link(0, 0)
+        pty.buffer.link(Prim, Prim)
       . assert(_ == t"https://example.com")
 
       test(m"OSC 8 with params field sets a hyperlink"):
         val pty = fresh.consume(t"$Esc]8;id=123;https://example.com${Bel}X")
-        pty.buffer.link(0, 0)
+        pty.buffer.link(Prim, Prim)
       . assert(_ == t"https://example.com")
 
     suite(m"DEC private modes"):
       test(m"unknown private mode is silently ignored"):
-        fresh.consume(t"$Esc[?1049hX").buffer.char(0, 0)
+        fresh.consume(t"$Esc[?1049hX").buffer.char(Prim, Prim)
       . assert(_ == 'X')
 
       test(m"DECTCEM ?25 l sets hideCursor in state"):
@@ -202,7 +202,7 @@ object Tests extends Suite(m"Yossarian Tests"):
 
     suite(m"Palette"):
       test(m"bright black (palette 8) is distinct from black"):
-        val black = fresh.consume(t"$Esc[30mA").buffer.style(0, 0).foreground
-        val brightBlack = fresh.consume(t"$Esc[90mA").buffer.style(0, 0).foreground
+        val black = fresh.consume(t"$Esc[30mA").buffer.style(Prim, Prim).foreground
+        val brightBlack = fresh.consume(t"$Esc[90mA").buffer.style(Prim, Prim).foreground
         black != brightBlack
       . assert(_ == true)


### PR DESCRIPTION
Yossarian's `Pty` state machine used `Int` for every numeric quantity — terminal positions, ANSI parameters, deltas, mode codes, and dimensions. Mixing them caused constant 0-vs-1 friction (ANSI escape sequences address rows and columns starting at 1, but the cell-buffer arrays are indexed from 0); the recently-fixed CUP/HVP arg-order bug from the parent PR was a direct symptom. This PR moves every value that names a position to `Ordinal` from Denominative, leaving counts/deltas/dimensions/mode codes as `Int`. The 0-vs-1 conversion now happens once, explicitly, at each boundary.

## What changed for users

`PtyState.cursor` and `PtyState.savedCursor` are now `Ordinal` instead of `Int`, defaulting to `Prim` instead of `0`. The cell-buffer accessors on `Screen` (`char`, `style`, `link`, `set`) take `Ordinal` x and y instead of `Int`. The `cha` / `cup` / `hvp` CSI handlers and the `Pty` cursor object's x/y getters and setters are also `Ordinal`. Counts (`cuu(n)`, `cud(n)`, `cuf(n)`, `cub(n)`, `scroll(n)`), dimensions (`width`, `height`, `capacity`) and ANSI mode codes (`ed`/`el` parameters, the `sgr` list) keep their `Int` types — they're not positions.

```scala
import yossarian.*, denominative.*
import strategies.throwUnsafely

val pty = Pty(80, 24).consume(t"hello")
pty.state0.cursor       // Ordinal, currently equal to Quin (5)
pty.buffer.char(Prim, Prim)  // 'h' — type-safe (Ordinal, Ordinal)
```

The conversion at each boundary is now syntactically obvious:

```scala
// 1-based ANSI input → Ordinal
case 'H' => val (r, c) = parsePair(params, 1); cup(r.u, c.u)

// Ordinal → 1-based ANSI output
def dsr(): Unit = output.put(t"\e[${cursor.y.n1};${cursor.x.n1}R")
```

Inside the cursor object, `x_=`/`y_=` clamp explicitly via `Ordinal` comparisons (Ordinal exposes `lt`/`gt`/`le`/`ge` but no built-in `min`/`max` between two ordinals); the linear cursor uses `+=` / `-=` against `Int` via symbolism's `Addable` extension.

All 30 existing tests still pass. The test helpers `cell(pty, x, y)` and `row(pty, y)` now take `Ordinal`, with assertions using `Prim`/`Sec`/`Ter`/`Quat`/`Quin` for low-numbered positions and `n.z` for larger ones.

Stacked on #962.