### PR TITLE
Make Escritoire's column sizing respect Measurable

### DIFF
--- a/lib/escritoire/src/core/escritoire.Columnar.scala
+++ b/lib/escritoire/src/core/escritoire.Columnar.scala
@@ -32,10 +32,16 @@
                                                                                                   */
 package escritoire
 
+import anticipation.*
 import gossamer.*
+import hieroglyph.*
 import vacuous.*
 
 trait Columnar:
-  def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int]
+  def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+    (using Text is Measurable)
+  :   Optional[Int]
+
   def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+    (using Text is Measurable)
   :   IndexedSeq[text]

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import gossamer.*
 import gossamer.Textual.concatenable
+import hieroglyph.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
@@ -67,59 +68,101 @@ package tableStyles:
   given minimal: TableStyle = TableStyle(1, Unset, Unset, Thin, Blank, Blank, LineCharset.Default)
 
 package columnar:
+  // Cumulative display width up to each char position; `widths(i)` is the width
+  // of `text.plain.s.substring(0, i)`. `widths.length == text.plain.s.length + 1`.
+  private def prefixWidths[textual: Textual](text: textual)(using Char is Measurable)
+  :   IArray[Int] =
+
+    val plain = text.plain.s
+    val n = plain.length
+    val arr = new Array[Int](n + 1)
+    var i = 0
+    while i < n do
+      arr(i + 1) = arr(i) + summon[Char is Measurable].width(plain.charAt(i))
+      i += 1
+
+    arr.immutable(using Unsafe)
+
+  // Sum of char widths over `text.plain`.
+  private def displayWidth[textual: Textual](text: textual)(using Text is Measurable): Int =
+    text.plain.metrics
+
   object Prose extends Columnar:
-    def longestWord[textual: Textual](text: textual, position: Int, lastStart: Int, max: Int): Int =
-      if position < text.length then
-        if textual.at(text, position.z) == textual.fromChar(' ')
-        then longestWord(text, position + 1, position + 1, max.max(position - lastStart))
-        else longestWord(text, position + 1, lastStart, max)
-      else
-        max.max(position - lastStart)
+    def longestWord[textual: Textual](text: textual)(using Char is Measurable): Int =
+      val plain = text.plain.s
+      val widths = prefixWidths(text)
+      val n = plain.length
+      var max = 0
+      var lastStart = 0
+      var i = 0
+      while i < n do
+        if plain.charAt(i) == ' ' then
+          val wordWidth = widths(i) - widths(lastStart)
+          if wordWidth > max then max = wordWidth
+          lastStart = i + 1
+        i += 1
+
+      val tailWidth = widths(n) - widths(lastStart)
+      if tailWidth > max then max = tailWidth
+      max
 
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
     :   Optional[Int] =
 
