### PR TITLE
Yossarian: insert/delete, scroll regions, deferred wrap, DA, REP

### DIFF
--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -185,6 +185,11 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
     def hvp(row: Ordinal, col: Ordinal): Unit = cup(row, col)
     def dsr(): Unit = output.put(t"\e[${cursor.y.n1};${cursor.x.n1}R")
+    // Primary DA: claim VT102 with advanced video option. The response
+    // shape `\e[?1;2c` is what xterm and most modern terminals reply.
+    def primaryDa(): Unit = output.put(t"\e[?1;2c")
+    // Secondary DA: terminal type 0 (VT100), firmware version 0, hardware 0.
+    def secondaryDa(): Unit = output.put(t"\e[>0;0;0c")
     def dectcem(visible: Boolean): Unit = state2 = state2.copy(hideCursor = !visible)
     def scp(): Unit = state2 = state2.copy(savedCursor = cursor())
     def rcp(): Unit = cursor() = state2.savedCursor
@@ -409,6 +414,8 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         case 'u' if params.s.isEmpty                             => rcp()
         case 'I' if params.s.isEmpty                             => focus(true)
         case 'O' if params.s.isEmpty                             => focus(false)
+        case 'c' if params.s.isEmpty || params.s == "0"          => primaryDa()
+        case 'c' if params.s.startsWith(">")                     => secondaryDa()
 
         case _ => raise(PtyEscapeError(BadCsiCommand(params, char)))
 
@@ -476,8 +483,10 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
           // Setters above cleared pendingWrap; nothing more to do.
         set(cursor.x, cursor.y, char)
         lastChar = char
-        if cursor.x.n0 == buffer2.width - 1 then pendingWrap = true
-        else cursor.x = cursor.x + 1
+        if cursor.x.n0 == buffer2.width - 1
+        then pendingWrap = true
+        else
+          cursor.x = cursor.x + 1
 
         proceed(Normal)
 

--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -161,6 +161,87 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
       val nextStop = ((cursor.x.n0/8 + 1)*8).z
       cursor.x = if nextStop >= buffer2.width.z then (buffer2.width - 1).z else nextStop
 
+    def ich(n: Int): Unit =
+      val row = cursor.y.n0
+      val col = cursor.x.n0
+      val width = buffer2.width
+      val shift = n.min(width - col)
+      var i = width - 1
+      while i >= col + shift do
+        buffer2.set(i.z, row.z, buffer2.char((i - shift).z, row.z),
+            buffer2.style((i - shift).z, row.z), buffer2.link((i - shift).z, row.z))
+        i -= 1
+      var j = col
+      while j < col + shift do
+        buffer2.set(j.z, row.z, ' ', style, link)
+        j += 1
+
+    def dch(n: Int): Unit =
+      val row = cursor.y.n0
+      val col = cursor.x.n0
+      val width = buffer2.width
+      val shift = n.min(width - col)
+      var i = col
+      while i < width - shift do
+        buffer2.set(i.z, row.z, buffer2.char((i + shift).z, row.z),
+            buffer2.style((i + shift).z, row.z), buffer2.link((i + shift).z, row.z))
+        i += 1
+      var j = width - shift
+      while j < width do
+        buffer2.set(j.z, row.z, ' ', style, link)
+        j += 1
+
+    def ech(n: Int): Unit =
+      val row = cursor.y.n0
+      val col = cursor.x.n0
+      val end = (col + n).min(buffer2.width)
+      var i = col
+      while i < end do
+        buffer2.set(i.z, row.z, ' ', style, link)
+        i += 1
+
+    def il(n: Int): Unit =
+      val top = cursor.y.n0
+      val height = buffer2.height
+      val width = buffer2.width
+      val shift = n.min(height - top)
+      var r = height - 1
+      while r >= top + shift do
+        var c = 0
+        while c < width do
+          buffer2.set(c.z, r.z, buffer2.char(c.z, (r - shift).z),
+              buffer2.style(c.z, (r - shift).z), buffer2.link(c.z, (r - shift).z))
+          c += 1
+        r -= 1
+      var rr = top
+      while rr < top + shift do
+        var c = 0
+        while c < width do
+          buffer2.set(c.z, rr.z, ' ', style, link)
+          c += 1
+        rr += 1
+
+    def dl(n: Int): Unit =
+      val top = cursor.y.n0
+      val height = buffer2.height
+      val width = buffer2.width
+      val shift = n.min(height - top)
+      var r = top
+      while r < height - shift do
+        var c = 0
+        while c < width do
+          buffer2.set(c.z, r.z, buffer2.char(c.z, (r + shift).z),
+              buffer2.style(c.z, (r + shift).z), buffer2.link(c.z, (r + shift).z))
+          c += 1
+        r += 1
+      var rr = height - shift
+      while rr < height do
+        var c = 0
+        while c < width do
+          buffer2.set(c.z, rr.z, ' ', style, link)
+          c += 1
+        rr += 1
+
     def decsc(): Unit =
       state2 = state2.copy(savedCursor = cursor(), savedStyle = style, savedLink = link)
 
