### PR TITLE
Migrate Decorum rules from token stream to untyped tree

### DIFF
--- a/lib/decorum/src/plugin/decorum.Annotations.scala
+++ b/lib/decorum/src/plugin/decorum.Annotations.scala
@@ -1,0 +1,72 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package decorum
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
+object Annotations:
+  // Walk the tree collecting the END-lines of every annotation on a
+  // `MemberDef`'s modifier list. R15.2 forbids a blank line between such
+  // an annotation and the declaration it annotates; the checker uses
+  // this set to flag any blank line whose predecessor closes an
+  // annotation. Multi-line annotations like `@Foo(\n  arg\n)` correctly
+  // record their *closing* line — the line a trailing blank would
+  // appear on — rather than the opening `@` line.
+  def collectEndLines(tree: untpd.Tree, source: SourceFile): Set[Int] =
+    val out = mutable.Set[Int]()
+    walk(tree): t =>
+      t match
+        case d: untpd.MemberDef =>
+          d.mods.annotations.foreach: ann =>
+            val sp = ann.span
+            if sp.exists then
+              val endOffset = (sp.end - 1).max(sp.start).max(0).min(source.content.length - 1)
+              if endOffset >= 0 then out += source.offsetToLine(endOffset) + 1
+        case _ => ()
+    out.toSet
+
+  // Generic untyped-tree pre-order traversal driven off `productIterator`,
+  // so we don't need to enumerate every tree shape. We descend into any
+  // field that is itself a `Tree`, and into any `Iterable` recursively
+  // (covering `List[Tree]` and `List[List[Tree]]` for parameter clauses).
+  private def walk(t: untpd.Tree)(visit: untpd.Tree => Unit): Unit =
+    visit(t)
+    t.productIterator.foreach(descend(_, visit))
+
+  private def descend(x: Any, visit: untpd.Tree => Unit): Unit = x match
+    case sub: untpd.Tree => walk(sub)(visit)
+    case it:  Iterable[?] => it.foreach(descend(_, visit))
+    case _                => ()

--- a/lib/decorum/src/plugin/decorum.Cases.scala
+++ b/lib/decorum/src/plugin/decorum.Cases.scala
@@ -1,0 +1,123 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package decorum
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
+case class CaseInfo
+   ( caseLine:     Int,
+     caseCol:      Int,
+     arrowLine:    Int,
+     arrowCol:     Int,
+     spacesBeforeArrow: Int,
+     bodyLine:     Int,
+     endLine:      Int,
+     isSingleLine: Boolean )
+
+object Cases:
+  // Group every `case` arm by its enclosing `Match` or `Try.cases`. R19 and
+  // R20 both reason within one such group: alignment of `=>` columns within
+  // a run of single-line cases, and the blank-line-before requirement for a
+  // multi-line case that follows an earlier case at the same indent.
+  def extract(tree: untpd.Tree, source: SourceFile): List[List[CaseInfo]] =
+    val out = mutable.ListBuffer[List[CaseInfo]]()
+
+    def visit(t: untpd.Tree): Unit =
+      t match
+        case m: untpd.Match =>
+          val infos = m.cases.flatMap(infoFor(_, source))
+          if infos.nonEmpty then out += infos
+        case tr: untpd.Try =>
+          val infos = tr.cases.flatMap(infoFor(_, source))
+          if infos.nonEmpty then out += infos
+        case _ =>
+          ()
+      t.productIterator.foreach(descend(_, visit))
+
+    visit(tree)
+    out.toList
+
+  private def descend(x: Any, visit: untpd.Tree => Unit): Unit = x match
+    case sub: untpd.Tree => visit(sub)
+    case it:  Iterable[?] => it.foreach(descend(_, visit))
+    case _                => ()
+
+  // Build a `CaseInfo` for one `CaseDef`. The `=>` column is recovered by
+  // searching the source between the pattern (or guard) end and the body
+  // start; this is more reliable than re-tokenising the line because the
+  // pattern itself can contain `=>` (e.g. function-type ascription) and the
+  // body can also (e.g. a lambda inside the body).
+  private def infoFor(c: untpd.CaseDef, source: SourceFile): Option[CaseInfo] =
+    val csp = c.span
+    val psp = c.pat.span
+    val gsp = c.guard.span
+    val bsp = c.body.span
+    if !csp.exists || !psp.exists || !bsp.exists then None
+    else
+      val content      = String(source.content)
+      val patternEnd   = if gsp.exists then gsp.end else psp.end
+      val bodyStart    = bsp.start
+      val arrowOffset  = content.indexOf("=>", patternEnd)
+      // The body's span often begins at the `=>` token itself (when the
+      // body is a synthetic `Block`), so we don't enforce arrow < bodyStart;
+      // we only require the arrow to be inside the case clause's span.
+      if arrowOffset < 0 || arrowOffset >= csp.end then None
+      else
+        val caseLine     = source.offsetToLine(csp.start) + 1
+        val caseCol      = source.column(csp.start) + 1
+        val arrowLine    = source.offsetToLine(arrowOffset) + 1
+        val arrowCol     = source.column(arrowOffset) + 1
+        val bodyLine     = source.offsetToLine(bodyStart) + 1
+        val endLine      = source.offsetToLine((bsp.end - 1).max(bsp.start)) + 1
+        // The body's `Block` span often opens at the `=>` token rather than
+        // the body content, so `bodyLine == caseLine` mis-classifies
+        // `case X =>\n  body` as single-line. Compare the body span's END
+        // line instead.
+        val isSingleLine = endLine == caseLine
+        // Count contiguous spaces immediately before `=>` (only relevant
+        // for multi-line cases — R33 sub-check requires exactly one).
+        var k = arrowOffset - 1
+        while k >= 0 && content.charAt(k) == ' ' do k -= 1
+        val spacesBeforeArrow = arrowOffset - 1 - k
+        Some(CaseInfo
+              ( caseLine          = caseLine,
+                caseCol           = caseCol,
+                arrowLine         = arrowLine,
+                arrowCol          = arrowCol,
+                spacesBeforeArrow = spacesBeforeArrow,
+                bodyLine          = bodyLine,
+                endLine           = endLine,
+                isSingleLine      = isSingleLine ))

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -60,9 +60,10 @@ object Checker:
     val state = State(file, expectedModule)
     val lines = Tokenizer.tokenize(rawText)
     val imports = Imports.extract(untpdTree, source)
-    state.packageInfo   = Packages.extract(untpdTree, source)
-    state.importLineSet = imports.iterator.flatMap(i => i.startLine to i.endLine).toSet
-    state.hasImports    = imports.nonEmpty
+    state.packageInfo        = Packages.extract(untpdTree, source)
+    state.importLineSet      = imports.iterator.flatMap(i => i.startLine to i.endLine).toSet
+    state.hasImports         = imports.nonEmpty
+    state.annotationEndLines = Annotations.collectEndLines(untpdTree, source)
     scanRawTabs(file, rawText, out)
     checkFileNaming(file, out)
     checkPackageRules(file, expectedModule, state.packageInfo, out)
@@ -117,6 +118,7 @@ object Checker:
     var importLineSet:        Set[Int]                   = Set.empty
     var hasImports:           Boolean                    = false
     var packageInfo:          Option[PackageInfo]        = None
+    var annotationEndLines:   Set[Int]                   = Set.empty
     var prevLineWasBlank:     Boolean                    = false
     var prevWasAnnotation:    Boolean                    = false
     var prevLineNum:          Int                        = 0
@@ -282,7 +284,7 @@ object Checker:
             "blank line is not permitted between an annotation and the declaration it annotates" )
         s.prevWasAnnotation = false
     else
-      s.prevWasAnnotation = lineStartsAnnotation(firstReal)
+      s.prevWasAnnotation = s.annotationEndLines.contains(lineNum)
       s.prevLineNum = lineNum
       // Comment-only and annotation-only lines belong to the next declaration:
       // they must not update `prevCodeLineIndent`, otherwise sibling-scope

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -66,7 +66,7 @@ object Checker:
     state.annotationEndLines = Annotations.collectEndLines(untpdTree, source)
     state.companions         = Companions.extract(untpdTree, source)
     scanRawTabs(file, rawText, out)
-    checkFileNaming(file, out)
+    checkFileNaming(file, untpdTree, out)
     checkPackageRules(file, expectedModule, state.packageInfo, out)
     checkImportRules(file, imports, lines, out)
     var idx = 0
@@ -1393,7 +1393,10 @@ object Checker:
               ( file, objLine, 1, "28",
                 s"object `$name` must appear before class/trait/enum `$name`" )
 
-  private def checkFileNaming(file: String, out: mutable.ListBuffer[Violation]): Unit =
+  private def checkFileNaming
+    ( file: String, untpdTree: untpd.Tree, out: mutable.ListBuffer[Violation] )
+  :   Unit =
+
     val segments = file.split("/").nn
     val name     = segments(segments.length - 1).nn
     if !name.endsWith(".scala") then ()
@@ -1413,6 +1416,34 @@ object Checker:
           Violation
             ( file, 1, 1, "29",
               s"file name `$name` does not match a documented soundness convention" )