-      val longestLine = lines.map(_.length).max
-      lines.map(longestWord(_, 0, 0, 0)).max.max((slack*maxWidth).toInt).min(longestLine)
+      // `Text is Measurable` (general derivation) is implied by `Char is Measurable`
+      // in scope; longestWord needs the per-char measurer.
+      given Char is Measurable = _.toString.tt.metrics
+      val longestLine = lines.map(displayWidth(_)).max
+      lines.map(longestWord(_)).max.max((slack*maxWidth).toInt).min(longestLine)
 
 
     def fit[textual: Textual](lines: IArray[textual], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[textual] =
 
-      def format
-        ( text: textual, position: Int, lineStart: Int, lastSpace: Int, lines: List[textual] )
-      :   List[textual] =
+      given measurable: Char is Measurable = _.toString.tt.metrics
 
-        if position < text.length then
-          if textual.at(text, position.z) == textual.fromChar(' ')
-          then format(text, position + 1, lineStart, position, lines)
+      def format(text: textual): List[textual] =
+        val plain = text.plain.s
+        val widths = prefixWidths(text)
+        val n = plain.length
+
+        // Walk char positions; accumulate display width since `lineStart`.
+        // Break at `lastSpace` once the next char would overflow `width`.
+        def recur(position: Int, lineStart: Int, lastSpace: Int, acc: List[textual])
+        :   List[textual] =
+
+          if position >= n then
+            if lineStart == position then acc else text.segment(lineStart.z thru position.u) :: acc
           else
-            if position - lineStart >= width then format
-              ( text,
-                position + 1,
-                lastSpace + 1,
-                lastSpace,
-                text.segment(lineStart.z thru lastSpace.u) :: lines )
+            val current = plain.charAt(position)
+            if current == ' ' then recur(position + 1, lineStart, position, acc)
+            else
+              val widthSoFar = widths(position + 1) - widths(lineStart)
+              if widthSoFar > width && lastSpace > lineStart then
+                val segment = text.segment(lineStart.z thru lastSpace.u)
+                recur(lastSpace + 1, lastSpace + 1, lastSpace + 1, segment :: acc)
+              else recur(position + 1, lineStart, lastSpace, acc)
 
-            else format(text, position + 1, lineStart, lastSpace, lines)
-        else if lineStart == position
-        then lines
-        else text.segment(lineStart.z thru position.u) :: lines
+        recur(0, 0, 0, Nil)
 
-
-      lines.to(IndexedSeq).flatMap(format(_, 0, 0, 0, Nil).reverse)
+      lines.to(IndexedSeq).flatMap(format(_).reverse)
 
   object ProseOrBreak extends Columnar:
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
     :   Optional[Int] =
 
       (maxWidth*slack + 1).toInt.min(maxWidth)
 
 
     def fit[textual: Textual](lines: IArray[textual], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[textual] =
 
-      if lines.map(Prose.longestWord(_, 0, 0, 0)).max < width
+      given Char is Measurable = _.toString.tt.metrics
+      if lines.map(Prose.longestWord(_)).max < width
       then Prose.fit(lines, width, textAlign)
       else
         var result: List[textual] = Nil
@@ -132,34 +175,44 @@ package columnar:
         result.reverse.to(Vector)
 
   case class Fixed(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
-      fixedWidth
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
+    :   Optional[Int] = fixedWidth
 
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[text] =
 
       lines.to(IndexedSeq).map: line =>
-        if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+        if line.plain.metrics > width then line.keep(width - ellipsis.length)+text(ellipsis)
+        else line
 
   case class Shortened(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
-      val naturalWidth = lines.map(_.length).max
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
+    :   Optional[Int] =
+      val naturalWidth = lines.map(_.plain.metrics).max
       (maxWidth*slack).toInt.min(naturalWidth)
 
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[text] =
 
       lines.to(IndexedSeq).map: line =>
-        if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+        if line.plain.metrics > width then line.keep(width - ellipsis.length)+text(ellipsis)
+        else line
 
   case class Collapsible(threshold: Double) extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
-      if slack > threshold then lines.map(_.length).max else Unset
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
+    :   Optional[Int] =
+      if slack > threshold then lines.map(_.plain.metrics).max else Unset
 
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[text] =
 
       lines.to(IndexedSeq)


### PR DESCRIPTION
Probably already brings `textMetrics.eastAsianScripts` into scope and declares its own `Char is Measurable` (forcing ✓ ✗ ⎇ to width 1, delegating elsewhere to `eastAsianScripts`). The reason CJK columns still rendered at the wrong width is in escritoire: `Columnar.width` and `Columnar.fit` were measuring with `_.length` (char count) rather than `_.plain.metrics` (display width), and the trait didn't even take `Text is Measurable` as a `using` clause.

Stacked on top of #968 (Writing/Grapheme).

## Release notes

`escritoire.Columnar.width` and `escritoire.Columnar.fit` now require `Text is Measurable` (already supplied by `Tabulation.grid`). The five built-in `Columnar` implementations — `Prose`, `ProseOrBreak`, `Fixed`, `Shortened`, `Collapsible` — measure column widths and wrap lines in display units instead of character counts. Wide East-Asian characters now contribute 2 (or whatever the active `Char is Measurable` says) to a column's width, and `Prose` line-wrapping respects the same widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)