@@ -265,6 +346,11 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         case 'K' => el(parseInt(params, 0))
         case 'S' => su(parseInt(params, 1))
         case 'T' => sd(parseInt(params, 1))
+        case '@' => ich(parseInt(params, 1))
+        case 'P' => dch(parseInt(params, 1))
+        case 'L' => il(parseInt(params, 1))
+        case 'M' => dl(parseInt(params, 1))
+        case 'X' => ech(parseInt(params, 1))
 
         case 'H' => val (r, c) = parsePair(params, 1); cup(r.u, c.u)
         case 'f' => val (r, c) = parsePair(params, 1); hvp(r.u, c.u)

--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -48,7 +48,8 @@ import turbulence.*
 import PtyEscapeError.Reason, Reason.*
 
 object Pty:
-  def apply(width: Int, height: Int): Pty = Pty(Screen(width, height), PtyState(), Spool())
+  def apply(width: Int, height: Int): Pty =
+    Pty(Screen(width, height), PtyState(scrollBottom = (height - 1).z), Spool())
 
   def stream(pty: Pty, in: Stream[Text]): Stream[Pty] raises PtyEscapeError = in match
     case head #:: tail =>
@@ -69,16 +70,23 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
     val escBuffer = StringBuilder()
     val buffer2: Screen = buffer.copy()
 
+    var pendingWrap: Boolean = state.pendingWrap
+    var lastChar: Char = ' '
+
     object cursor:
       private var index: Ordinal = state.cursor
 
       def apply(): Ordinal = index
-      def update(value: Ordinal): Unit = index = value
+
+      def update(value: Ordinal): Unit =
+        pendingWrap = false
+        index = value
 
       def x: Ordinal = (index.n0%buffer2.width).z
       def y: Ordinal = (index.n0/buffer2.width).z
 
       def x_=(x2: Ordinal): Unit =
+        pendingWrap = false
         val clamped: Ordinal =
           if x2 < Prim then Prim
           else if x2 >= buffer2.width.z then (buffer2.width - 1).z
@@ -87,6 +95,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         index = (y.n0*buffer2.width + clamped.n0).z
 
       def y_=(y2: Ordinal): Unit =
+        pendingWrap = false
         val clamped: Ordinal =
           if y2 < Prim then Prim
           else if y2 >= buffer2.height.z then (buffer2.height - 1).z
@@ -94,9 +103,14 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
         index = (clamped.n0*buffer2.width + x.n0).z
 
+      // Internal advancement that does NOT clear pendingWrap (used by put).
+      def setIndex(value: Ordinal): Unit = index = value
+
     var style = state.style
     var state2 = state
     var link = state.link
+    var scrollTop: Ordinal = state.scrollTop
+    var scrollBottom: Ordinal = state.scrollBottom
 
     enum Context:
       case Normal, Escape, Csi, Csi2, Osc, Osc2, EatString, EatString2
@@ -146,8 +160,29 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
     def title(text: Text): Unit = state2 = state2.copy(title = text)
     def setLink(text: Text): Unit = link = text