+      else
+        // Patterns of the form `<lowercase>.<Uppercase>.scala` name a single
+        // top-level type. Verify the parsed file declares it as a class,
+        // trait, enum, object, or type alias. Lowercase-tail patterns
+        // (`gossamer.internal.scala`, `ambience.variables.scala`) are
+        // namespace-style files and remain exempt.
+        val typedName = """[a-z][a-zA-Z0-9_]*\.([A-Z][a-zA-Z0-9_]*)""".r
+        typedName.findFirstMatchIn(base).foreach: m =>
+          val typeName = m.group(1).nn
+          if !declaresTopLevel(untpdTree, typeName) then
+            out += Violation
+                    ( file, 1, 1, "29",
+                      s"file name `$name` declares no top-level `$typeName` "
+                        +"(class/trait/enum/object/type)" )
+
+  // True iff the package body (or any nested package body) holds a `TypeDef`
+  // or `ModuleDef` whose name matches `target`. Used by R29 to verify that
+  // a `<module>.<Type>.scala` filename actually declares that type.
+  private def declaresTopLevel(tree: untpd.Tree, target: String): Boolean =
+    tree match
+      case untpd.EmptyTree       => true  // parse failure: don't false-positive
+      case pkg: untpd.PackageDef =>
+        pkg.stats.exists:
+          case td: untpd.TypeDef    => td.name.toString == target
+          case md: untpd.ModuleDef  => md.name.toString == target
+          case nested: untpd.PackageDef => declaresTopLevel(nested, target)
+          case _                    => false
+      case _                     => false
 
   private def isCrossModuleExport(base: String): Boolean =
     val u = base.indexOf('_')

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -66,11 +66,13 @@ object Checker:
     state.annotationEndLines = Annotations.collectEndLines(untpdTree, source)
     state.companions         = Companions.extract(untpdTree, source)
     val caseGroups           = Cases.extract(untpdTree, source)
+    val forGroups            = Comprehensions.extract(untpdTree, source)
     scanRawTabs(file, rawText, out)
     checkFileNaming(file, untpdTree, out)
     checkPackageRules(file, expectedModule, state.packageInfo, out)
     checkImportRules(file, imports, lines, out)
     checkCaseRules(file, caseGroups, lines, out)
+    checkForRules(file, forGroups, out)
     var idx = 0
 
     while idx < lines.length do
@@ -1993,7 +1995,6 @@ object Checker:
     if k2Idx < 0 then return
     val k2 = toks(k2Idx)
     applySequenceRules(file, List(k1, chainElem(k2, k2Idx)), toks, out)
-    checkGeneratorAlignment(toks, start, k2Idx, file, out)
 
   private def processWhileSeq
     ( toks: IndexedSeq[Pos], start: Int, file: String, out: mutable.ListBuffer[Violation] )
@@ -2035,92 +2036,43 @@ object Checker:
     else
       applySequenceRules(file, List(k1, chainElem(first, firstIdx)), toks, out)
 
-  // R34: alignment within a for-comprehension's generator block. The block
-  // spans tokens between `for` (at `forIdx`) and the matching `yield`/`do`
-  // (at `kwIdx`). For every gen/bind/filter line that begins at depth-0
-  // within the block, check that the LHS column and `<-`/`=` column match
-  // the first generator's, and that an `if` filter sits at the operator
-  // column.
-  private def checkGeneratorAlignment
-    ( toks:   IndexedSeq[Pos],
-      forIdx: Int,
-      kwIdx:  Int,
-      file:   String,
-      out:    mutable.ListBuffer[Violation] )
+  // R34: alignment within each for-comprehension's enumerator block. The
+  // first non-filter generator's LHS column and `<-`/`=` column define the
+  // reference. Other generators must match both; bindings (`y = e`) match
+  // the same way; filter lines (`if expr`) must instead sit at the
+  // operator column. Single-line comprehensions collapse to one
+  // enumerator per group and skip the check.
+  private def checkForRules
+    ( file:    String,
+      groups:  List[List[GenLine]],
+      out:     mutable.ListBuffer[Violation] )
   :   Unit =
 
-    case class GenLine(line: Int, startCol: Int, opCol: Int, isFilter: Boolean)
+    groups.foreach: gens =>
+      if gens.length >= 2 then
+        val firstGen = gens.find(!_.isFilter).getOrElse(gens.head)
+        val refLhs   = firstGen.startCol
+        val refOp    = firstGen.opCol
 
-    // Group token indices by their line, in order of appearance.
-    val byLine = mutable.LinkedHashMap[Int, mutable.ArrayBuffer[Int]]()
-    var i      = forIdx + 1
-    while i < kwIdx do
-      val ln = toks(i).line
-      byLine.getOrElseUpdate(ln, mutable.ArrayBuffer[Int]()) += i
-      i += 1
-
-    // Walk lines in order, tracking paren/bracket depth so we can identify
-    // continuation lines (depth > 0 at line start).
-    val genLines = mutable.ArrayBuffer[GenLine]()
-    var depth    = 0
-    byLine.foreach: (ln, idxs) =>
-      val depthAtStart = depth
-      // Update depth across this line's tokens for the next iteration.
-      var j = 0
-      while j < idxs.length do
-        val t = toks(idxs(j)).text
-        if t == "(" || t == "[" || t == "{" then depth += 1
-        else if t == ")" || t == "]" || t == "}" then depth -= 1
-        j += 1
-
-      if depthAtStart == 0 && idxs.nonEmpty then
-        val first = toks(idxs(0))
-        if first.text == "if" then
-          genLines += GenLine(ln, first.col, first.col, isFilter = true)
-        else
-          // Find first `<-` or `=` at line-relative depth 0.
-          var d     = 0
-          var opCol = -1
-          var k     = 0
-          while k < idxs.length && opCol < 0 do
-            val t = toks(idxs(k)).text
-            if t == "(" || t == "[" || t == "{" then d += 1
-            else if t == ")" || t == "]" || t == "}" then d -= 1
-            else if d == 0 && (t == "<-" || t == "=") then opCol = toks(idxs(k)).col
-            k += 1
-          if opCol >= 0 then
-            genLines += GenLine(ln, first.col, opCol, isFilter = false)
-
-    // Need at least two generator/binding/filter lines for alignment to bite.
-    if genLines.length < 2 then return
-
-    // The first non-filter line establishes the LHS and operator columns.
-    val firstGen = genLines.find(!_.isFilter).getOrElse(genLines.head)
-    val refLhs   = firstGen.startCol
-    val refOp    = firstGen.opCol
-
-    var idx = 0
-    while idx < genLines.length do
-      val gl = genLines(idx)
-      if !(gl.line == firstGen.line && gl.startCol == firstGen.startCol) then
-        if gl.isFilter then
-          if gl.startCol != refOp then
-            out += Violation
-                    ( file, gl.line, gl.startCol, "34.3",
-                      s"`if` filter should align with `<-`/`=` at column $refOp "
-                        +s"(found ${gl.startCol})" )
-        else
-          if gl.startCol != refLhs then
-            out += Violation
-                    ( file, gl.line, gl.startCol, "34.2",
-                      s"generator should align with the first generator's LHS at column "
-                        +s"$refLhs (found ${gl.startCol})" )
-          if gl.opCol != refOp then
-            out += Violation
-                    ( file, gl.line, gl.opCol, "34.1",
-                      s"`<-`/`=` should be vertically aligned at column $refOp "
-                        +s"(found ${gl.opCol})" )
-      idx += 1
+        gens.foreach: gl =>
+          if !(gl.line == firstGen.line && gl.startCol == firstGen.startCol) then
+            if gl.isFilter then
+              if gl.startCol != refOp then
+                out += Violation
+                        ( file, gl.line, gl.startCol, "34.3",
+                          s"`if` filter should align with `<-`/`=` at column $refOp "
+                            +s"(found ${gl.startCol})" )
+            else
+              if gl.startCol != refLhs then
+                out += Violation
+                        ( file, gl.line, gl.startCol, "34.2",
+                          s"generator should align with the first generator's LHS at column "
+                            +s"$refLhs (found ${gl.startCol})" )
+              if gl.opCol != refOp then
+                out += Violation
+                        ( file, gl.line, gl.opCol, "34.1",
+                          s"`<-`/`=` should be vertically aligned at column $refOp "
+                            +s"(found ${gl.opCol})" )
 
   private def checkSequences
     ( file:  String,

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -60,10 +60,12 @@ object Checker:
     val state = State(file, expectedModule)
     val lines = Tokenizer.tokenize(rawText)
     val imports = Imports.extract(untpdTree, source)
+    state.packageInfo   = Packages.extract(untpdTree, source)
     state.importLineSet = imports.iterator.flatMap(i => i.startLine to i.endLine).toSet
     state.hasImports    = imports.nonEmpty
     scanRawTabs(file, rawText, out)
     checkFileNaming(file, out)
+    checkPackageRules(file, expectedModule, state.packageInfo, out)
     checkImportRules(file, imports, lines, out)
     var idx = 0
 
@@ -114,6 +116,7 @@ object Checker:
     var consecutiveBlanks:    Int                        = 0
     var importLineSet:        Set[Int]                   = Set.empty
     var hasImports:           Boolean                    = false
+    var packageInfo:          Option[PackageInfo]        = None
     var prevLineWasBlank:     Boolean                    = false
     var prevWasAnnotation:    Boolean                    = false
     var prevLineNum:          Int                        = 0
@@ -208,7 +211,7 @@ object Checker:
 
     s.phase match
       case Phase.License      => checkLicense(s, lineNum, line, emit)
-      case Phase.Package      => checkPackage(s, lineNum, rest, emit)
+      case Phase.Package      => checkPackage(s)
       case Phase.AfterPackage => checkAfterPackage(s, isBlank, emit)
       case Phase.Imports      => checkImports(s, isBlank, lineNum, emit)
       case Phase.Body         => ()
@@ -495,44 +498,55 @@ object Checker:
         emit(1, "6", "line 32 must close the license-header block comment with `*/`")
       s.phase = Phase.Package
 
-  private def checkPackage
-    ( s:       State,
-      lineNum: Int,
-      rest:    IndexedSeq[Token],
-      emit:    (Int, String, String) => Unit )
+  // Phase machine: when the line containing the package declaration is
+  // reached (or any line beyond the license region if the file has no
+  // valid package), advance the phase. R7 violations are emitted from
+  // `checkPackageRules` over the parsed `PackageDef`.
+  private def checkPackage(s: State): Unit =
+    s.packageInfo match
+      case Some(p) if p.line == PackageLine => s.phase = Phase.AfterPackage
+      case _                                => s.phase = Phase.Body
+
+  // R7: validate the file's `package` declaration. The parsed package
+  // info distinguishes "no real declaration" (empty-package wrapper)
+  // from a real `PackageDef`. Multi-segment paths (`a.b`), wrong line,
+  // names that don't match `expectedModule`, names with invalid
+  // characters (e.g. backticked identifiers), and extra statements on
+  // the same line are each rejected with rule "7".
+  private def checkPackageRules
+    ( file:           String,
+      expectedModule: Option[String],
+      pkg:            Option[PackageInfo],
+      out:            mutable.ListBuffer[Violation] )
   :   Unit =
 
-    if lineNum != PackageLine then
-      emit
-        ( 1, "7",
-          s"expected `package` declaration on line 33, found content on line $lineNum" )
-      s.phase = Phase.Body
-    else
-      val nonWs = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment).toList
-      nonWs match
-        case keyword :: ident :: tail
-          if keyword.text == "package" && ident.kind == Kind.Code =>
+    pkg match
+      case None =>
+        out += Violation(file, PackageLine, 1, "7", "line 33 must be `package <module>`")
 
