### PR TITLE
Tab, DECSC/DECRC, RIS, string-discard sequences

### DIFF
--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -58,15 +58,19 @@ object Pty:
     case _ =>
       Stream()
 
-case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
+case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
   def stream: Stream[Text] = output.stream
+
+  def title: Text = state.title
+  def cursor: Ordinal = state.cursor
+  def cursorVisible: Boolean = !state.hideCursor
 
   def consume(input: Text): Pty raises PtyEscapeError =
     val escBuffer = StringBuilder()
     val buffer2: Screen = buffer.copy()
 
     object cursor:
-      private var index: Ordinal = state0.cursor
+      private var index: Ordinal = state.cursor
 
       def apply(): Ordinal = index
       def update(value: Ordinal): Unit = index = value
@@ -90,14 +94,14 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
         index = (clamped.n0*buffer2.width + x.n0).z
 
-    var style = state0.style
-    var state = state0
-    var link = state0.link
+    var style = state.style
+    var state2 = state
+    var link = state.link
 
     enum Context:
-      case Normal, Escape, Csi, Csi2, Osc, Osc2
+      case Normal, Escape, Csi, Csi2, Osc, Osc2, EatString, EatString2
 
-    import Context.{Normal, Escape, Csi, Csi2, Osc, Osc2}
+    import Context.{Normal, Escape, Csi, Csi2, Osc, Osc2, EatString, EatString2}
 
     def wipe(cursor: Ordinal): Unit = buffer2.set(cursor, ' ', style, link)
 
@@ -140,18 +144,37 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
       case 2 => for x <- 0 until buffer2.width do set(x.z, cursor.y, ' ')
       case n => raise(PtyEscapeError(BadCsiParameter(n, t"EL")))
 
-    def title(text: Text): Unit = state = state.copy(title = text)
+    def title(text: Text): Unit = state2 = state2.copy(title = text)
     def setLink(text: Text): Unit = link = text
     def su(n: Int): Unit = buffer2.scroll(n)
     def sd(n: Int): Unit = buffer2.scroll(-n)
     def hvp(row: Ordinal, col: Ordinal): Unit = cup(row, col)
     def dsr(): Unit = output.put(t"\e[${cursor.y.n1};${cursor.x.n1}R")
-    def dectcem(visible: Boolean): Unit = state = state.copy(hideCursor = !visible)
-    def scp(): Unit = state = state.copy(savedCursor = cursor())
-    def rcp(): Unit = cursor() = state.savedCursor
-    def detectFocus(value: Boolean): Unit = state = state.copy(focusDetectionMode = value)
-    def focus(value: Boolean): Unit = state = state.copy(focus = value)
-    def bcp(value: Boolean): Unit = state = state.copy(bracketedPasteMode = value)
+    def dectcem(visible: Boolean): Unit = state2 = state2.copy(hideCursor = !visible)
+    def scp(): Unit = state2 = state2.copy(savedCursor = cursor())
+    def rcp(): Unit = cursor() = state2.savedCursor
+    def detectFocus(value: Boolean): Unit = state2 = state2.copy(focusDetectionMode = value)
+    def focus(value: Boolean): Unit = state2 = state2.copy(focus = value)
+    def bcp(value: Boolean): Unit = state2 = state2.copy(bracketedPasteMode = value)
+
+    def ht(): Unit =
+      val nextStop = ((cursor.x.n0/8 + 1)*8).z
+      cursor.x = if nextStop >= buffer2.width.z then (buffer2.width - 1).z else nextStop
+
+    def decsc(): Unit =
+      state2 = state2.copy(savedCursor = cursor(), savedStyle = style, savedLink = link)
+
+    def decrc(): Unit =
+      cursor() = state2.savedCursor
+      style = state2.savedStyle
+      link = state2.savedLink
+
+    def ris(): Unit =
+      style = Style()
+      link = t""
+      for i <- 0 until buffer2.capacity do wipe(i.z)
+      cursor() = Prim
+      state2 = PtyState()
 
     def osc(command: Text): Unit = command match
       case r"8;([^;]*);$text(.*)" => setLink(text)
@@ -254,7 +277,6 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
         case _ => raise(PtyEscapeError(BadCsiCommand(params, char)))
 
-    // Uses the Ubuntu color palette
     def palette(n: Int): Chroma = n match
       case 0  => Chroma(001, 001, 001)
       case 1  => Chroma(222, 056, 043)
@@ -321,7 +343,7 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
         proceed(Normal)
 
       if index >= input.length
-      then Pty(buffer2, state.copy(cursor = cursor(), style = style, link = link), output = output)
+      then Pty(buffer2, state2.copy(cursor = cursor(), style = style, link = link), output = output)
       else
         val current: Char = unsafely(input.s.charAt(index))
 