-    def su(n: Int): Unit = buffer2.scroll(n)
-    def sd(n: Int): Unit = buffer2.scroll(-n)
+    def su(n: Int): Unit = buffer2.scroll(n, scrollTop.n0, scrollBottom.n0)
+    def sd(n: Int): Unit = buffer2.scroll(-n, scrollTop.n0, scrollBottom.n0)
+
+    def decstbm(top: Ordinal, bottom: Ordinal): Unit =
+      val t = if top < Prim then Prim else top
+      val b = if bottom >= buffer2.height.z then (buffer2.height - 1).z else bottom
+      if t < b then
+        scrollTop = t
+        scrollBottom = b
+        cursor() = (t.n0*buffer2.width).z
+
+    def ind(): Unit =
+      if cursor.y == scrollBottom then su(1)
+      else if cursor.y.n0 < buffer2.height - 1 then cursor.y = cursor.y + 1
+
+    def ri(): Unit =
+      if cursor.y == scrollTop then sd(1)
+      else if cursor.y > Prim then cursor.y = cursor.y - 1
+
+    def nel(): Unit =
+      cursor.x = Prim
+      ind()
+
     def hvp(row: Ordinal, col: Ordinal): Unit = cup(row, col)
     def dsr(): Unit = output.put(t"\e[${cursor.y.n1};${cursor.x.n1}R")
     def dectcem(visible: Boolean): Unit = state2 = state2.copy(hideCursor = !visible)
@@ -202,45 +237,51 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
     def il(n: Int): Unit =
       val top = cursor.y.n0
-      val height = buffer2.height
-      val width = buffer2.width
-      val shift = n.min(height - top)
-      var r = height - 1
-      while r >= top + shift do
-        var c = 0
-        while c < width do
-          buffer2.set(c.z, r.z, buffer2.char(c.z, (r - shift).z),
-              buffer2.style(c.z, (r - shift).z), buffer2.link(c.z, (r - shift).z))
-          c += 1
-        r -= 1
-      var rr = top
-      while rr < top + shift do
-        var c = 0
-        while c < width do
-          buffer2.set(c.z, rr.z, ' ', style, link)
-          c += 1
-        rr += 1
+      // IL only operates if cursor is inside the scroll region. The bottom
+      // limit is the scroll region's bottom (not the screen bottom).
+      if top < scrollTop.n0 || top > scrollBottom.n0 then ()
+      else
+        val width = buffer2.width
+        val bottom = scrollBottom.n0
+        val shift = n.min(bottom - top + 1)
+        var r = bottom
+        while r >= top + shift do
+          var c = 0
+          while c < width do
+            buffer2.set(c.z, r.z, buffer2.char(c.z, (r - shift).z),
+                buffer2.style(c.z, (r - shift).z), buffer2.link(c.z, (r - shift).z))
+            c += 1
+          r -= 1
+        var rr = top
+        while rr < top + shift do
+          var c = 0
+          while c < width do
+            buffer2.set(c.z, rr.z, ' ', style, link)
+            c += 1
+          rr += 1
 
     def dl(n: Int): Unit =
       val top = cursor.y.n0
-      val height = buffer2.height
-      val width = buffer2.width
-      val shift = n.min(height - top)
-      var r = top
-      while r < height - shift do
-        var c = 0
-        while c < width do
-          buffer2.set(c.z, r.z, buffer2.char(c.z, (r + shift).z),
-              buffer2.style(c.z, (r + shift).z), buffer2.link(c.z, (r + shift).z))
-          c += 1
-        r += 1
-      var rr = height - shift
-      while rr < height do
-        var c = 0
-        while c < width do
-          buffer2.set(c.z, rr.z, ' ', style, link)
-          c += 1
-        rr += 1
+      if top < scrollTop.n0 || top > scrollBottom.n0 then ()
+      else
+        val width = buffer2.width
+        val bottom = scrollBottom.n0
+        val shift = n.min(bottom - top + 1)
+        var r = top
+        while r <= bottom - shift do
+          var c = 0
+          while c < width do
+            buffer2.set(c.z, r.z, buffer2.char(c.z, (r + shift).z),
+                buffer2.style(c.z, (r + shift).z), buffer2.link(c.z, (r + shift).z))
+            c += 1
+          r += 1
+        var rr = bottom - shift + 1
+        while rr <= bottom do
+          var c = 0
+          while c < width do
+            buffer2.set(c.z, rr.z, ' ', style, link)
+            c += 1
+          rr += 1
 
     def decsc(): Unit =
       state2 = state2.copy(savedCursor = cursor(), savedStyle = style, savedLink = link)