-          if !ident.text.matches("[A-Za-z_][A-Za-z0-9_]*") then
-            emit
-              ( 1, "7",
-                s"package declaration must be a single identifier segment, not `${ident.text}`" )
+      case Some(p) if p.line != PackageLine =>
+        out += Violation
+                ( file, p.line, 1, "7",
+                  s"expected `package` declaration on line 33, "
+                    +s"found content on line ${p.line}" )
 
-          s.expectedModule.foreach: expected =>
-            if ident.text != expected then
-              emit
-                ( 1, "7",
-                  s"package `${ident.text}` does not match expected module `$expected`" )
+      case Some(p) =>
+        val name = p.segments.mkString(".")
+        if p.segments.length > 1 || !p.segments.head.matches("[A-Za-z_][A-Za-z0-9_]*") then
+          out += Violation
+                  ( file, p.line, 1, "7",
+                    s"package declaration must be a single identifier segment, not `$name`" )
+        else
+          expectedModule.foreach: expected =>
+            if name != expected then
+              out += Violation
+                      ( file, p.line, 1, "7",
+                        s"package `$name` does not match expected module `$expected`" )
 
-          if tail.nonEmpty then
-            emit
-              ( 1, "7",
-                "package declaration must contain only `package <ident>` on line 33" )
-
-        case _ =>
-          emit(1, "7", "line 33 must be `package <module>`")
-
-      s.phase = Phase.AfterPackage
+        if p.extraStatementOnSameLine then
+          out += Violation
+                  ( file, p.line, 1, "7",
+                    "package declaration must contain only `package <ident>` on line 33" )
 
   private def checkAfterPackage
     ( s: State, isBlank: Boolean, emit: (Int, String, String) => Unit )

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -34,16 +34,37 @@ package decorum
 
 import scala.collection.mutable
 
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
 object Checker:
   private val MaxColumns: Int = 100
   private val PackageLine: Int = 33
 
+  // Test-friendly entry point: parses `rawText` standalone via `Parsing.parse`
+  // before delegating to the tree-aware overload. The plugin should call the
+  // overload below directly with the compilation unit's existing untyped
+  // tree to avoid re-parsing.
   def check(file: String, expectedModule: Option[String], rawText: String): LazyList[Violation] =
+    val (tree, source) = Parsing.parse(file, rawText)
+    check(file, expectedModule, rawText, tree, source)
+
+  def check
+     ( file:           String,
+       expectedModule: Option[String],
+       rawText:        String,
+       untpdTree:      untpd.Tree,
+       source:         SourceFile )
+  :   LazyList[Violation] =
     val out   = mutable.ListBuffer[Violation]()
     val state = State(file, expectedModule)
     val lines = Tokenizer.tokenize(rawText)
+    val imports = Imports.extract(untpdTree, source)
+    state.importLineSet = imports.iterator.flatMap(i => i.startLine to i.endLine).toSet
+    state.hasImports    = imports.nonEmpty
     scanRawTabs(file, rawText, out)
     checkFileNaming(file, out)
+    checkImportRules(file, imports, lines, out)
     var idx = 0
 
     while idx < lines.length do
@@ -91,8 +112,8 @@ object Checker:
   private class State(val file: String, val expectedModule: Option[String]):
     var phase:                Phase                      = Phase.License
     var consecutiveBlanks:    Int                        = 0
-    var prevImportGroup:      Option[Int]                = None
-    var prevImportName:       Option[String]             = None
+    var importLineSet:        Set[Int]                   = Set.empty
+    var hasImports:           Boolean                    = false
     var prevLineWasBlank:     Boolean                    = false
     var prevWasAnnotation:    Boolean                    = false
     var prevLineNum:          Int                        = 0
@@ -101,7 +122,6 @@ object Checker:
     var prevCodeLineIndent:   Int                        = -1
     var prevLineEndedMatch:   Boolean                    = false
     var prevCodeLineLastTok:  String                     = ""
-    var inMultilineImport:    Boolean                    = false
     var caseRun:              Option[CaseRun]            = None
     var blanksSinceDecl:      Int                        = 0
     var prevDeclByIndent:     mutable.Map[Int, DeclShape] = mutable.Map.empty
@@ -178,7 +198,7 @@ object Checker:
     if !isStringContent && s.openParens == 0 then
       checkR3IndentWidth(isBlank, leadingCols, emit)
     checkR4TrailingWs(line, emit)
-    checkR31ContinuationIndent(s, leadingCols, isBlank, firstReal, emit)
+    checkR31ContinuationIndent(s, lineNum, leadingCols, isBlank, firstReal, emit)
 
     if isBlank then
       s.consecutiveBlanks += 1
@@ -190,7 +210,7 @@ object Checker:
       case Phase.License      => checkLicense(s, lineNum, line, emit)
       case Phase.Package      => checkPackage(s, lineNum, rest, emit)
       case Phase.AfterPackage => checkAfterPackage(s, isBlank, emit)
-      case Phase.Imports      => checkImports(s, isBlank, firstReal, rest, emit)
+      case Phase.Imports      => checkImports(s, isBlank, lineNum, emit)
       case Phase.Body         => ()
 
     checkTokens(s, lineNum, line, s.prevCodeLineLastTok, emit)
