### PR TITLE
Make Textual operand-parametric

### DIFF
--- a/lib/dendrology/src/dag/dendrology.TextualDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.TextualDagStyle.scala
@@ -34,6 +34,7 @@ package dendrology
 
 import anticipation.*
 import gossamer.*
+import gossamer.Textual.concatenable
 import symbolism.*
 
 import DagTile.*

--- a/lib/dendrology/src/tree/dendrology.TextualTreeStyle.scala
+++ b/lib/dendrology/src/tree/dendrology.TextualTreeStyle.scala
@@ -34,6 +34,7 @@ package dendrology
 
 import anticipation.*
 import gossamer.*
+import gossamer.Textual.concatenable
 import symbolism.*
 
 case class TextualTreeStyle[line: Textual](space: Text, last: Text, branch: Text, extender: Text)

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -55,6 +55,10 @@ object Teletype:
 
     inline def add(left: Teletype, right: Teletype): Teletype = left.append(right)
 
+  given concatenable: Teletype is Concatenable:
+    type Operand = Teletype
+    def concat(left: Teletype, right: Teletype): Teletype = left.append(right)
+
   given out: Stdio => Out.type is Writable by Teletype = new Writable:
     type Self = Out.type
     type Operand = Teletype
@@ -70,6 +74,7 @@ object Teletype:
       stream.flow(())(Err.print(next) yet write(target, more))
 
   given textual: Teletype is Textual:
+    type Operand = Char
     type Show[value] = value is Teletypeable
 
     def classTag: ClassTag[Teletype] = summon[ClassTag[Teletype]]
@@ -77,7 +82,8 @@ object Teletype:
     def text(teletype: Teletype): Text = teletype.plain
     def length(text: Teletype): Int = text.plain.length
     def apply(text: Text): Teletype = Teletype(text)
-    def apply(char: Char): Teletype = Teletype(char.show)
+    def apply(operand: Char): Teletype = Teletype(operand.show)
+    def fromChar(char: Char): Char = char
 
     def map(text: Teletype)(lambda: Char => Char): Teletype =
       val array = text.plain.s.toCharArray.nn
@@ -93,7 +99,7 @@ object Teletype:
     val empty: Teletype = Teletype.empty
 
     def concat(left: Teletype, right: Teletype): Teletype = left.append(right)
-    def unsafeChar(text: Teletype, index: Ordinal): Char = text.plain.s.charAt(index.n0)
+    def at(text: Teletype, index: Ordinal): Char = text.plain.s.charAt(index.n0)
 
     def indexOf(text: Teletype, sub: Text, start: Ordinal): Optional[Ordinal] =
       text.plain.s.indexOf(sub.s, start.n0).puncture(-1).let(_.z)

--- a/lib/escritoire/src/core/escritoire.TextAlignment.scala
+++ b/lib/escritoire/src/core/escritoire.TextAlignment.scala
@@ -34,6 +34,7 @@ package escritoire
 
 import anticipation.*
 import gossamer.*
+import gossamer.Textual.concatenable
 import hieroglyph.*
 import rudiments.*
 import symbolism.*

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import contingency.*
 import denominative.*
 import gossamer.*
+import gossamer.Textual.concatenable
 import rudiments.*
 import symbolism.*
 import vacuous.*
@@ -69,7 +70,7 @@ package columnar:
   object Prose extends Columnar:
     def longestWord[textual: Textual](text: textual, position: Int, lastStart: Int, max: Int): Int =
       if position < text.length then
-        if textual.unsafeChar(text, position.z) == ' '
+        if textual.at(text, position.z) == textual.fromChar(' ')
         then longestWord(text, position + 1, position + 1, max.max(position - lastStart))
         else longestWord(text, position + 1, lastStart, max)
       else
@@ -90,7 +91,7 @@ package columnar:
       :   List[textual] =
 
         if position < text.length then
-          if textual.unsafeChar(text, position.z) == ' '
+          if textual.at(text, position.z) == textual.fromChar(' ')
           then format(text, position + 1, lineStart, position, lines)
           else
             if position - lineStart >= width then format