@@ -253,9 +294,11 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
     def ris(): Unit =
       style = Style()
       link = t""
+      scrollTop = Prim
+      scrollBottom = (buffer2.height - 1).z
       for i <- 0 until buffer2.capacity do wipe(i.z)
       cursor() = Prim
-      state2 = PtyState()
+      state2 = PtyState(scrollBottom = scrollBottom)
 
     def osc(command: Text): Unit = command match
       case r"8;([^;]*);$text(.*)" => setLink(text)
@@ -355,6 +398,12 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         case 'H' => val (r, c) = parsePair(params, 1); cup(r.u, c.u)
         case 'f' => val (r, c) = parsePair(params, 1); hvp(r.u, c.u)
 
+        case 'r' =>
+          if params.s.isEmpty then decstbm(Prim, (buffer2.height - 1).z)
+          else
+            val (top, bot) = parsePair(params, 1)
+            decstbm(top.u, bot.u)
+
         case 'n' if parseInt(params, 0) == 6                     => dsr()
         case 's' if params.s.isEmpty || parseInt(params, 0) == 6 => scp()
         case 'u' if params.s.isEmpty                             => rcp()
@@ -409,10 +458,11 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
       inline def lf(): Pty =
         cursor.x = Prim
-        ff()
+        ind()
+        proceed(Normal)
 
       inline def ff(): Pty =
-        if cursor.y.n0 < buffer2.height - 1 then cursor.y = cursor.y + 1 else su(1)
+        ind()
         proceed(Normal)
 
       inline def cr(): Pty =
@@ -420,16 +470,22 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         proceed(Normal)
 
       inline def put(char: Char): Pty =
+        if pendingWrap then
+          cursor.x = Prim
+          ind()
+          // Setters above cleared pendingWrap; nothing more to do.
         set(cursor.x, cursor.y, char)
-        cursor() += 1
-        if cursor().n0 == buffer2.capacity then
-          buffer2.scroll(1)
-          cursor() -= buffer2.width
+        lastChar = char
+        if cursor.x.n0 == buffer2.width - 1 then pendingWrap = true
+        else cursor.x = cursor.x + 1
 
         proceed(Normal)
 
       if index >= input.length
-      then Pty(buffer2, state2.copy(cursor = cursor(), style = style, link = link), output = output)
+      then Pty(buffer2,
+          state2.copy(cursor = cursor(), style = style, link = link, scrollTop = scrollTop,
+              scrollBottom = scrollBottom, pendingWrap = pendingWrap),
+          output = output)
       else
         val current: Char = unsafely(input.s.charAt(index))
 
@@ -472,14 +528,17 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
           case Escape =>
             current match
-              case '['                            => recur(index + 1, Csi)
-              case ']'                            => recur(index + 1, Osc)
-              case 'P' | 'X' | '^' | '_'          => recur(index + 1, EatString)
-              case '7'                            => decsc(); proceed(Normal)
-              case '8'                            => decrc(); proceed(Normal)
-              case 'c'                            => ris(); proceed(Normal)
-              case 'D' | 'E' | 'M' | 'N' | 'O'    => proceed(Normal) // single-char Fe escapes
-              case '\\'                           => proceed(Normal) // bare ST is ignored
+              case '['                   => recur(index + 1, Csi)
+              case ']'                   => recur(index + 1, Osc)
+              case 'P' | 'X' | '^' | '_' => recur(index + 1, EatString)
+              case '7'                   => decsc(); proceed(Normal)
+              case '8'                   => decrc(); proceed(Normal)
+              case 'c'                   => ris(); proceed(Normal)
+              case 'D'                   => ind(); proceed(Normal)
+              case 'E'                   => nel(); proceed(Normal)
+              case 'M'                   => ri(); proceed(Normal)
+              case 'N' | 'O'             => proceed(Normal) // SS2 / SS3 — charset not supported
+              case '\\'                  => proceed(Normal) // bare ST is ignored
 
               case char =>
                 raise(PtyEscapeError(BadFeEscape(char)))