@@ -331,6 +351,7 @@ object Checker:
   // is governed by R12/R22/R30 and the surrounding bracket structure.
   private def checkR31ContinuationIndent
     ( s:           State,
+      lineNum:     Int,
       leadingCols: Int,
       isBlank:     Boolean,
       firstReal:   Option[Token],
@@ -341,7 +362,7 @@ object Checker:
     else if s.prevCodeLineIndent < 0 then ()
     else if s.bracketFormality.nonEmpty then ()
     else if s.quoteSpliceBraces.nonEmpty then ()
-    else if s.inMultilineImport then ()
+    else if s.importLineSet.contains(lineNum) then ()
     else
       val isCommentOnly   = firstReal.exists(_.kind == Kind.Comment)
       val isStringContent = firstReal.exists(_.kind == Kind.Strs)
@@ -522,118 +543,107 @@ object Checker:
 
     s.phase = Phase.Imports
 
+  // Drives the phase machine across the imports region. R9.1/9.2/9.3 are
+  // emitted from `checkImportRules` over the parsed import list; this
+  // function only handles transition to `Phase.Body` and R10 (blank line
+  // between imports and the first declaration).
   private def checkImports
-    ( s:         State,
-      isBlank:   Boolean,
-      firstReal: Option[Token],
-      rest:      IndexedSeq[Token],
-      emit:      (Int, String, String) => Unit )
+    ( s:       State,
+      isBlank: Boolean,
+      lineNum: Int,
+      emit:    (Int, String, String) => Unit )
   :   Unit =
 
-    if isBlank then s.inMultilineImport = false
-    else if s.inMultilineImport then
-      // Continuation of a multi-line `import …,\n  more, more` or
-      // `import …{a, b,\n  c}` statement. Update state and skip checks.
-      s.inMultilineImport = importContinues(rest)
-    else firstReal.foreach: head =>
-      if head.text == "import" then
-        val path  = importPath(rest)
-        val group = classifyImport(path)
-        // Top-level aliases are forbidden only for soundness libs (group 4
-        // and 5). Standard-library aliases (`import scala.collection.mutable
-        // as scm`, `import java.util.concurrent as juc`, etc.) and
-        // language-feature aliases are an established convention.
-        if importHasAlias(rest) && group >= 5 then
-          emit
-            ( 1, "9.1",
-              "top-level imports must not use aliases (`as` or `=>`); write the full path" )
-
-        s.prevImportGroup match
-          case Some(prevGroup) =>
-            // Groups 5 and 6 are "third-party" siblings: lowercase wildcard
-            // (`import contingency.*`) and other named imports
-            // (`import filesystemOptions.x`, `import AsyncError.Reason`)
-            // routinely interleave in soundness code, so we don't require
-            // ordering or blank lines between them. Alphabetical and
-            // blank-within-group checks still apply within strictly the same
-            // group (5 with 5, 6 with 6).
-            val areSiblings = group >= 5 && prevGroup >= 5
-            if !areSiblings && group < prevGroup then
-              emit
-                ( 1, "9.2",
-                  s"import group $group appears after group $prevGroup" )
-            else if !areSiblings && group > prevGroup then
-              if !s.prevLineWasBlank then
-                emit
-                  ( 1, "9.3",
-                    "import groups must be separated by exactly one blank line" )
-            else if group == prevGroup then
-              if s.prevLineWasBlank then
-                emit
-                  ( 1, "9.3",
-                    "unexpected blank line within an import group" )
-              s.prevImportName.foreach: prevName =>
-                if path < prevName then
-                  emit
-                    ( 1, "9.2",
-                      s"import `$path` is out of alphabetical order (after `$prevName`)" )
-
-          case None => ()
-
-        s.prevImportGroup = Some(group)
-        s.prevImportName  = Some(path)
-        s.inMultilineImport = importContinues(rest)
-      else
-        if !s.prevLineWasBlank && s.prevImportGroup.isDefined then
-          emit
-            ( 1, "10",
-              "missing blank line between imports and first declaration" )
-        s.phase = Phase.Body
-
-  private def importContinues(rest: IndexedSeq[Token]): Boolean =
-    val nonWs = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment)
-    if nonWs.isEmpty then false
+    if isBlank then ()
+    else if s.importLineSet.contains(lineNum) then ()
     else
-      val opens  = nonWs.count(_.text == "{")
-      val closes = nonWs.count(_.text == "}")
-      val unbalanced = opens > closes
-      val endsWithComma = nonWs.last.text == ","
-      unbalanced || endsWithComma
+      if !s.prevLineWasBlank && s.hasImports then
+        emit(1, "10", "missing blank line between imports and first declaration")
+      s.phase = Phase.Body
 
-  // Detects top-level `as` / `=>` aliases on an import statement, e.g.
-  // `import scala.collection.immutable as sci`. Selector-renaming inside
-  // braces (`import java.nio.file.{Files, Path as JPath}`) is permitted —
-  // an `as` token at depth > 0 (inside `{…}`) does not count.
-  private def importHasAlias(rest: IndexedSeq[Token]): Boolean =
-    var depth = 0
-    var found = false
-    rest.foreach: t =>
-      if t.kind == Kind.Code then
-        if t.text == "{" then depth += 1
-        else if t.text == "}" then depth -= 1
-        else if depth == 0 && (t.text == "as" || t.text == "=>") then found = true
-    found
+  // R9.1/9.2/9.3: classify and order the parsed top-level imports. Multi-line
+  // imports (`import a.{\n  b,\n  c\n}`) span lines naturally via the tree,
+  // and multi-import lines (`import a.b, c.d`) appear as multiple Import
+  // nodes whose `startLine` collide — only the first import on each line
+  // drives the group, the rest are treated as continuations.
+  private def checkImportRules
+    ( file:    String,
+      imports: List[ImportInfo],
+      lines:   IndexedSeq[IndexedSeq[Token]],
+      out:     mutable.ListBuffer[Violation] )
+  :   Unit =
 
-  private def importPath(rest: IndexedSeq[Token]): String =
-    val nonWs = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment).toList
-    nonWs match
-      case _ :: tail =>
-        // Stop at a top-level `as` (rename of the whole import). An `as`
-        // inside braces (`{Float as _, *}`) is a selector rename and is
-        // part of the import path.
-        val sb    = new StringBuilder
-        var depth = 0
-        var done  = false
-        tail.foreach: t =>
-          if !done then
-            if t.text == "{" then { depth += 1; sb.append(t.text) }
-            else if t.text == "}" then { depth -= 1; sb.append(t.text) }
-            else if depth == 0 && t.text == "as" then done = true
-            else sb.append(t.text)
-        sb.toString
+    val rows: List[ImportInfo] =
+      imports.groupBy(_.startLine).toList.sortBy(_._1).flatMap(_._2.headOption)
 
-      case _ =>
-        ""
+    var prevGroup:   Option[Int]    = None
+    var prevName:    Option[String] = None
+    var prevEndLine: Int            = -1
+
+    rows.foreach: imp =>
+      val group = classifyImport(imp.path)
+
+      // Top-level aliases are forbidden only for soundness libs (group 5+).
+      // Standard-library aliases (`import scala.collection.mutable as scm`,
+      // `import java.util.concurrent as juc`) and language-feature aliases
+      // remain an established convention.
+      if imp.hasTopLevelAlias && group >= 5 then
+        out += Violation
+                ( file, imp.startLine, 1, "9.1",
+                  "top-level imports must not use aliases (`as` or `=>`); "
+                    +"write the full path" )
+
+      prevGroup match
+        case Some(pg) =>
+          // Groups 5 and 6 are "third-party" siblings: lowercase wildcard
+          // (`import contingency.*`) and other named imports
+          // (`import filesystemOptions.x`, `import AsyncError.Reason`)
+          // routinely interleave in soundness code, so we don't require
+          // ordering or blank lines between them. Alphabetical and
+          // blank-within-group checks still apply within strictly the
+          // same group (5 with 5, 6 with 6).
+          val areSiblings  = group >= 5 && pg >= 5
+          val blankBetween = blankLinesBetween(prevEndLine, imp.startLine, lines) > 0
+          if !areSiblings && group < pg then
+            out += Violation
+                    ( file, imp.startLine, 1, "9.2",
+                      s"import group $group appears after group $pg" )
+          else if !areSiblings && group > pg then
+            if !blankBetween then
+              out += Violation
+                      ( file, imp.startLine, 1, "9.3",
+                        "import groups must be separated by exactly one blank line" )
+          else if group == pg then
+            if blankBetween then
+              out += Violation
+                      ( file, imp.startLine, 1, "9.3",
+                        "unexpected blank line within an import group" )
+            prevName.foreach: pn =>
+              if imp.path < pn then
+                out += Violation
+                        ( file, imp.startLine, 1, "9.2",
+                          s"import `${imp.path}` is out of alphabetical order "
+                            +s"(after `$pn`)" )
+        case None => ()
+
+      prevGroup   = Some(group)
+      prevName    = Some(imp.path)
+      prevEndLine = imp.endLine
+
+  private def blankLinesBetween
+    ( prevEnd: Int,
+      curStart: Int,
+      lines: IndexedSeq[IndexedSeq[Token]] )
+  :   Int =
+    var count = 0
+    var l     = prevEnd + 1
+    while l < curStart do
+      val idx = l - 1
+      if idx >= 0 && idx < lines.length then
+        val toks = lines(idx)
+        if toks.isEmpty || toks.forall(_.kind == Kind.Space) then count += 1
+      l += 1
+    count
 
   private def classifyImport(path: String): Int =
     // For multi-import lines (`import a.*, b.x, c.y`), classify by the first

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -64,6 +64,7 @@ object Checker:
     state.importLineSet      = imports.iterator.flatMap(i => i.startLine to i.endLine).toSet
     state.hasImports         = imports.nonEmpty
     state.annotationEndLines = Annotations.collectEndLines(untpdTree, source)
+    state.companions         = Companions.extract(untpdTree, source)
     scanRawTabs(file, rawText, out)
     checkFileNaming(file, out)
     checkPackageRules(file, expectedModule, state.packageInfo, out)
@@ -134,8 +135,7 @@ object Checker:
     var usingNameColumn:      Option[Int]                = None
     var prevLineHadAlignment: Boolean                    = false
     var pendingR11:           List[Violation]            = Nil
-    val typeDecls:            mutable.Map[String, Int]   = mutable.Map.empty
-    val objectDecls:          mutable.Map[String, Int]   = mutable.Map.empty
+    var companions:           CompanionDecls             = CompanionDecls(Map.empty, Map.empty)
     // Cross-line tracking for R30: each unclosed `(`/`[` records whether it
     // looked like a formal-block opener and the indent of the line it
     // opened on. Closers on later lines pop to decide whether the bracket
@@ -227,7 +227,6 @@ object Checker:
     checkMatchCases(s, lineNum, leadingCols, isBlank, rest, line, out)
     checkSiblingPadding(s, lineNum, leadingCols, isBlank, rest, out)
     checkUsingAlignment(s, lineNum, leadingCols, rest, emit)
-    recordDeclarations(s, lineNum, rest)
     if !isBlank then
       s.prevLineEndedMatch = lineEndsWithMatch(rest)
       val sem = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment)