@@ -337,7 +359,7 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
               case '\u0006' => proceed(Normal) // ack()
               case '\u0007' => proceed(Normal) // bel()
               case '\u0008' => bs()
-              case '\u0009' => proceed(Normal) // ht()
+              case '\u0009' => ht(); proceed(Normal)
               case '\u000a' => lf()
               case '\u000b' => proceed(Normal) // vt()
               case '\u000c' => ff()
@@ -364,13 +386,29 @@ case class Pty(buffer: Screen, state0: PtyState, output: Spool[Text]):
 
           case Escape =>
             current match
-              case '['                                      => recur(index + 1, Csi)
-              case ']'                                      => recur(index + 1, Osc)
-              case 'N' | 'O' | 'P' | '\\' | 'X' | '^' | '_' => proceed(Normal)
+              case '['                            => recur(index + 1, Csi)
+              case ']'                            => recur(index + 1, Osc)
+              case 'P' | 'X' | '^' | '_'          => recur(index + 1, EatString)
+              case '7'                            => decsc(); proceed(Normal)
+              case '8'                            => decrc(); proceed(Normal)
+              case 'c'                            => ris(); proceed(Normal)
+              case 'D' | 'E' | 'M' | 'N' | 'O'    => proceed(Normal) // single-char Fe escapes
+              case '\\'                           => proceed(Normal) // bare ST is ignored
 
               case char =>
                 raise(PtyEscapeError(BadFeEscape(char)))
                 proceed(Normal)
+
+          case EatString =>
+            current match
+              case '\u0007'                          => proceed(Normal) // BEL ends the string
+              case '\u001b'                          => proceed(EatString2)
+              case _                                 => proceed(EatString)
+
+          case EatString2 =>
+            current match
+              case '\\' => proceed(Normal)
+              case _    => proceed(EatString)
 
           case Osc =>
             current match