--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -197,6 +197,24 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
     def focus(value: Boolean): Unit = state2 = state2.copy(focus = value)
     def bcp(value: Boolean): Unit = state2 = state2.copy(bracketedPasteMode = value)
 
+    def writeChar(char: Char): Unit =
+      if pendingWrap then
+        cursor.x = Prim
+        ind()
+      set(cursor.x, cursor.y, char)
+      lastChar = char
+      if cursor.x.n0 == buffer2.width - 1
+      then pendingWrap = true
+      else
+        cursor.x = cursor.x + 1
+
+    def rep(n: Int): Unit =
+      val count = if n == 0 then 1 else n
+      var i = 0
+      while i < count do
+        writeChar(lastChar)
+        i += 1
+
     def ht(): Unit =
       val nextStop = ((cursor.x.n0/8 + 1)*8).z
       cursor.x = if nextStop >= buffer2.width.z then (buffer2.width - 1).z else nextStop
@@ -399,6 +417,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         case 'L' => il(parseInt(params, 1))
         case 'M' => dl(parseInt(params, 1))
         case 'X' => ech(parseInt(params, 1))
+        case 'b' => rep(parseInt(params, 1))
 
         case 'H' => val (r, c) = parsePair(params, 1); cup(r.u, c.u)
         case 'f' => val (r, c) = parsePair(params, 1); hvp(r.u, c.u)
@@ -477,17 +496,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         proceed(Normal)
 
       inline def put(char: Char): Pty =
-        if pendingWrap then
-          cursor.x = Prim
-          ind()
-          // Setters above cleared pendingWrap; nothing more to do.
-        set(cursor.x, cursor.y, char)
-        lastChar = char
-        if cursor.x.n0 == buffer2.width - 1
-        then pendingWrap = true
-        else
-          cursor.x = cursor.x + 1
-
+        writeChar(char)
         proceed(Normal)
 
       if index >= input.length

--- a/lib/yossarian/src/core/yossarian.PtyState.scala
+++ b/lib/yossarian/src/core/yossarian.PtyState.scala
@@ -47,4 +47,7 @@ case class PtyState
     bracketedPasteMode: Boolean = false,
     hideCursor:         Boolean = false,
     title:              Text    = t"",
-    link:               Text    = t"" )
+    link:               Text    = t"",
+    scrollTop:          Ordinal = Prim,
+    scrollBottom:       Ordinal = Prim,
+    pendingWrap:        Boolean = false )

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -69,22 +69,28 @@ object internal:
 
     def styles: IArray[Style] = styleBuffer.clone().immutable(using Unsafe)
 
-    def scroll(n: Int): Unit =
-      val offset = math.abs(width*n)
-      val length = capacity - offset
-      val source = if n < 0 then 0 else offset
-      val destination = if n < 0 then offset else 0
+    def scroll(n: Int): Unit = scroll(n, 0, height - 1)
+
+    def scroll(n: Int, top: Int, bottom: Int): Unit =
+      val regionRows = bottom - top + 1
+      val absN = math.abs(n).min(regionRows)
+      val offset = width*absN
+      val length = width*(regionRows - absN)
+      val regionStart = top*width
+
+      val source = if n < 0 then regionStart else regionStart + offset
+      val destination = if n < 0 then regionStart + offset else regionStart
 
       System.arraycopy(styleBuffer, source, styleBuffer, destination, length)
       System.arraycopy(charBuffer, source, charBuffer, destination, length)
       System.arraycopy(linkBuffer, source, linkBuffer, destination, length)
 
-      val start = if n < 0 then 0 else length
+      val fillStart = if n < 0 then regionStart else regionStart + length
 
       for i <- 0 until offset do