@@ -1366,20 +1365,6 @@ object Checker:
     rest.length >= 2 && rest(0).text == ":" && rest(1).kind == Kind.Space
       && rest(1).text == "   " && rest.lastOption.exists(_.text == "=")
 
-  private def recordDeclarations(s: State, lineNum: Int, rest: IndexedSeq[Token]): Unit =
-    val nonWs = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment)
-    if nonWs.nonEmpty then
-      val (kw, idx) = skipModifiers(nonWs, 0)
-      if idx < nonWs.length then
-        val keyword = nonWs(idx).text
-        val nameIdx = idx + 1
-        if nameIdx < nonWs.length && nonWs(nameIdx).kind == Kind.Code then
-          val name = nonWs(nameIdx).text
-          if keyword == "class" || keyword == "trait" || keyword == "enum" then
-            if !s.typeDecls.contains(name) then s.typeDecls(name) = lineNum
-          else if keyword == "object" then
-            if !s.objectDecls.contains(name) then s.objectDecls(name) = lineNum
-
   private val ModifierWords: Set[String] = Set
     ( "private", "protected", "public", "final", "sealed", "abstract",
       "implicit", "lazy", "override", "case", "inline", "transparent",
@@ -1400,8 +1385,8 @@ object Checker:
     ( file: String, s: State, out: mutable.ListBuffer[Violation] )
   :   Unit =
 
-    s.objectDecls.foreach: (name, objLine) =>
-      s.typeDecls.get(name).foreach: typeLine =>
+    s.companions.objectLines.foreach: (name, objLine) =>
+      s.companions.typeLines.get(name).foreach: typeLine =>
         if objLine > typeLine then
           out +=
             Violation

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -65,10 +65,12 @@ object Checker:
     state.hasImports         = imports.nonEmpty
     state.annotationEndLines = Annotations.collectEndLines(untpdTree, source)
     state.companions         = Companions.extract(untpdTree, source)
+    val caseGroups           = Cases.extract(untpdTree, source)
     scanRawTabs(file, rawText, out)
     checkFileNaming(file, untpdTree, out)
     checkPackageRules(file, expectedModule, state.packageInfo, out)
     checkImportRules(file, imports, lines, out)
+    checkCaseRules(file, caseGroups, lines, out)
     var idx = 0
 
     while idx < lines.length do
@@ -82,7 +84,6 @@ object Checker:
 
     state.pendingR11.foreach(out += _)
     state.pendingR11 = Nil
-    finalizeCaseRun(state, out)
     checkCompanionOrdering(file, state, out)
     checkSequences(file, lines, out)
     LazyList.from(out)
@@ -108,9 +109,6 @@ object Checker:
       val idx    = base.indexOf(prefix)
       if idx > 0 then Some(base.substring(0, idx).nn) else Some(moduleDir)
 
-  private case class CaseEntry(lineNum: Int, arrowCol: Int)
-  private class CaseRun(val indent: Int, val cases: mutable.ListBuffer[CaseEntry])
-
   private case class DeclShape(line: Int, indent: Int, kwSeq: String, padding: Int)
 
   private class State(val file: String, val expectedModule: Option[String]):
@@ -126,9 +124,7 @@ object Checker:
     var prevWasReturnType:    Boolean                    = false
     var prevReturnTypeLine:   Int                        = 0
     var prevCodeLineIndent:   Int                        = -1
-    var prevLineEndedMatch:   Boolean                    = false
     var prevCodeLineLastTok:  String                     = ""
-    var caseRun:              Option[CaseRun]            = None
     var blanksSinceDecl:      Int                        = 0
     var prevDeclByIndent:     mutable.Map[Int, DeclShape] = mutable.Map.empty
     var openParens:           Int                        = 0
@@ -224,11 +220,9 @@ object Checker:
     checkChainContinuation(s, lineNum, leadingCols, isBlank, firstReal, emit)
     checkR32GivenArrowAlign(s, leadingCols, isBlank, rest, emit)
     checkReturnTypeBlank(s, lineNum, isBlank, rest, emit)
-    checkMatchCases(s, lineNum, leadingCols, isBlank, rest, line, out)
     checkSiblingPadding(s, lineNum, leadingCols, isBlank, rest, out)
     checkUsingAlignment(s, lineNum, leadingCols, rest, emit)
     if !isBlank then
-      s.prevLineEndedMatch = lineEndsWithMatch(rest)
       val sem = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment)
       sem.lastOption.foreach: t => s.prevCodeLineLastTok = t.text
       s.prevFormalOpenerIndent = s.currentFormalOpenerIndent
@@ -1455,103 +1449,76 @@ object Checker:
       // Cross-module export pattern: <other-module>_<this-module>_core or <other-module>.<TypeName>
       prefix.headOption.exists(_.isLower)
 
-  private def lineEndsWithMatch(rest: IndexedSeq[Token]): Boolean =
-    val sem = rest.filter(t => t.kind != Kind.Space && t.kind != Kind.Comment)
-    sem.lastOption.exists(_.text == "match")
-      || (sem.length >= 2 && sem(sem.length - 2).text == "match" && sem.last.text == ":")
-
-  private case class CaseLine(arrowCol: Int, isSingleLine: Boolean, isCase: Boolean)
-
-  private def parseCaseLine(rest: IndexedSeq[Token], leadingCols: Int): CaseLine =
-    if rest.isEmpty || rest(0).text != "case" then CaseLine(-1, false, false)
-    else
-      val secondSem = rest.indexWhere(t => t.kind != Kind.Space && t.kind != Kind.Comment, 1)
-      if secondSem >= 0 && (rest(secondSem).text == "class" || rest(secondSem).text == "object")
-      then CaseLine(-1, false, false)
-      else
-        val arrowIdx = rest.indexWhere(t => t.text == "=>")
-        // No `=>` on this line — it's an enum case (or a match case with a
-        // multi-line pattern, which is uncommon). Either way, skip both R19 and R20.
-        if arrowIdx < 0 then CaseLine(-1, false, false)
-        else
-          var col = leadingCols + 1
-          var k = 0
-          while k < arrowIdx do
-            col += rest(k).text.length
-            k += 1
-          val hasBodyAfter = rest.drop(arrowIdx + 1).exists: t =>
-            t.kind != Kind.Space && t.kind != Kind.Comment
-          CaseLine(col, hasBodyAfter, true)
-
-  private def checkMatchCases
-    ( s:           State,
-      lineNum:     Int,
-      leadingCols: Int,
-      isBlank:     Boolean,
-      rest:        IndexedSeq[Token],
-      line:        IndexedSeq[Token],
-      out:         mutable.ListBuffer[Violation] )
+  // R19/R20: walk each `Match`/`Try` case group from the parsed tree.
+  // Within a group, runs of *single-line* cases at the same indent with no
+  // intervening blank lines must have their `=>` columns aligned (R19);
+  // any *multi-line* case other than the first in its group must be
+  // preceded by a blank line (R20). A separate sub-check requires exactly
+  // one space before `=>` in a multi-line case.
+  private def checkCaseRules
+    ( file:   String,
+      groups: List[List[CaseInfo]],
+      lines:  IndexedSeq[IndexedSeq[Token]],
+      out:    mutable.ListBuffer[Violation] )
   :   Unit =
 
-    inline def emit(col: Int, rule: String, msg: String): Unit =
-      out += Violation(s.file, lineNum, col, rule, msg)
+    groups.foreach: group =>
+      // R20: blank line required before each non-first multi-line case
+      // unless the source already has one.
+      group.zipWithIndex.foreach: (c, i) =>
+        if !c.isSingleLine then
+          if i > 0 && !blankBetween(group(i - 1).endLine, c.caseLine, lines) then
+            out += Violation
+                    ( file, c.caseLine, c.caseCol, "20",
+                      "a blank line is required before a multi-line case "
+                        +"(except for the first case)" )
+          // Sub-check: exactly one space before `=>` in a multi-line case.
+          if c.spacesBeforeArrow != 1 then
+            out += Violation
+                    ( file, c.arrowLine, c.arrowCol, "R33-multiline-case-arrow-space",
+                      "exactly one space is required before `=>` in a multi-line case" )
 
-    if isBlank then
-      finalizeCaseRun(s, out)
-      return
+      // R19: split into runs of consecutive single-line cases at the same
+      // case-keyword column with no blank line between them; align `=>` in
+      // any run of size ≥ 2.
+      val runs = mutable.ListBuffer[mutable.ListBuffer[CaseInfo]]()
+      var current: Option[mutable.ListBuffer[CaseInfo]] = None
+      var prev:    Option[CaseInfo]                     = None
+      group.foreach: c =>
+        val canExtend = c.isSingleLine && current.exists: run =>
+          val head = run.head
+          head.caseCol == c.caseCol && !blankBetween(prev.get.endLine, c.caseLine, lines)
+        if canExtend then current.get += c
+        else
+          current = if c.isSingleLine then
+            val r = mutable.ListBuffer[CaseInfo](c)
+            runs += r
+            Some(r)
+          else None
+        prev = Some(c)
 