--- a/lib/yossarian/src/core/yossarian.PtyState.scala
+++ b/lib/yossarian/src/core/yossarian.PtyState.scala
@@ -39,6 +39,8 @@ import gossamer.*
 case class PtyState
   ( cursor:             Ordinal = Prim,
     savedCursor:        Ordinal = Prim,
+    savedStyle:         Style   = Style(),
+    savedLink:          Text    = t"",
     style:              Style   = Style(),
     focusDetectionMode: Boolean = false,
     focus:              Boolean = true,

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -58,7 +58,7 @@ object Tests extends Suite(m"Yossarian Tests"):
       . assert(_ == t"hi        ")
 
       test(m"cursor advances after writing"):
-        fresh.consume(t"hi").state0.cursor
+        fresh.consume(t"hi").state.cursor
       . assert(_ == Ter)
 
       test(m"writing past row width wraps to next row"):
@@ -80,17 +80,17 @@ object Tests extends Suite(m"Yossarian Tests"):
     suite(m"Backspace"):
       test(m"BS moves cursor left without erasing"):
         val pty = fresh.consume(t"abc\b")
-        (row(pty, Prim), pty.state0.cursor)
+        (row(pty, Prim), pty.state.cursor)
       . assert(_ == (t"abc       ", Ter))
 
       test(m"BS+SP+BS erases the previous character"):
         val pty = fresh.consume(t"abc\b \b")
-        (row(pty, Prim), pty.state0.cursor)
+        (row(pty, Prim), pty.state.cursor)
       . assert(_ == (t"ab        ", Ter))
 
       test(m"BS at column 0 stays at column 0"):
         val pty = fresh.consume(t"\b")
-        pty.state0.cursor
+        pty.state.cursor
       . assert(_ == Prim)
 
     suite(m"Cursor positioning"):
@@ -164,12 +164,12 @@ object Tests extends Suite(m"Yossarian Tests"):
     suite(m"OSC"):
       test(m"OSC 0 sets the window title (BEL terminator)"):
         val pty = fresh.consume(t"$Esc]0;My Title$Bel")
-        pty.state0.title
+        pty.state.title
       . assert(_ == t"My Title")
 
       test(m"OSC 0 sets the window title (ST terminator)"):
         val pty = fresh.consume(t"$Esc]0;My Title$Esc\\")
-        pty.state0.title
+        pty.state.title
       . assert(_ == t"My Title")
 
       test(m"OSC 8 with empty params sets a hyperlink"):
@@ -188,11 +188,11 @@ object Tests extends Suite(m"Yossarian Tests"):
       . assert(_ == 'X')
 
       test(m"DECTCEM ?25 l sets hideCursor in state"):
-        fresh.consume(t"$Esc[?25l").state0.hideCursor
+        fresh.consume(t"$Esc[?25l").state.hideCursor
       . assert(_ == true)
 
       test(m"DECTCEM ?25 h clears hideCursor in state"):
-        fresh.consume(t"$Esc[?25l$Esc[?25h").state0.hideCursor
+        fresh.consume(t"$Esc[?25l$Esc[?25h").state.hideCursor
       . assert(_ == false)
 
     suite(m"Output channel"):
@@ -206,3 +206,54 @@ object Tests extends Suite(m"Yossarian Tests"):
         val brightBlack = fresh.consume(t"$Esc[90mA").buffer.style(Prim, Prim).foreground
         black != brightBlack
       . assert(_ == true)
+
+    suite(m"Tab"):
+      test(m"tab from column 0 advances to column 8"):
+        fresh.consume(t"\tX").state.cursor
+      . assert(_ == 9.z)
+
+      test(m"tab from column 7 still advances to column 8"):
+        Pty(20, 4).consume(t"abcdefg\tX").state.cursor
+      . assert(_ == 9.z)
+
+      test(m"tab past last tab stop clamps to last column"):
+        fresh.consume(t"abcdefghi\t").state.cursor
+      . assert(_ == 9.z)
+
+    suite(m"DECSC / DECRC"):
+      test(m"ESC 8 restores cursor saved by ESC 7"):
+        fresh.consume(t"$Esc[3;5H${Esc}7$Esc[1;1H${Esc}8X").state.cursor
+      . assert(_ == (2*10 + 5).z)
+
+      test(m"ESC 8 restores style saved by ESC 7"):
+        val pty = fresh.consume(t"$Esc[1m${Esc}7$Esc[0m${Esc}8X")
+        pty.buffer.style(Prim, Prim).bold
+      . assert(_ == true)
+
+    suite(m"RIS"):
+      test(m"ESC c clears screen, homes cursor, and resets style"):
+        val pty = fresh.consume(t"$Esc[1;31mhello${Esc}c")
+        (row(pty, Prim), pty.state.cursor, pty.buffer.style(Prim, Prim).bold)
+      . assert(_ == (t"          ", Prim, false))
+
+    suite(m"String-discard sequences"):
+      test(m"DCS string is silently absorbed up to ST"):
+        fresh.consume(t"${Esc}Psome data$Esc\\X").buffer.char(Prim, Prim)
+      . assert(_ == 'X')
+
+      test(m"APC string is silently absorbed up to BEL"):
+        fresh.consume(t"${Esc}_app data${Bel}X").buffer.char(Prim, Prim)
+      . assert(_ == 'X')
+
+    suite(m"Top-level accessors"):
+      test(m"pty.title forwards to state.title"):
+        fresh.consume(t"$Esc]0;My Window$Bel").title
+      . assert(_ == t"My Window")
+
+      test(m"pty.cursor forwards to state.cursor"):
+        fresh.consume(t"hi").cursor
+      . assert(_ == Ter)
+
+      test(m"pty.cursorVisible reflects DECTCEM"):
+        (fresh.cursorVisible, fresh.consume(t"$Esc[?25l").cursorVisible)
+      . assert(_ == (true, false))


### PR DESCRIPTION
A small cleanup PR that adds five commonly-emitted escape sequences Yossarian was previously missing or fudging, plus a small surface-level tidy on `Pty`.

## What changed for users

Five new escape sequences are now handled:

- **Tab (`\t`)** — was a no-op; now advances the cursor to the next 8-column tab stop, clamped to `width - 1` if past the last stop within the screen width.
- **`ESC 7` / `ESC 8` (DECSC / DECRC)** — save and restore the cursor position, the SGR style, and the active hyperlink together. `PtyState` carries new `savedStyle` and `savedLink` fields alongside `savedCursor`. The simpler `\e[s` / `\e[u` (SCP / RCP) still save only the cursor.
- **`ESC c` (RIS)** — full reset: screen cleared, cursor homed, default style and link restored, `state` replaced with a fresh `PtyState`.
- **DCS / SOS / PM / APC strings** (introduced by `ESC P` / `ESC X` / `ESC ^` / `ESC _`) — silently absorbed up to ST or BEL via two new `EatString` / `EatString2` contexts. Previously they were treated as single-character Fe escapes, leaving the rest of the string to be interpreted as cell content.

`Pty` gains forwarder accessors so the common bits of state can be read without going through the case-class field:

```scala
pty.title           // Text
pty.cursor          // Ordinal
pty.cursorVisible   // Boolean (the inverse of state.hideCursor)
```

The case-class field formerly named `state0` is now `state` (and the consume-local mutable mirror is `state2`, matching the existing `buffer` / `buffer2` pattern). Anyone reading `pty.state0.…` will need to update to `pty.state.…`; the new forwarders cover the most common cases.

The misleading "Uses the Ubuntu color palette" comment in front of the palette table is dropped — the values aren't actually Ubuntu's defaults.

11 new tests cover the new sequences and the accessor surface; all 41 tests pass.