-        styleBuffer(start + i) = Style()
-        charBuffer(start + i) = ' '
-        linkBuffer(start + i) = t""
+        styleBuffer(fillStart + i) = Style()
+        charBuffer(fillStart + i) = ' '
+        linkBuffer(fillStart + i) = t""
 
     def set(x: Ordinal, y: Ordinal, char: Char, style: Style, link: Text): Unit =
       styleBuffer(offset(x, y)) = style

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -459,7 +459,7 @@ object Tests extends Suite(m"Yossarian Tests"):
         Pty24x80().consume(t"$Esc[4;24mX").buffer.style(Prim, Prim).underline
       . assert(_ == false)
 
-    suite(m"vttest §11.7: REP [REP]"):
+    suite(m"vttest §11.7: REP"):
       test(m"REP \\e[3b repeats the previous char 3 times"):
         // After printing 'X', \e[3b should write 'X' three more times.
         safely:

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -377,7 +377,7 @@ object Tests extends Suite(m"Yossarian Tests"):
         drainOutput(pty)
       . assert(_ == t"$Esc[5;10R")
 
-      test(m"DA \\e[c responds with device attributes [da-query]"):
+      test(m"DA \\e[c responds with device attributes"):
         // Real VT100 responds \e[?1;2c. Yossarian doesn't reply at all.
         // Aspirational until DA is implemented.
         safely:

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -372,7 +372,7 @@ object Tests extends Suite(m"Yossarian Tests"):
           drainOutput(pty).s.startsWith(s"${0x1b.toChar}[?")
       . aspire(_ == true)
 
-    suite(m"vttest §8: Insert / delete characters [insert-delete]"):
+    suite(m"vttest §8: Insert / delete characters"):
       test(m"ICH \\e[3@ inserts 3 spaces at cursor"):
         safely:
           val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3@")

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -295,15 +295,12 @@ object Tests extends Suite(m"Yossarian Tests"):
         Pty24x80().consume(t"abc$Esc[HX").buffer.char(Prim, Prim)
       . assert(_ == 'X')
 
-      test(m"CUP at last row+col writes to last cell [deferred-wrap]"):
-        // Real terminals defer the wrap when writing to the bottom-right cell
-        // and don't scroll. Yossarian wraps eagerly: after writing 'X' at
-        // (79, 23), the cursor lands one past the screen, the buffer scrolls
-        // up by one row, and 'X' ends up at (79, 22). Aspirational until
-        // deferred-wrap support lands.
+      test(m"CUP at last row+col writes to last cell (deferred wrap)"):
+        // The cursor stays at the bottom-right cell with a pending wrap;
+        // the next character would scroll, but we don't write one here.
         val pty = Pty24x80().consume(t"$Esc[24;80HX")
         pty.buffer.char(79.z, 23.z)
-      . aspire(_ == 'X')
+      . assert(_ == 'X')
 
       test(m"CUP beyond last row clamps to last row"):
         val pty = Pty24x80().consume(t"$Esc[99;1HX")
@@ -348,15 +345,31 @@ object Tests extends Suite(m"Yossarian Tests"):
         (pty.buffer.char(4.z, Prim), pty.buffer.style(4.z, Prim).bold, pty.cursor)
       . assert(_ == ('X', true, Sen))
 
-    suite(m"vttest §2: Scrolling regions [scrolling-region]"):
+    suite(m"vttest §2: Scrolling regions"):
       test(m"DECSTBM \\e[3;7r limits LF scrolling to rows 3..7"):
         // Set scroll region 3..7, position at row 7, LF — should scroll content
         // within rows 3..7 only, leaving rows 1-2 and 8+ untouched.