--- a/lib/gossamer/src/core/gossamer.Textual.scala
+++ b/lib/gossamer/src/core/gossamer.Textual.scala
@@ -43,13 +43,19 @@ import vacuous.*
 object Textual:
   def apply[textual: Textual](text: Text): textual = textual(text)
 
+  given concatenable: [textual: Textual] => textual is Concatenable:
+    type Operand = textual
+    def concat(left: textual, right: textual): textual = textual.concat(left, right)
+
   given text: Text is Textual:
+    type Operand = Char
     type Show[value] = value is spectacular.Showable
 
     val classTag: ClassTag[Text] = summon[ClassTag[Text]]
 
     def show[value](value: value)(using show: Show[value]): Text = show.text(value)
-    def apply(char: Char): Text = char.toString.tt
+    def apply(operand: Char): Text = operand.toString.tt
+    def fromChar(char: Char): Char = char
     def text(text: Text): Text = text
     def length(text: Text): Int = text.s.length
     def apply(text: Text): Text = text
@@ -64,7 +70,7 @@ object Textual:
 
     def empty: Text = Text("")
     def concat(left: Text, right: Text): Text = Text(left.s+right.s)
-    def unsafeChar(text: Text, index: Ordinal): Char = text.s.charAt(index.n0)
+    def at(text: Text, index: Ordinal): Char = text.s.charAt(index.n0)
 
     def indexOf(text: Text, sub: Text, start: Ordinal): Optional[Ordinal] =
       text.s.indexOf(sub.s, start.n0).puncture(-1).let(_.z)
@@ -75,20 +81,21 @@ object Textual:
     def builder(size: Optional[Int]): Builder[Text] = TextBuilder(size)
     def size(text: Self): Int = text.length
 
-trait Textual extends Typeclass, Concatenable, Countable, Segmentable, Zeroic:
-  type Operand = Self
+trait Textual extends Typeclass, Countable, Segmentable, Zeroic:
+  type Operand
   type Show[value]
 
   def show[value](value: value)(using show: Show[value]): Self
   def apply(text: Text): Self
-  def apply(char: Char): Self
+  def apply(operand: Operand): Self
+  def fromChar(char: Char): Operand
   def classTag: ClassTag[Self]
   def length(text: Self): Int
   def text(text: Self): Text
-  def map(text: Self)(lambda: Char => Char): Self
+  def map(text: Self)(lambda: Operand => Operand): Self
   def empty: Self
   def concat(left: Self, right: Self): Self
-  def unsafeChar(text: Self, index: Ordinal): Char
+  def at(text: Self, index: Ordinal): Operand
   def indexOf(text: Self, sub: Text, start: Ordinal = Prim): Optional[Ordinal]
 
   def lastIndexOf(text: Self, sub: Text): Optional[Ordinal] =

--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -91,24 +91,29 @@ object internal:
       given showable: Ascii is Showable =
         ascii => String(ascii.mutable(using Unsafe), "ASCII").nn.tt
 
+      given concatenable: Ascii is Concatenable:
+        type Operand = Ascii
+        def concat(left: Ascii, right: Ascii): Ascii = textual.concat(left, right)
+
       extension (ascii: Ascii) def bytes: Data = ascii
 
       given textual: Ascii is Textual:
+        type Operand = Byte
         type Show[value] = value is Showable
 
         val empty: Ascii = IArray.from[Byte](Nil)
         val classTag: ClassTag[Ascii] = summon[ClassTag[Ascii]]
 
         def apply(text: Text): Ascii = text.sysData
-        def apply(char: Char): Ascii = IArray(char.toByte)
+        def apply(operand: Byte): Ascii = IArray(operand)
+        def fromChar(char: Char): Byte = char.toByte
         def length(ascii: Ascii): Int = ascii.size
         def text(ascii: Ascii): Text = String(ascii.mutable(using Unsafe), "ASCII").nn.tt
-        def unsafeChar(ascii: Ascii, index: Ordinal): Char = ascii(index.n0).toChar
+        def at(ascii: Ascii, index: Ordinal): Byte = ascii(index.n0)
         def builder(size: Optional[Int]): Builder[Ascii] = AsciiBuilder(size)
         def size(ascii: Ascii): Int = ascii.length
 