-    val info = parseCaseLine(rest, leadingCols)
-    if !info.isCase then
-      // Non-case line: close any active run
-      finalizeCaseRun(s, out)
-    else
-      // Multi-line case isolation (Rule 20)
-      if !info.isSingleLine then
-        val isFirstInScope = s.prevCodeLineIndent < leadingCols
-        if !s.prevLineWasBlank && !s.prevLineEndedMatch && !isFirstInScope then
-          emit
-            ( leadingCols + 1, "20",
-              "a blank line is required before a multi-line case (except for the first case)" )
+      runs.foreach: run =>
+        if run.size >= 2 then
+          val expected = run.iterator.map(_.arrowCol).max
+          run.foreach: c =>
+            if c.arrowCol != expected then
+              out += Violation
+                      ( file, c.arrowLine, c.arrowCol, "19",
+                        s"`=>` should be at column $expected to align with the case run" )
 
-        // R33: a multi-line case must have exactly one space before `=>` —
-        // alignment-padding only applies to runs of single-line cases (R19).
-        val arrowIdx = rest.indexWhere(_.text == "=>")
-        if arrowIdx > 0 then
-          val before = rest(arrowIdx - 1)
-          if before.kind != Kind.Space || before.text != " " then
-            var c = leadingCols + 1
-            var k = 0
-            while k < arrowIdx do
-              c += rest(k).text.length
-              k += 1
-            emit
-              ( c, "R33-multiline-case-arrow-space",
-                "exactly one space is required before `=>` in a multi-line case" )
-
-        finalizeCaseRun(s, out)
-      else
-        // Single-line case
-        s.caseRun match
-          case Some(run) if run.indent == leadingCols && !s.prevLineWasBlank =>
-            run.cases += CaseEntry(lineNum, info.arrowCol)
-
-          case _ =>
-            finalizeCaseRun(s, out)
-            val newRun = CaseRun(leadingCols, mutable.ListBuffer.empty)
-            newRun.cases += CaseEntry(lineNum, info.arrowCol)
-            s.caseRun = Some(newRun)
-
-  private def finalizeCaseRun(s: State, out: mutable.ListBuffer[Violation]): Unit =
-    s.caseRun.foreach: run =>
-      if run.cases.size >= 2 then
-        val expected = run.cases.iterator.map(_.arrowCol).max
-        run.cases.foreach: entry =>
-          if entry.arrowCol != expected then
-            out +=
-              Violation
-                ( s.file, entry.lineNum, entry.arrowCol, "19",
-                  s"`=>` should be at column $expected to align with the case run" )
-    s.caseRun = None
+  private def blankBetween
+    ( prevEnd:  Int,
+      curStart: Int,
+      lines:    IndexedSeq[IndexedSeq[Token]] )
+  :   Boolean =
+    var l = prevEnd + 1
+    while l < curStart do
+      val idx = l - 1
+      if idx >= 0 && idx < lines.length then
+        val toks = lines(idx)
+        if toks.isEmpty || toks.forall(_.kind == Kind.Space) then return true
+      l += 1
+    false
 
   private val DeclKeywords: Set[String] =
     Set("def", "val", "var", "type", "class", "trait", "object", "enum", "given")

--- a/lib/decorum/src/plugin/decorum.Companions.scala
+++ b/lib/decorum/src/plugin/decorum.Companions.scala
@@ -1,0 +1,88 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package decorum
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
+case class CompanionDecls
+   ( typeLines:   Map[String, Int],
+     objectLines: Map[String, Int] )
+
+object Companions:
+  // Walk the tree collecting (name -> first-line) maps for type-like decls
+  // (class/trait/enum) and for objects. R28 asks that the object precede
+  // its companion type, which becomes a simple line comparison over the
+  // intersection of these maps. Matching the previous token-based
+  // recorder, we apply first-wins across the whole file rather than
+  // restricting to a particular scope.
+  def extract(tree: untpd.Tree, source: SourceFile): CompanionDecls =
+    val types   = mutable.Map[String, Int]()
+    val objects = mutable.Map[String, Int]()
+
+    def line(t: untpd.Tree): Option[Int] =
+      val sp = t.span
+      if sp.exists then Some(source.offsetToLine(sp.start) + 1) else None
+
+    walk(tree): t =>
+      t match
+        case td: untpd.TypeDef =>
+          // A `TypeDef` with a `Template` rhs is a class/trait/enum;
+          // type aliases (`type X = Y`) have a non-Template rhs and are
+          // ignored for R28.
+          td.rhs match
+            case _: untpd.Template =>
+              line(td).foreach: l =>
+                val name = td.name.toString
+                if !types.contains(name) then types(name) = l
+            case _ =>
+              ()
+        case md: untpd.ModuleDef =>
+          line(md).foreach: l =>
+            val name = md.name.toString
+            if !objects.contains(name) then objects(name) = l
+        case _ =>
+          ()
+
+    CompanionDecls(types.toMap, objects.toMap)
+
+  private def walk(t: untpd.Tree)(visit: untpd.Tree => Unit): Unit =
+    visit(t)
+    t.productIterator.foreach(descend(_, visit))
+
+  private def descend(x: Any, visit: untpd.Tree => Unit): Unit = x match
+    case sub: untpd.Tree => walk(sub)(visit)
+    case it:  Iterable[?] => it.foreach(descend(_, visit))
+    case _                => ()

--- a/lib/decorum/src/plugin/decorum.Comprehensions.scala
+++ b/lib/decorum/src/plugin/decorum.Comprehensions.scala
@@ -1,0 +1,137 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package decorum
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
+case class GenLine
+   ( line:     Int,
+     startCol: Int,
+     opCol:    Int,
+     isFilter: Boolean )
+
+object Comprehensions:
+  // Walk the tree for every `for ... yield`/`for ... do` and return each
+  // comprehension's enumerators (`x <- xs`, `y = expr`, `if filter`) as a
+  // `List[GenLine]`. R34 then checks LHS / `<-`-or-`=` / filter alignment
+  // within each list. Comprehensions whose enumerators all sit on a single
+  // line don't need alignment — those lists collapse to one entry and the
+  // rule check no-ops.
+  def extract(tree: untpd.Tree, source: SourceFile): List[List[GenLine]] =
+    val out = mutable.ListBuffer[List[GenLine]]()
+
+    def visit(t: untpd.Tree): Unit =
+      t match
+        case fy: untpd.ForYield =>
+          val gens = fy.enums.flatMap(genLine(_, source))
+          if gens.nonEmpty then out += gens
+        case fd: untpd.ForDo =>
+          val gens = fd.enums.flatMap(genLine(_, source))
+          if gens.nonEmpty then out += gens
+        case _ =>
+          ()
+      t.productIterator.foreach(descend(_, visit))
+
+    visit(tree)
+    out.toList
+
+  private def descend(x: Any, visit: untpd.Tree => Unit): Unit = x match
+    case sub: untpd.Tree => visit(sub)
+    case it:  Iterable[?] => it.foreach(descend(_, visit))
+    case _                => ()
+
+  // Build a `GenLine` for one enumerator. `GenFrom` is `x <- xs`; `GenAlias`
+  // is `x = e`. Anything else in `enums` is a filter expression whose span
+  // begins at the `if` keyword (the parser uses `atSpan(in.skipToken())`).
+  private def genLine(t: untpd.Tree, source: SourceFile): Option[GenLine] =
+    t match
+      case g: untpd.GenFrom  => binaryEnum(t, g.pat, g.expr, "<-", source)
+      case g: untpd.GenAlias => binaryEnum(t, g.pat, g.expr, "=",  source)
+      case other =>
+        val sp = other.span
+        if !sp.exists then None
+        else
+          // The filter's tree span starts at the expression itself (`x > 0`),
+          // not at the `if` keyword the user actually typed. Walk back across
+          // whitespace to recover the `if` position so R34.3 compares against
+          // the column the user sees.
+          val content   = String(source.content)
+          val ifOffset  = findIfBefore(content, sp.start)
+          val keyOffset = if ifOffset >= 0 then ifOffset else sp.start
+          val line      = source.offsetToLine(keyOffset) + 1
+          val col       = source.column(keyOffset) + 1
+          Some(GenLine(line, col, col, isFilter = true))
+
+  // Locate the `if` keyword that immediately precedes the given offset,
+  // skipping any whitespace between them. Returns -1 if no preceding `if`
+  // is found (e.g. the filter is the first token on its line — only the
+  // generator-expression survives parsing in some recovery paths).
+  private def findIfBefore(content: String, start: Int): Int =
+    var i = start - 1
+    while i >= 0 && content.charAt(i).isWhitespace do i -= 1
+    if i >= 1 && content.charAt(i) == 'f' && content.charAt(i - 1) == 'i' then
+      val before = i - 2
+      if before < 0 || !isWordChar(content.charAt(before)) then i - 1 else -1
+    else -1
+
+  private def isWordChar(c: Char): Boolean = c.isLetterOrDigit || c == '_'
+
+  // For a generator/binding, the LHS column is the pattern's start column,
+  // and the operator column is found by scanning the source between the
+  // pattern's end and the right-hand-side expression's start for the
+  // literal `<-` or `=`.
+  private def binaryEnum
+    ( t:      untpd.Tree,
+      pat:    untpd.Tree,
+      expr:   untpd.Tree,
+      opText: String,
+      source: SourceFile )
+  :   Option[GenLine] =
+    val patSp  = pat.span
+    val exprSp = expr.span
+    val sp     = t.span
+    if !patSp.exists || !sp.exists then None
+    else
+      val line     = source.offsetToLine(sp.start) + 1
+      val startCol = source.column(patSp.start) + 1
+      val from     = patSp.end
+      val to       = if exprSp.exists then exprSp.start else sp.end
+      val content  = String(source.content)
+      val opOffset = content.indexOf(opText, from)
+      val opCol =
+        if opOffset < 0 || opOffset >= to then -1
+        else source.column(opOffset) + 1
+      Some(GenLine(line, startCol, opCol, isFilter = false))