-        // Yossarian doesn't implement DECSTBM yet, so this raises BadCsiCommand.
-        safely:
-          val pty = Pty24x80().consume(t"top$Esc[3;7r$Esc[7;1H\nlast")
-          trim(row(pty, Prim))
-      . aspire(_ == t"top")
+        val pty = Pty24x80().consume(t"top$Esc[3;7r$Esc[7;1H\nlast")
+        trim(row(pty, Prim))
+      . assert(_ == t"top")
+
+      test(m"IND (\\eD) at scroll-region bottom scrolls within region"):
+        val pty = Pty24x80().consume(
+            t"$Esc[3;7r$Esc[3;1HA$Esc[4;1HB$Esc[7;1HZ${Esc}D")
+        // Region rows 3..7 (0-indexed 2..6) before IND: A B _ _ Z. After IND,
+        // each row in the region shifts up: row 3 ← row 4 = B, row 6 ← row 7
+        // = Z, row 7 = blank.
+        (head(row(pty, Ter)), head(row(pty, Sen)))
+      . assert(_ == ('B', 'Z'))
+
+      test(m"RI (\\eM) at scroll-region top scrolls region down"):
+        val pty = Pty24x80().consume(
+            t"$Esc[3;7r$Esc[5;1HA$Esc[3;1H${Esc}M")
+        // Region rows 3..7 (0-indexed 2..6) before RI: _ _ A _ _. After RI
+        // each row shifts down by one within the region: A goes from row 5
+        // (idx 4) to row 6 (idx 5).
+        head(row(pty, Sen))
+      . assert(_ == 'A')
 
     suite(m"vttest §6: Terminal reports"):
       test(m"DSR \\e[6n responds with cursor position"):

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -378,43 +378,35 @@ object Tests extends Suite(m"Yossarian Tests"):
       . assert(_ == t"$Esc[5;10R")
 
       test(m"DA \\e[c responds with device attributes"):
-        // Real VT100 responds \e[?1;2c. Yossarian doesn't reply at all.
-        // Aspirational until DA is implemented.
-        safely:
-          val pty = Pty24x80().consume(t"$Esc[c")
-          drainOutput(pty).s.startsWith(s"${0x1b.toChar}[?")
-      . aspire(_ == true)
+        val pty = Pty24x80().consume(t"$Esc[c")
+        drainOutput(pty)
+      . assert(_.s.startsWith(s"${0x1b.toChar}[?"))
 
     suite(m"vttest §8: Insert / delete characters"):
       test(m"ICH \\e[3@ inserts 3 spaces at cursor"):
-        safely:
-          val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3@")
-          take(row(pty, Prim), 11)
-      . aspire(_ == t"ABC   DEFGH")
+        val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3@")
+        take(row(pty, Prim), 11)
+      . assert(_ == t"ABC   DEFGH")
 
       test(m"DCH \\e[3P deletes 3 chars at cursor"):
-        safely:
-          val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3P")
-          take(row(pty, Prim), 5)
-      . aspire(_ == t"ABCGH")
+        val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3P")
+        take(row(pty, Prim), 5)
+      . assert(_ == t"ABCGH")
 
       test(m"IL \\e[2L inserts 2 blank lines at cursor row"):
-        safely:
-          val pty = Pty24x80().consume(t"$Esc[1;1HA\nB\nC$Esc[2;1H$Esc[2L")
-          (head(row(pty, Prim)), head(row(pty, 3.z)))
-      . aspire(_ == ('A', 'B'))
+        val pty = Pty24x80().consume(t"$Esc[1;1HA\nB\nC$Esc[2;1H$Esc[2L")
+        (head(row(pty, Prim)), head(row(pty, 3.z)))
+      . assert(_ == ('A', 'B'))
 
       test(m"DL \\e[2M deletes 2 lines at cursor row"):
-        safely:
-          val pty = Pty24x80().consume(t"$Esc[1;1HA\nB\nC\nD$Esc[2;1H$Esc[2M")
-          (head(row(pty, Sec)), head(row(pty, Prim)))
-      . aspire(_ == ('D', 'A'))
+        val pty = Pty24x80().consume(t"$Esc[1;1HA\nB\nC\nD$Esc[2;1H$Esc[2M")
+        (head(row(pty, Sec)), head(row(pty, Prim)))
+      . assert(_ == ('D', 'A'))
 
       test(m"ECH \\e[3X overwrites 3 cells with spaces"):
-        safely:
-          val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3X")
-          take(row(pty, Prim), 8)
-      . aspire(_ == t"ABC   GH")
+        val pty = Pty24x80().consume(t"$Esc[1;1HABCDEFGH$Esc[1;4H$Esc[3X")
+        take(row(pty, Prim), 8)
+      . assert(_ == t"ABC   GH")
 
     suite(m"vttest §10: Reset"):
       test(m"RIS clears screen, homes cursor, resets style"):