-        def map(ascii: Ascii)(lambda: Char => Char): Ascii = ascii.map: byte =>
-          lambda(byte.toChar).toByte
+        def map(ascii: Ascii)(lambda: Byte => Byte): Ascii = ascii.map(lambda)
 
         def concat(left: Ascii, right: Ascii): Ascii =
           IArray.build[Byte](left.length + right.length): array =>

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -56,6 +56,8 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
+import Textual.concatenable
+
 export gossamer.internal.opaques.Ascii
 
 inline def append[textual: Textual, value](using builder: Builder[textual] aka "builder")
@@ -64,7 +66,7 @@ inline def append[textual: Textual, value](using builder: Builder[textual] aka "
 
   inline value match
     case text: Text => builder().append(textual(text))
-    case char: Char => builder().append(textual(char))
+    case char: Char => builder().append(char)
     case other      => provide[textual.Show[value]](builder().append(textual.show(value)))
 
 
@@ -73,7 +75,7 @@ inline def appendln[textual: Textual, value](using builder: Builder[textual] aka
 :   Unit =
 
   append[textual, value](value)
-  builder().append(textual('\n'))
+  builder().append('\n')
 
 
 inline def builder[value](using value: value aka "builder"): value = value()
@@ -130,7 +132,7 @@ extension [textual](text: textual)
 
     cuttable.cut(text, delimiter, limit)
 
-extension [textual: Textual](words: Iterable[textual])
+extension [textual: Textual { type Operand = Char }](words: Iterable[textual])
   def pascal: textual = words.map(_.lower.capitalize).join
   def camel: textual = pascal.uncapitalize
   def snake: textual = words.join(textual("_".tt))
@@ -139,28 +141,7 @@ extension [textual: Textual](words: Iterable[textual])
 
 extension [textual: Textual](text: textual)
   inline def length: Int = textual.length(text)
-  inline def lower: textual = textual.map(text)(_.toLower)
-  inline def upper: textual = textual.map(text)(_.toUpper)
   def plain: Text = textual.text(text)
-
-  def broken(predicate: (Char, Char) => Boolean, break: Char = '\u200b'): textual =
-    val breakText = textual(break.toString.tt)
-    val builder = textual.builder()
-
-    @tailrec
-    def recur(from: Ordinal = Prim, index: Ordinal = Sec): textual =
-      if index >= text.limit - 1 then
-        builder.append(text.from(from))
-        builder()
-      else
-        if !predicate(textual.unsafeChar(text, index - 1), textual.unsafeChar(text, index))
-        then recur(from, index + 1)
-        else
-          builder.append(text.segment(from till index))
-          builder.append(breakText)
-          recur(index, index + 1)
-
-    recur()
 
   // FIXME
   def justify(width: Int): textual =
@@ -192,31 +173,10 @@ extension [textual: Textual](text: textual)
     case Ltr => text.segment(Interval.initial(count))
     case Rtl => text.segment(text.limit - count till text.limit)
 
-  def skip(predicate: Char => Boolean): textual = text.skip(predicate, Ltr)
-
-  def skip(predicate: Char => Boolean, bidi: Bidi): textual = bidi match
-    case Ltr => text.where(!predicate(_)).lay(textual.empty)(text.from(_))
-    case Rtl => text.where(!predicate(_), bidi = Rtl).lay(textual.empty)(text.upto(_))
-
-  def keep(predicate: Char => Boolean): textual = text.keep(predicate, Ltr)
-
-  def keep(predicate: Char => Boolean, bidi: Bidi): textual = bidi match
-    case Ltr => text.where(!predicate(_)).lay(text)(text.before(_))
-    case Rtl => text.where(!predicate(_), bidi = Rtl).lay(text)(text.after(_))
-
-  def capitalize: textual = textual.concat(text.keep(1).upper, text.after(Prim))
-  def uncapitalize: textual = textual.concat(text.keep(1).lower, text.after(Prim))
-
   inline def tail: textual = text.skip(1, Ltr)
   inline def init: textual = text.skip(1, Rtl)
 
-  def chars: IArray[Char] =
-    val n = text.length
-    IArray.build[Char](n): array =>
-      var i = 0
-      while i < n do
-        array(i) = textual.unsafeChar(text, i.z)
-        i += 1
+  def chars: IArray[Char] = textual.text(text).s.toCharArray.nn.immutable(using Unsafe)
 
   def snip(n: Int): (textual, textual) =
     (text.segment(Prim till n.z), text.segment(n.z till text.limit))
@@ -229,12 +189,11 @@ extension [textual: Textual](text: textual)
     val builder = textual.builder(n)
     var index = n - 1
     while index >= 0 do
-      builder.append(textual.unsafeChar(text, index.z))
+      builder.append(textual(textual.at(text, index.z)))
       index -= 1
     builder()
 
   def contains(substring: Text): Boolean = textual.indexOf(text, substring).present
-  def contains(char: Char): Boolean = textual.indexOf(text, char.show).present
 
   def search(regex: Regex, overlap: Boolean = false): Stream[textual] =
     regex.search(textual.text(text), overlap = overlap).map(text.segment(_))
@@ -255,6 +214,66 @@ extension [textual: Textual](text: textual)
     case Ltr => textual.indexOf(text, substring)
     case Rtl => if substring.nil then Unset else textual.lastIndexOf(text, substring)
 
+  def count(substring: Text): Int =
+    if substring.nil then 0 else
+      def recur(start: Ordinal, total: Int): Int =
+        textual.indexOf(text, substring, start).lay(total): found =>
+          recur(found + substring.length, total + 1)
+
+      recur(Prim, 0)
+
+  def words: List[textual] = text.cut(" ".tt)
+  def lines: List[textual] = text.cut("\n".tt)
+  def unkebab: List[textual] = text.cut("-".tt)
+  def unsnake: List[textual] = text.cut("_".tt)
+
+  def starts(prefix: Text): Boolean = textual.text(text).s.startsWith(prefix.s)
+  def ends(suffix: Text): Boolean = textual.text(text).s.endsWith(suffix.s)
+
+  def strip(affix: Text, bidi: Bidi = Ltr): textual = bidi match
+    case Ltr => if text.starts(affix) then text.skip(affix.length) else text
+    case Rtl => if text.ends(affix) then text.skip(affix.length, Rtl) else text
+
+extension [textual: Textual { type Operand = Char }](text: textual)
+  inline def lower: textual = textual.map(text)(_.toLower)
+  inline def upper: textual = textual.map(text)(_.toUpper)
+
+  def broken(predicate: (Char, Char) => Boolean, break: Char = '\u200b'): textual =
+    val breakText = textual(break.toString.tt)
+    val builder = textual.builder()
+
+    @tailrec
+    def recur(from: Ordinal = Prim, index: Ordinal = Sec): textual =
+      if index >= text.limit - 1 then
+        builder.append(text.from(from))
+        builder()
+      else
+        if !predicate(textual.at(text, index - 1), textual.at(text, index))
+        then recur(from, index + 1)
+        else
+          builder.append(text.segment(from till index))
+          builder.append(breakText)
+          recur(index, index + 1)
+
+    recur()
+
+  def skip(predicate: Char => Boolean): textual = text.skip(predicate, Ltr)
+
+  def skip(predicate: Char => Boolean, bidi: Bidi): textual = bidi match
+    case Ltr => text.where(!predicate(_)).lay(textual.empty)(text.from(_))
+    case Rtl => text.where(!predicate(_), bidi = Rtl).lay(textual.empty)(text.upto(_))
+
+  def keep(predicate: Char => Boolean): textual = text.keep(predicate, Ltr)
+
+  def keep(predicate: Char => Boolean, bidi: Bidi): textual = bidi match
+    case Ltr => text.where(!predicate(_)).lay(text)(text.before(_))
+    case Rtl => text.where(!predicate(_), bidi = Rtl).lay(text)(text.after(_))
+
+  def capitalize: textual = textual.concat(text.keep(1).upper, text.after(Prim))
+  def uncapitalize: textual = textual.concat(text.keep(1).lower, text.after(Prim))
+
+  def contains(char: Char): Boolean = textual.indexOf(text, char.show).present
+
   inline def trim: textual =
     val start = text.where(!_.isWhitespace).or(text.limit - 1)
     val end = text.where(!_.isWhitespace, bidi = Rtl).or(Prim)
@@ -271,11 +290,11 @@ extension [textual: Textual](text: textual)
 
     val first: Ordinal = bidi match
       case Ltr => start.or(Prim)
-      case Rtl => start.or(length.limit - 1)
+      case Rtl => start.or(text.length.limit - 1)
 
     def recur(ordinal: Ordinal): Optional[Ordinal] =
       if ordinal >= text.limit || ordinal < Prim then Unset
-      else if predicate(textual.unsafeChar(text, ordinal)) then ordinal
+      else if predicate(textual.at(text, ordinal)) then ordinal
       else recur(ordinal + step)
 
     recur(first)
@@ -302,18 +321,10 @@ extension [textual: Textual](text: textual)
 
   inline def count(predicate: Char => Boolean): Int =
     def recur(index: Ordinal, sum: Int): Int = if index >= text.limit then sum else
-      val increment = if predicate(textual.unsafeChar(text, index)) then 1 else 0
+      val increment = if predicate(textual.at(text, index)) then 1 else 0
       recur(index + 1, sum + increment)
 
     recur(Prim, 0)
-
-  def count(substring: Text): Int =
-    if substring.nil then 0 else
-      def recur(start: Ordinal, total: Int): Int =
-        textual.indexOf(text, substring, start).lay(total): found =>
-          recur(found + substring.length, total + 1)
-
-      recur(Prim, 0)
 
   def blank: Boolean = text.where(!_.isWhitespace).absent
 
@@ -351,24 +362,6 @@ extension [textual: Textual](text: textual)
         text.before(index).lower :: recur(text.from(index))
 
     recur(text)
-
-  def words: List[textual] = text.cut(" ".tt)
-  def lines: List[textual] = text.cut("\n".tt)
-  def unkebab: List[textual] = text.cut("-".tt)
-  def unsnake: List[textual] = text.cut("_".tt)
-
-  def starts(prefix: Text): Boolean =
-    def recur(index: Ordinal): Boolean =
-      index > (prefix.length - 1).z
-      || textual.unsafeChar(text, index) == prefix.s.charAt(index.n0) && recur(index + 1)
-
-    prefix.length <= text.length && recur(Prim)
-
-  def ends(suffix: Text): Boolean = text.keep(suffix.length, Rtl) == suffix
-
-  def strip(affix: Text, bidi: Bidi = Ltr): textual = bidi match
-    case Ltr => if text.starts(affix) then text.skip(affix.length) else text
-    case Rtl => if text.ends(affix) then text.skip(affix.length, Rtl) else text
 
   inline def tr(from: Char, to: Char): textual =
     textual.map(text)(char => if char == from then to else char)


### PR DESCRIPTION
Refactor `Textual` so each instance picks its element type via `type Operand`. This unblocks `Writing is Textual by Grapheme` (where `length` is grapheme count) in the next PR; the existing `Text`/`Ascii`/`Teletype` instances pick `Char`/`Byte`/`Char` respectively, leaving their behaviour numerically unchanged. `Textual` no longer extends `Concatenable`; an explicit derivation lives in `object Textual` and is imported where Self+Self `+` is used on a generic `text: Textual`.

## Release notes

`Textual` exposes a parametric `type Operand` and the methods `at(text, i): Operand` and `fromChar(char: Char): Operand`. `Text`, `Ascii`, and `Teletype` keep their previous semantics (`Operand = Char` for `Text`/`Teletype`, `Operand = Byte` for `Ascii`).

The case-folding and predicate-based extension methods (`lower`, `upper`, `where`, `broken`, `pad`, `trim`, …) are restricted to `Textual { type Operand = Char }`. Operand-agnostic methods (`length`, `segment`, `slices`, `words`, `starts`/`ends`, `reverse`, …) still work on any `Textual`.

For Self+Self `+` on a generic `text: Textual`, add `import gossamer.Textual.concatenable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)