--- a/lib/decorum/src/plugin/decorum.Imports.scala
+++ b/lib/decorum/src/plugin/decorum.Imports.scala
@@ -34,58 +34,104 @@ package decorum
 
 import scala.collection.mutable
 
-import dotty.tools.dotc.*, ast.tpd, core.Contexts.*, plugins.*, util.{SourceFile, SourcePosition}
-import dotty.tools.dotc.util.Spans.Span
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
 
-class DecorumPhase(options: List[String]) extends PluginPhase:
-  val phaseName: String                = "decorum"
-  override val runsAfter: Set[String]  = Set("typer")
-  override val runsBefore: Set[String] = Set("pickler")
+case class ImportInfo
+   ( startLine:        Int,
+     endLine:          Int,
+     path:             String,
+     hasTopLevelAlias: Boolean )
 
-  private val errors: Boolean   = options.contains("errors")
-  private val seen: mutable.Set[String] = mutable.Set.empty
+object Imports:
+  // Extract every top-level `import` (or `export`) statement from the
+  // package body. Imports inside templates / blocks are intentionally
+  // ignored — Decorum's R9 only governs file-top imports.
+  def extract(tree: untpd.Tree, source: SourceFile): List[ImportInfo] =
+    val out = mutable.ListBuffer[ImportInfo]()
+    val content = String(source.content)
 
-  private val esc: Char = 27.toChar
-  private val bel: Char = 7.toChar
-  private val gray   = s"$esc[38;2;128;128;128m"
-  private val orange = s"$esc[38;2;255;165;0m"
-  private val yellow = s"$esc[38;2;255;215;0m"
-  private val cyan   = s"$esc[38;2;0;200;255m"
-  private val reset  = s"$esc[0m"
+    def visitTopLevel(t: untpd.Tree): Unit = t match
+      case pkg: untpd.PackageDef =>
+        pkg.stats.foreach(visitTopLevel)
+      case imp: untpd.Import =>
+        recordImport(imp, content, source, out)
+      case _ =>
+        ()
 
-  private def colourPrefix(rule: String, useColor: Boolean): String =
-    if useColor then
-      val hyperlink = false
-      val rendered  = rule.replace(".", s"$gray.$cyan")
-      val d         = rule.takeWhile(_ != '.')
-      val link      = if hyperlink then s"$esc]8;;https://soundness.dev/SN-de/$d$bel" else ""
-      val unlink    = if hyperlink then s"$esc]8;;$bel" else ""
-      s"$link$gray[$orange↯SN$gray-${yellow}de$gray/$cyan$rendered$gray]$reset$unlink "
+    visitTopLevel(tree)
+    out.toList
+
+  private def recordImport
+    ( imp:     untpd.Import,
+      content: String,
+      source:  SourceFile,
+      out:     mutable.ListBuffer[ImportInfo] )
+  :   Unit =
+    val span = imp.span
+    if !span.exists then ()
     else
-      s"[↯SN-de/$rule] "
+      val start = span.start.max(0).min(content.length)
+      val end   = span.end.max(start).min(content.length)
+      val text  = content.substring(start, end).nn
+      val (path, hasAlias) = analyse(text)
+      out += ImportInfo
+              ( startLine        = source.offsetToLine(start) + 1,
+                endLine          = source.offsetToLine((end - 1).max(start)) + 1,
+                path             = path,
+                hasTopLevelAlias = hasAlias )
 
-  override def transformUnit(tree: tpd.Tree)(using context: Context): tpd.Tree =
-    val source: SourceFile = context.compilationUnit.source
-    val path: String       = source.file.path
-    if seen.add(path) then
-      val text: String = String(source.content)
-      val module       = Checker.expectedModule(path)
-      val useColor     =
-        try
-          import dotty.tools.dotc.config.Settings.Setting.value
-          value(context.settings.color)(using context) != "never"
-        catch case _: Throwable => false
-      val unitTree = context.compilationUnit.untpdTree
-      Checker.check(path, module, text, unitTree, source).foreach: violation =>
-        val pos = position(source, violation.line, violation.column)
-        val msg = colourPrefix(violation.rule, useColor)+violation.message
-        if errors then report.error(msg, pos) else report.warning(msg, pos)
-    super.transformUnit(tree)
+  // Reduce an import statement's source text to:
+  //   - the path string (concatenation of the path tokens and any selector
+  //     braces, with whitespace stripped, stopping at a top-level `as`); and
+  //   - whether the statement contains a top-level rename (`as` or `=>`
+  //     outside any `{…}`).
+  // This mirrors the rules the original token-based checker applied; using
+  // a span-bounded substring keeps its semantics intact.
+  private def analyse(text: String): (String, Boolean) =
+    val keyword = stripKeyword(text)
+    val sb       = StringBuilder()
+    var depth    = 0
+    var hasAlias = false
+    var i        = 0
+    var done     = false
+    val n        = keyword.length
+    while i < n do
+      val ch = keyword.charAt(i)
+      ch match
+        case '{' => depth += 1; if !done then sb.append(ch); i += 1
+        case '}' => depth -= 1; if !done then sb.append(ch); i += 1
+        case '/' if i + 1 < n && keyword.charAt(i + 1) == '/' =>
+          while i < n && keyword.charAt(i) != '\n' do i += 1
+        case '/' if i + 1 < n && keyword.charAt(i + 1) == '*' =>
+          i += 2
+          while i + 1 < n && !(keyword.charAt(i) == '*' && keyword.charAt(i + 1) == '/') do i += 1
+          if i + 1 < n then i += 2
+        case c if c.isWhitespace =>
+          // Look ahead for top-level `as` keyword.
+          if depth == 0 && i + 3 <= n && keyword.regionMatches(i + 1, "as", 0, 2)
+            && (i + 3 == n || !isWordChar(keyword.charAt(i + 3))) then
+            hasAlias = true
+            done = true
+            i += 3
+          else i += 1
+        case '=' if depth == 0 && i + 1 < n && keyword.charAt(i + 1) == '>' =>
+          hasAlias = true
+          done = true
+          i += 2
+        case _ =>
+          if !done then sb.append(ch)
+          i += 1
+    (sb.toString, hasAlias)
 
-  private def position(source: SourceFile, line: Int, column: Int): SourcePosition =
-    val lineStart =
-      try source.lineToOffset((line - 1).max(0))
-      catch case _: Throwable => 0
+  // Skip leading whitespace and the `import` (or `export`) keyword from
+  // `text` (the source slice of the import statement). Returns the text
+  // following the keyword.
+  private def stripKeyword(text: String): String =
+    var i = 0
+    while i < text.length && text.charAt(i).isWhitespace do i += 1
+    val start = i
+    while i < text.length && isWordChar(text.charAt(i)) do i += 1
+    text.substring(i).nn
 
-    val offset = (lineStart + (column - 1).max(0)).min(source.content.length)
-    SourcePosition(source, Span(offset))
+  private def isWordChar(c: Char): Boolean = c.isLetterOrDigit || c == '_'

--- a/lib/decorum/src/plugin/decorum.Packages.scala
+++ b/lib/decorum/src/plugin/decorum.Packages.scala
@@ -1,0 +1,69 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package decorum
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
+case class PackageInfo
+   ( line:                     Int,
+     segments:                 List[String],
+     extraStatementOnSameLine: Boolean )
+
+object Packages:
+  // The parser always wraps a file in a `PackageDef`; when the source has no
+  // `package` declaration the wrapper is synthetic with an empty-name `pid`.
+  // Distinguish "no real declaration" (return None) from a real one.
+  def extract(tree: untpd.Tree, source: SourceFile): Option[PackageInfo] = tree match
+    case pkg: untpd.PackageDef => describe(pkg, source)
+    case _                     => None
+
+  private def describe(pkg: untpd.PackageDef, source: SourceFile): Option[PackageInfo] =
+    val segments = pidSegments(pkg.pid)
+    val span     = pkg.span
+    if segments.isEmpty || !span.exists then None
+    else
+      val line = source.offsetToLine(span.start) + 1
+      val extra = pkg.stats.exists: stat =>
+        val ss = stat.span
+        ss.exists && source.offsetToLine(ss.start) + 1 == line
+      Some(PackageInfo(line, segments, extra))
+
+  // Render a package qualifier (`a.b.c`) as a list of segments. The empty
+  // package's synthetic `Ident("<empty>")` produces an empty list.
+  private def pidSegments(t: untpd.Tree): List[String] = t match
+    case untpd.Ident(name)        =>
+      val n = name.toString
+      if n == "<empty>" || n.isEmpty then Nil else List(n)
+    case untpd.Select(qual, name) => pidSegments(qual) :+ name.toString
+    case _                        => Nil

--- a/lib/decorum/src/plugin/decorum.Parsing.scala
+++ b/lib/decorum/src/plugin/decorum.Parsing.scala
@@ -32,60 +32,26 @@
                                                                                                   */
 package decorum
 