@@ -462,10 +454,9 @@ object Tests extends Suite(m"Yossarian Tests"):
     suite(m"vttest §11.7: REP"):
       test(m"REP \\e[3b repeats the previous char 3 times"):
         // After printing 'X', \e[3b should write 'X' three more times.
-        safely:
-          val pty = Pty24x80().consume(t"X$Esc[3b")
-          take(row(pty, Prim), 4)
-      . aspire(_ == t"XXXX")
+        val pty = Pty24x80().consume(t"X$Esc[3b")
+        take(row(pty, Prim), 4)
+      . assert(_ == t"XXXX")
 
     suite(m"vttest §11.8: XTerm features"):
       test(m"OSC 0 sets the window title"):


### PR DESCRIPTION
Four small slices that, together, take Yossarian from 12 failing vttest tests to just 3 — the only ones left are the `[grapheme]`-tagged ones that need Hieroglyph's UAX #29 + UAX #11 work. Stacked on #965.

## What changed for users

### 1. ICH, DCH, IL, DL, ECH

The five VT220 insert/delete operations on cells and lines:

| Sequence | Effect |
|---|---|
| `CSI Pn @` | ICH — insert Pn blank cells at the cursor |
| `CSI Pn P` | DCH — delete Pn cells at the cursor |
| `CSI Pn L` | IL — insert Pn blank lines at the cursor row |
| `CSI Pn M` | DL — delete Pn lines at the cursor row |
| `CSI Pn X` | ECH — erase Pn cells (no shift) |

IL and DL clip to the active scroll region.

### 2. DECSTBM scroll regions, IND/RI/NEL, deferred wrap

**DECSTBM** (`CSI top;bot r`). Sets the inclusive top/bottom rows (1-indexed) within which `LF`, `IND`, `RI`, `IL`, `DL`, `SU`, `SD` operate. Default is the full screen. New `PtyState.scrollTop` / `scrollBottom` fields carry the region across `consume` calls.

**IND, RI, NEL.** The single-character Fe escapes (`ESC D`, `ESC M`, `ESC E`) are now wired: IND moves cursor down or scrolls at the bottom of the region; RI moves up or scrolls at the top; NEL is `CR + IND`. Previously they were no-ops.

**Deferred wrap.** Real terminals don't scroll when you write the very last cell — the cursor stays put with a "pending wrap" flag and only wraps on the *next* printable character. New `PtyState.pendingWrap` field; cursor setters clear it automatically; `put` sets it when writing to the right-edge cell.

```scala
import yossarian.*, denominative.*
import strategies.throwUnsafely

val pty = Pty(80, 24).consume(t"$Esc[3;7r$Esc[7;1H\nlast")
// LF at row 7 scrolled rows 3..7 only; rows 1, 2, 8..24 untouched.
```

### 3. Device Attributes responses

Programs probing the terminal at startup (vim, less, screen, mosh) emit `CSI c` or `CSI > c` and stall until the terminal answers. Yossarian now answers:

- `CSI c` → `\e[?1;2c` (VT100 with advanced video)
- `CSI > c` → `\e[>0;0;0c` (terminal type 0, firmware 0, hardware 0)

### 4. REP — repeat the last printed character

`CSI Pn b` emits the last printable character Pn additional times, honouring the same cursor advance and pending-wrap rules as a normal write. Pn defaults to 1; Pn=0 is also treated as 1.

## Test results

**Before this PR:** 65 of 77 vttest tests passing. After: **76 of 79 passing** (added two tests for IND/RI in scroll regions).

Tags dropped from suite names: `[insert-delete]`, `[scrolling-region]`, `[deferred-wrap]`, `[da-query]`, `[REP]`. Remaining failures are all `[grapheme]` (3 tests) — those will flip green when Hieroglyph gains UAX #29 segmentation and UAX #11 width tables.

Each commit is one slice and is independently meaningful; reviewing them separately should be straightforward.