-import scala.collection.mutable
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.core.Contexts.{Context, ContextBase}
+import dotty.tools.dotc.parsing.Parsers
+import dotty.tools.dotc.reporting.{Diagnostic, Reporter}
+import dotty.tools.dotc.util.SourceFile
 
-import dotty.tools.dotc.*, ast.tpd, core.Contexts.*, plugins.*, util.{SourceFile, SourcePosition}
-import dotty.tools.dotc.util.Spans.Span
+object Parsing:
+  // A Reporter that discards everything; we don't surface parser diagnostics
+  // from Decorum — the main compiler will report parse errors itself.
+  private class SilentReporter extends Reporter:
+    def doReport(dia: Diagnostic)(using Context): Unit = ()
 
-class DecorumPhase(options: List[String]) extends PluginPhase:
-  val phaseName: String                = "decorum"
-  override val runsAfter: Set[String]  = Set("typer")
-  override val runsBefore: Set[String] = Set("pickler")
-
-  private val errors: Boolean   = options.contains("errors")
-  private val seen: mutable.Set[String] = mutable.Set.empty
-
-  private val esc: Char = 27.toChar
-  private val bel: Char = 7.toChar
-  private val gray   = s"$esc[38;2;128;128;128m"
-  private val orange = s"$esc[38;2;255;165;0m"
-  private val yellow = s"$esc[38;2;255;215;0m"
-  private val cyan   = s"$esc[38;2;0;200;255m"
-  private val reset  = s"$esc[0m"
-
-  private def colourPrefix(rule: String, useColor: Boolean): String =
-    if useColor then
-      val hyperlink = false
-      val rendered  = rule.replace(".", s"$gray.$cyan")
-      val d         = rule.takeWhile(_ != '.')
-      val link      = if hyperlink then s"$esc]8;;https://soundness.dev/SN-de/$d$bel" else ""
-      val unlink    = if hyperlink then s"$esc]8;;$bel" else ""
-      s"$link$gray[$orange↯SN$gray-${yellow}de$gray/$cyan$rendered$gray]$reset$unlink "
-    else
-      s"[↯SN-de/$rule] "
-
-  override def transformUnit(tree: tpd.Tree)(using context: Context): tpd.Tree =
-    val source: SourceFile = context.compilationUnit.source
-    val path: String       = source.file.path
-    if seen.add(path) then
-      val text: String = String(source.content)
-      val module       = Checker.expectedModule(path)
-      val useColor     =
-        try
-          import dotty.tools.dotc.config.Settings.Setting.value
-          value(context.settings.color)(using context) != "never"
-        catch case _: Throwable => false
-      val unitTree = context.compilationUnit.untpdTree
-      Checker.check(path, module, text, unitTree, source).foreach: violation =>
-        val pos = position(source, violation.line, violation.column)
-        val msg = colourPrefix(violation.rule, useColor)+violation.message
-        if errors then report.error(msg, pos) else report.warning(msg, pos)
-    super.transformUnit(tree)
-
-  private def position(source: SourceFile, line: Int, column: Int): SourcePosition =
-    val lineStart =
-      try source.lineToOffset((line - 1).max(0))
-      catch case _: Throwable => 0
-
-    val offset = (lineStart + (column - 1).max(0)).min(source.content.length)
-    SourcePosition(source, Span(offset))
+  // Parse the given source text into an untyped Scala 3 AST. Returns the
+  // tree paired with its SourceFile. If parsing throws, returns the empty
+  // tree — callers should treat that as "no structural info available".
+  def parse(file: String, text: String): (untpd.Tree, SourceFile) =
+    val source = SourceFile.virtual(file, text)
+    try
+      val base   = new ContextBase
+      val ctx    = base.initialCtx.fresh.setReporter(new SilentReporter).setSource(source)
+      val parser = new Parsers.Parser(source)(using ctx)
+      (parser.parse(), source)
+    catch case _: Throwable => (untpd.EmptyTree, source)

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -239,23 +239,43 @@ object Tests extends Suite(m"Decorum Tests"):
     suite(m"Phase 3: Match-case rules"):
 
       test(m"Misaligned `=>` in case run is rejected"):
-        rules("x match\n  case Short      => 1\n  case LongerName => 2\n  case Med => 3\n")
+        rules
+         ( "def f(x: Any): Any = x match\n"
+            +"  case Short      => 1\n"
+            +"  case LongerName => 2\n"
+            +"  case Med => 3\n" )
       . assert(_.contains("19"))
 
       test(m"Aligned `=>` in case run is accepted"):
-        rules("x match\n  case Short      => 1\n  case LongerName => 2\n  case Medium     => 3\n")
+        rules
+         ( "def f(x: Any): Any = x match\n"
+            +"  case Short      => 1\n"
+            +"  case LongerName => 2\n"
+            +"  case Medium     => 3\n" )
       . assert(!_.contains("19"))
 
       test(m"Multi-line case without preceding blank line is rejected"):
-        rules("x match\n  case Foo => 1\n  case Bar =>\n    bigBody\n")
+        rules
+         ( "def f(x: Any): Any = x match\n"
+            +"  case Foo => 1\n"
+            +"  case Bar =>\n"
+            +"    bigBody\n" )
       . assert(_.contains("20"))
 
       test(m"Multi-line case as first case (after `match`) is accepted"):
-        rules("x match\n  case Bar =>\n    bigBody\n")
+        rules
+         ( "def f(x: Any): Any = x match\n"
+            +"  case Bar =>\n"
+            +"    bigBody\n" )
       . assert(!_.contains("20"))
 
       test(m"Multi-line case after blank is accepted"):
-        rules("x match\n  case Foo => 1\n\n  case Bar =>\n    bigBody\n")
+        rules
+         ( "def f(x: Any): Any = x match\n"
+            +"  case Foo => 1\n"
+            +"\n"
+            +"  case Bar =>\n"
+            +"    bigBody\n" )
       . assert(!_.contains("20"))
 
     suite(m"Phase 3: Sibling padding and using alignment"):


### PR DESCRIPTION
Decorum's rule checks ran almost entirely on a hand-rolled token stream, which made structural rules ("the same expression", "the next declaration", "the cases of this match") expensive and brittle to express. This stack moves the structural rules onto the parser's `untpd` tree carried by the compilation unit, while keeping the cheap lexical rules (line length, trailing whitespace, comma spacing, operator spacing) on the token stream where they belong. The plugin reuses the existing parsed tree from `compilationUnit.untpdTree`, so no extra parser work runs at compile time; the test entry point parses standalone via a fresh `ContextBase` so the test harness keeps its plain-text interface.

Migrated rules:

* **R7** package declaration — extracted from `untpd.PackageDef.pid`; multi-segment paths, wrong-line, name mismatch, invalid-identifier characters, and extra statements on the same line all now fall out of the parsed structure.
* **R9** imports (9.1/9.2/9.3 + R10) — each top-level `import`/`export` becomes one `ImportInfo`. Multi-line imports and multi-import lines (`import a.b, c.d`) are handled naturally; the brace/comma continuation heuristics fall away.
* **R15** annotations (15.2) — annotation end-lines are recovered from `MemberDef.mods.annotations`, so multi-line annotations like `` @Foo(\n  arg = 1\n) `` correctly trigger the rule when followed by a blank line (the previous "line starts with `@`" heuristic only matched the opening line).
* **R19/R20** match-case alignment — every `Match` and `Try` case group is walked from the tree; alignment runs and multi-line-blank-line spacing are computed once over `CaseInfo` records.
* **R28** companion ordering — class-likes (TypeDef with a Template rhs) and objects (`ModuleDef`) are collected in a single tree walk; first-wins semantics across the whole file matches the previous recorder.
* **R29** filename — the existing pattern check is preserved, with a new tree-based extension: for `<lowercase>.<Uppercase>.scala` the file must declare a top-level `TypeDef` or `ModuleDef` of that name. Currently surfaces 8 mismatches across the codebase (e.g. `gossamer.TextBuffer.scala` declares `TextBuilder`) — addressed in follow-up commits.
* **R34** for-comprehension alignment — every `ForYield`/`ForDo` is walked; generators (`x <- xs`), bindings (`y = e`), and filters (`if expr`) are turned into `GenLine` records. Filters have their span at the expression rather than the `if` keyword, so the `if` position is recovered by walking back across whitespace in the source.

Each migrated rule retired its token-based scaffolding (per-line phase callbacks, `prevLineEndedMatch`, `prevImportGroup`, `prevWasAnnotation`, `caseRun`, `inMultilineImport`, etc.) along with the corresponding helper functions and State fields.

A common `productIterator`-driven traversal handles tree walking generically across the new files (`Imports`, `Packages`, `Annotations`, `Companions`, `Cases`, `Comprehensions`).

## Release notes

Decorum's structural rule checks now run against the parser's untyped Scala AST instead of a hand-rolled token stream. The default rule set is unchanged, with two user-visible improvements:

- **R15.2** now correctly flags blank lines after multi-line annotations like `` @Foo(\n  arg = 1\n) ``; the previous implementation only flagged blanks after single-line `@Foo` annotations.
- **R29** now also verifies that files named `<module>.<Type>.scala` actually declare a top-level `class`/`trait`/`enum`/`object`/`type` of that name. The existing filename-pattern checks are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)