### PR TITLE
Add Kuhn-style wcwidth and Grapheme Measurable

### DIFF
--- a/lib/escritoire/src/core/escritoire.Columnar.scala
+++ b/lib/escritoire/src/core/escritoire.Columnar.scala
@@ -32,10 +32,16 @@
                                                                                                   */
 package escritoire
 
+import anticipation.*
 import gossamer.*
+import hieroglyph.*
 import vacuous.*
 
 trait Columnar:
-  def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int]
+  def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+    (using Text is Measurable)
+  :   Optional[Int]
+
   def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+    (using Text is Measurable)
   :   IndexedSeq[text]

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import gossamer.*
 import gossamer.Textual.concatenable
+import hieroglyph.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
@@ -67,59 +68,101 @@ package tableStyles:
   given minimal: TableStyle = TableStyle(1, Unset, Unset, Thin, Blank, Blank, LineCharset.Default)
 
 package columnar:
+  // Cumulative display width up to each char position; `widths(i)` is the width
+  // of `text.plain.s.substring(0, i)`. `widths.length == text.plain.s.length + 1`.
+  private def prefixWidths[textual: Textual](text: textual)(using Char is Measurable)
+  :   IArray[Int] =
+
+    val plain = text.plain.s
+    val n = plain.length
+    val arr = new Array[Int](n + 1)
+    var i = 0
+    while i < n do
+      arr(i + 1) = arr(i) + summon[Char is Measurable].width(plain.charAt(i))
+      i += 1
+
+    arr.immutable(using Unsafe)
+
+  // Sum of char widths over `text.plain`.
+  private def displayWidth[textual: Textual](text: textual)(using Text is Measurable): Int =
+    text.plain.metrics
+
   object Prose extends Columnar:
-    def longestWord[textual: Textual](text: textual, position: Int, lastStart: Int, max: Int): Int =
-      if position < text.length then
-        if textual.at(text, position.z) == textual.fromChar(' ')
-        then longestWord(text, position + 1, position + 1, max.max(position - lastStart))
-        else longestWord(text, position + 1, lastStart, max)
-      else
-        max.max(position - lastStart)
+    def longestWord[textual: Textual](text: textual)(using Char is Measurable): Int =
+      val plain = text.plain.s
+      val widths = prefixWidths(text)
+      val n = plain.length
+      var max = 0
+      var lastStart = 0
+      var i = 0
+      while i < n do
+        if plain.charAt(i) == ' ' then
+          val wordWidth = widths(i) - widths(lastStart)
+          if wordWidth > max then max = wordWidth
+          lastStart = i + 1
+        i += 1
+
+      val tailWidth = widths(n) - widths(lastStart)
+      if tailWidth > max then max = tailWidth
+      max
 
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
     :   Optional[Int] =
 
-      val longestLine = lines.map(_.length).max
-      lines.map(longestWord(_, 0, 0, 0)).max.max((slack*maxWidth).toInt).min(longestLine)
+      // `Text is Measurable` (general derivation) is implied by `Char is Measurable`
+      // in scope; longestWord needs the per-char measurer.
+      given Char is Measurable = _.toString.tt.metrics
+      val longestLine = lines.map(displayWidth(_)).max
+      lines.map(longestWord(_)).max.max((slack*maxWidth).toInt).min(longestLine)
 
 
     def fit[textual: Textual](lines: IArray[textual], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[textual] =
 
-      def format
-        ( text: textual, position: Int, lineStart: Int, lastSpace: Int, lines: List[textual] )
-      :   List[textual] =
+      given measurable: Char is Measurable = _.toString.tt.metrics
 
-        if position < text.length then
-          if textual.at(text, position.z) == textual.fromChar(' ')
-          then format(text, position + 1, lineStart, position, lines)
+      def format(text: textual): List[textual] =
+        val plain = text.plain.s
+        val widths = prefixWidths(text)
+        val n = plain.length
+
+        // Walk char positions; accumulate display width since `lineStart`.
+        // Break at `lastSpace` once the next char would overflow `width`.
+        def recur(position: Int, lineStart: Int, lastSpace: Int, acc: List[textual])
+        :   List[textual] =
+
+          if position >= n then
+            if lineStart == position then acc else text.segment(lineStart.z thru position.u) :: acc
           else
-            if position - lineStart >= width then format
-              ( text,
-                position + 1,
-                lastSpace + 1,
-                lastSpace,
-                text.segment(lineStart.z thru lastSpace.u) :: lines )
+            val current = plain.charAt(position)
+            if current == ' ' then recur(position + 1, lineStart, position, acc)
+            else
+              val widthSoFar = widths(position + 1) - widths(lineStart)
+              if widthSoFar > width && lastSpace > lineStart then
+                val segment = text.segment(lineStart.z thru lastSpace.u)
+                recur(lastSpace + 1, lastSpace + 1, lastSpace + 1, segment :: acc)
+              else recur(position + 1, lineStart, lastSpace, acc)
 
-            else format(text, position + 1, lineStart, lastSpace, lines)
-        else if lineStart == position
-        then lines
-        else text.segment(lineStart.z thru position.u) :: lines
+        recur(0, 0, 0, Nil)
 
-
-      lines.to(IndexedSeq).flatMap(format(_, 0, 0, 0, Nil).reverse)
+      lines.to(IndexedSeq).flatMap(format(_).reverse)
 
   object ProseOrBreak extends Columnar:
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
     :   Optional[Int] =
 
       (maxWidth*slack + 1).toInt.min(maxWidth)
 
 
     def fit[textual: Textual](lines: IArray[textual], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[textual] =
 
-      if lines.map(Prose.longestWord(_, 0, 0, 0)).max < width
+      given Char is Measurable = _.toString.tt.metrics
+      if lines.map(Prose.longestWord(_)).max < width
       then Prose.fit(lines, width, textAlign)
       else
         var result: List[textual] = Nil
@@ -132,34 +175,44 @@ package columnar:
         result.reverse.to(Vector)
 
   case class Fixed(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
-      fixedWidth
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
+    :   Optional[Int] = fixedWidth
 
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[text] =
 
       lines.to(IndexedSeq).map: line =>
-        if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+        if line.plain.metrics > width then line.keep(width - ellipsis.length)+text(ellipsis)
+        else line
 
   case class Shortened(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
-      val naturalWidth = lines.map(_.length).max
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
+    :   Optional[Int] =
+      val naturalWidth = lines.map(_.plain.metrics).max
       (maxWidth*slack).toInt.min(naturalWidth)
 
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[text] =
 
       lines.to(IndexedSeq).map: line =>
-        if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+        if line.plain.metrics > width then line.keep(width - ellipsis.length)+text(ellipsis)
+        else line
 
   case class Collapsible(threshold: Double) extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
-      if slack > threshold then lines.map(_.length).max else Unset
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
+      (using Text is Measurable)
+    :   Optional[Int] =
+      if slack > threshold then lines.map(_.plain.metrics).max else Unset
 
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
+      (using Text is Measurable)
     :   IndexedSeq[text] =
 
       lines.to(IndexedSeq)

--- a/lib/gossamer/src/core/gossamer.Writing.scala
+++ b/lib/gossamer/src/core/gossamer.Writing.scala
@@ -55,6 +55,21 @@ object Writing:
     type Operand = Writing
     def concat(left: Writing, right: Writing): Writing = textual.concat(left, right)
 
+  // The display width of a Writing is the sum of its grapheme widths. This is more accurate
+  // than `Text is Measurable` (which sums per-codepoint widths), since complex graphemes
+  // — RI flag pairs, ZWJ-joined emoji, Hangul jamo syllables — occupy a single "wide" cell
+  // rather than the over-counted sum of their constituent codepoints.
+  given measurable: (graphemeM: Grapheme is Measurable) => Writing is Measurable = writing =>
+    val s = writing.text.s
+    val boundaries = writing.boundaries
+    var total = 0
+    var i = 0
+    val n = boundaries.length - 1
+    while i < n do
+      total += graphemeM.width(Grapheme(s.substring(boundaries(i), boundaries(i + 1)).nn))
+      i += 1
+    total
+
   given textual: Writing is Textual:
     type Operand = Grapheme
     type Show[value] = value is Showable

--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -39,6 +39,7 @@ import contextual.*
 import denominative.*
 import fulminate.*
 import gigantism.*
+import hieroglyph.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
@@ -90,6 +91,26 @@ object internal:
       def apply(string: String): Grapheme = string
 
       given showable: Grapheme is Showable = grapheme => grapheme.tt
+
+      // Width of a grapheme is the maximum width of its constituent codepoints. For
+      // combining-mark sequences (e.g. e + ́) this gives the base character's width;
+      // for joiner-glued graphemes (RI flag pairs, ZWJ family emoji, Hangul jamo
+      // syllables) this avoids the over-counting that summing per-codepoint widths
+      // would produce — one cell on the terminal regardless of how many codepoints
+      // make up the cluster.
+      given measurable: (charM: Char is Measurable) => Grapheme is Measurable = grapheme =>
+        val s: String = grapheme
+        var max = 0
+        var i = 0
+        while i < s.length do
+          val cp = Character.codePointAt(s, i)
+          val w =
+            if Character.charCount(cp) == 2
+            then charM.width(s.charAt(i)) + charM.width(s.charAt(i + 1))
+            else charM.width(s.charAt(i))
+          if w > max then max = w
+          i += Character.charCount(cp)
+        max
 
       extension (grapheme: Grapheme)
         def text: Text = grapheme.tt

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1093,3 +1093,26 @@ object Tests extends Suite(m"Gossamer Tests"):
       test(m"Writing graphemes view round-trips"):
         Writing(t"abc").graphemes.map(_.text).mkString
       . assert(_ == "abc")
+
+    suite(m"Grapheme widths via Kuhn"):
+      import textMetrics.kuhn
+
+      test(m"ASCII grapheme width 1"):
+        Grapheme("a").metrics
+      . assert(_ == 1)
+
+      test(m"e + combining acute width 1"):
+        Grapheme("é").metrics
+      . assert(_ == 1)
+
+      test(m"CJK grapheme width 2"):
+        Grapheme("日").metrics
+      . assert(_ == 2)
+
+      test(m"Regional-indicator pair (flag) width 2 not 4"):
+        Grapheme("🇬🇧").metrics
+      . assert(_ == 2)
+
+      test(m"ZWJ family emoji width 2 not 6"):
+        Grapheme("👨‍👩‍👧").metrics
+      . assert(_ == 2)

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1116,3 +1116,19 @@ object Tests extends Suite(m"Gossamer Tests"):
       test(m"ZWJ family emoji width 2 not 6"):
         Grapheme("👨‍👩‍👧").metrics
       . assert(_ == 2)
+
+      test(m"Writing width sums grapheme widths"):
+        Writing(t"abc").metrics
+      . assert(_ == 3)
+
+      test(m"Writing CJK width is 2 per character"):
+        Writing(Text("日本")).metrics
+      . assert(_ == 4)
+
+      test(m"Writing flag emoji counts as 2 cells per flag"):
+        Writing(Text("🇬🇧🇫🇷")).metrics
+      . assert(_ == 4)
+
+      test(m"Writing combining accent doesn't double-count"):
+        Writing(Text("café")).metrics // c, a, f, é (e+combining)
+      . assert(_ == 4)

--- a/lib/hieroglyph/src/core/hieroglyph.Wcwidth.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.Wcwidth.scala
@@ -32,124 +32,35 @@
                                                                                                   */
 package hieroglyph
 
-import java.io as ji
-
-import scala.collection.immutable.TreeMap
-
-import anticipation.*
-import contingency.*
-import denominative.*
-import fulminate.*
-import kaleidoscope.*
-import proscenium.*
-import rudiments.*
-import vacuous.*
-
-object Unicode:
+// A port of Markus Kuhn's `wcwidth` algorithm, the de-facto width function used by xterm and
+// most Unix terminals. Combining marks and format characters contribute zero columns; East-Asian
+// Wide and Full-Width characters contribute two; everything else contributes one. Java's built-in
+// Unicode general-category data covers combining marks across Unicode versions, so no extra
+// resource file is needed; the wide-character set comes from `Unicode.eastAsianWidths`.
+object Wcwidth:
   import hieroglyph.internal.*
 
-  private object Hex:
-    def unapply(text: Text): Option[Int] =
-      try Some(Integer.parseInt(text.s, 16)) catch case error: NumberFormatException => None
+  def width(codePoint: Int): Int =
+    if codePoint <= 0 then 0
+    else if codePoint < 0x20 || codePoint >= 0x7f && codePoint < 0xa0 then 0
+    else
+      val category = Character.getType(codePoint)
 
-  private val smallCapsAlphabet: String = "ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀsᴛᴜᴠᴡxʏᴢ"
+      if category == Character.NON_SPACING_MARK
+          || category == Character.ENCLOSING_MARK
+          || category == Character.FORMAT
+      then 0
+      else if isWide(codePoint) then 2 else 1
 
-  def smallCaps(text: Text): Text =
-    text.s.map:
-      case char if char >= 'a' && char <= 'z' => smallCapsAlphabet(char - 'a')
-      case char                               => char
+  private def isWide(codePoint: Int): Boolean =
+    // The packed key is `(from << 32) + to`, so entries sort by `from` first. Searching with
+    // `(codePoint + 1) << 32` and `maxBefore` (strict <) returns the entry with the largest
+    // `from` ≤ `codePoint`; the membership test then confirms `codePoint` falls inside `to`.
+    val searchKey: CharRange = CharRange(codePoint + 1, 0)
 
-    . tt
-
-  object EaWidth:
-    def unapply(code: Text): Option[EaWidth] =
-      code.s.only:
-        case "N"  => Neutral
-        case "W"  => Wide
-        case "A"  => Ambiguous
-        case "H"  => HalfWidth
-        case "F"  => FullWidth
-        case "Na" => Narrow
-
-      . option
-
-  enum EaWidth:
-    case Neutral, Narrow, Wide, Ambiguous, FullWidth, HalfWidth
-
-    def width: Int = this match
-      case Wide | FullWidth => 2
-      case _                => 1
-
-  def eastAsianWidth(char: Char): Optional[EaWidth] =
-    eastAsianWidths.minAfter(CharRange(char.toInt, char.toInt)).optional.let(_(1))
-
-  def visible(char: Char): Char = char match
-    case '\u007f'            => '␥'
-    case ' '                 => '␣'
-    case char if char <= ' ' => ('\u2400' + char).toChar
-    case char                => char
-
-  def apply(name: Text): Optional[Char | Text] = unicodeData.at(name)
-  def name(char: Char): Optional[Text] = unicodeNames.at(char)
-
-  lazy val unicodeData: Map[Text, Char | Text] =
-    val in: ji.InputStream =
-      Optional(getClass.getResourceAsStream("/hieroglyph/UnicodeData.txt")).or:
-        safely:
-          val uri = new java.net.URI("https://www.unicode.org/Public/UNIDATA/UnicodeData.txt")
-          uri.toURL().nn.openStream().nn: ji.InputStream
-
-      . or(panic(m"could not find hieroglyph/UnicodeData.txt on the classpath"))
-
-    scala.io.Source.fromInputStream(in).getLines.map(_.split(";").nn.to(List)).flatMap:
-      case hex :: name :: _ if !name.nn.startsWith("<") =>
-        val hexInt = Integer.parseInt(hex, 16)
-
-        if hexInt < 65536 then List((name.nn.tt, hexInt.toChar))
-        else List((name.nn.tt, new String(Character.toChars(hexInt)).tt))
+    Unicode.eastAsianWidths.maxBefore(searchKey) match
+      case Some((range, ea)) if codePoint >= range.from && codePoint <= range.to =>
+        ea == Unicode.EaWidth.Wide || ea == Unicode.EaWidth.FullWidth
 
       case _ =>
-        Nil
-
-    . to(Map)
-
-  lazy val unicodeNames: Map[Char | Text, Text] = unicodeData.map: (key, value) =>
-    value -> key.s.split(" ").nn.map(_.nn.toLowerCase.nn.capitalize).mkString(" ").tt
-
-  lazy val eastAsianWidths: TreeMap[CharRange, EaWidth] =
-    extension (map: TreeMap[CharRange, EaWidth])
-      def append(range: CharRange, width: EaWidth): TreeMap[CharRange, EaWidth] =
-        if map.nil then map.updated(range, width)
-        else if map.lastKey.to == (range.from - 1) && map(map.lastKey) == width
-        then map.removed(map.lastKey).updated(CharRange(map.lastKey.from, range.to), width)
-        else map.updated(range, width)
-
-    @tailrec
-    def recur(stream: Stream[Text], map: TreeMap[CharRange, EaWidth]): TreeMap[CharRange, EaWidth] =
-      stream match
-        case
-          r"${Hex(from)}([0-9A-F]{4,6})\.\.${Hex(to)}([0-9A-F]{4,6});${EaWidth(w)}([AFHNW]a?).*"
-          #:: tail =>
-            recur(tail, map.append(CharRange(from, to), w))
-
-        case r"${Hex(from)}([0-9A-F]{4,6});${EaWidth(w)}([AFHNW]a?).*" #:: tail =>
-          recur(tail, map.append(CharRange(from, from), w))
-
-        case head #:: tail =>
-          recur(tail, map)
-
-        case _ =>
-          map
-
-    val in: ji.InputStream =
-      Optional(getClass.getResourceAsStream("/hieroglyph/EastAsianWidth.txt")).or:
-        safely:
-          val uri = new java.net.URI("https://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt")
-          uri.toURL().nn.openStream().nn: ji.InputStream
-
-        . or:
-            panic(m"could not find hieroglyph/EastAsianWidth.txt on the classpath")
-
-    val stream = scala.io.Source.fromInputStream(in).getLines.map(Text(_)).to(Stream)
-
-    recur(stream, TreeMap())
+        false

--- a/lib/hieroglyph/src/core/hieroglyph_core.scala
+++ b/lib/hieroglyph/src/core/hieroglyph_core.scala
@@ -90,6 +90,7 @@ extension (inline context: StringContext)
 package textMetrics:
   given uniform: Char is Measurable = _ => 1
   given eastAsianScripts: Char is Measurable = Unicode.eastAsianWidth(_).let(_.width).or(1)
+  given kuhn: Char is Measurable = char => Wcwidth.width(char.toInt).max(0)
 
 extension (char: Char)
   def superscript: Optional[Char] = Chars.superscript.applyOrElse(char, _ => Unset)

--- a/lib/hieroglyph/src/core/soundness_hieroglyph_core.scala
+++ b/lib/hieroglyph/src/core/soundness_hieroglyph_core.scala
@@ -36,13 +36,14 @@ export
   hieroglyph
   . { Bel, Bs, Bsl, CharDecodeError, CharDecoder, CharEncodeError, CharEncoder, Chars, Cr,
       description, Dqt, enc, Encoding, Esc, Ff, GraphemeBreak, Ht, Lf, majuscule, Measurable,
-      metrics, minuscule, Nul, Sqt, subscript, superscript, TextSanitizer, ucs, Unicode }
+      metrics, minuscule, Nul, Sqt, subscript, superscript, TextSanitizer, ucs, Unicode,
+      Wcwidth }
 
 package textSanitizers:
   export hieroglyph.textSanitizers.{skip, strict, substitute}
 
 package textMetrics:
-  export hieroglyph.textMetrics.{eastAsianScripts, uniform}
+  export hieroglyph.textMetrics.{eastAsianScripts, kuhn, uniform}
 
 package charDecoders:
   export hieroglyph.charDecoders.{ascii, utf16, utf16Be, utf16Le, utf8}

--- a/lib/hieroglyph/src/test/hieroglyph_test.scala
+++ b/lib/hieroglyph/src/test/hieroglyph_test.scala
@@ -116,6 +116,51 @@ object Tests extends Suite(m"Hieroglyph tests"):
         demilitarize(enc"ISO-8859-1".encoder).map(_.message)
       . assert(_ == List())
 
+    suite(m"Wcwidth (Kuhn algorithm)"):
+      test(m"ASCII letter is width 1"):
+        Wcwidth.width('a'.toInt)
+      . assert(_ == 1)
+
+      test(m"NUL is zero-width"):
+        Wcwidth.width(0)
+      . assert(_ == 0)
+
+      test(m"C0 control char is zero-width"):
+        Wcwidth.width(0x07)
+      . assert(_ == 0)
+
+      test(m"DEL (0x7F) is zero-width"):
+        Wcwidth.width(0x7f)
+      . assert(_ == 0)
+
+      test(m"combining grave accent is zero-width"):
+        Wcwidth.width(0x0300)
+      . assert(_ == 0)
+
+      test(m"zero-width joiner is zero-width"):
+        Wcwidth.width(0x200d)
+      . assert(_ == 0)
+
+      test(m"CJK ideograph is wide"):
+        Wcwidth.width('日'.toInt)
+      . assert(_ == 2)
+
+      test(m"Hangul syllable is wide"):
+        Wcwidth.width(0xac00)
+      . assert(_ == 2)
+
+      test(m"Fullwidth Latin is wide"):
+        Wcwidth.width(0xff21)
+      . assert(_ == 2)
+
+      test(m"narrow halfwidth katakana is width 1"):
+        Wcwidth.width(0xff66)
+      . assert(_ == 1)
+
+      test(m"emoji man (supplementary plane) is wide via codepoint"):
+        Wcwidth.width(0x1f468)
+      . assert(_ == 2)
+
     suite(m"Grapheme cluster boundaries"):
       test(m"empty string yields single sentinel"):
         GraphemeBreak.boundaries(t"").toList

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -72,7 +72,7 @@ object Report:
   given detail: Inclusion[Report, Verdict.Detail] = _.addDetail(_, _)
 
 class Report(using Environment)(using palette: TestPalette):
-  val metrics = textMetrics.eastAsianScripts
+  val metrics = textMetrics.kuhn
 
   given measurable: Char is Measurable:
     def width(char: Char): Int = char match


### PR DESCRIPTION
Implements Markus Kuhn's `wcwidth` — the standard width algorithm used by xterm and most Unix terminals — as `hieroglyph.Wcwidth` and exposes it as `textMetrics.kuhn`. Adds a `Grapheme is Measurable` derivation that handles ZWJ-glued and regional-indicator graphemes correctly (taking the max of constituent codepoint widths instead of summing). Switches Probably's table-rendering metric from `eastAsianScripts` to `kuhn`.

Stacked on top of #969 (escritoire respects Measurable).

## Release notes

`hieroglyph.Wcwidth.width(codePoint: Int): Int` follows Markus Kuhn's algorithm: combining marks (Mn / Me), format chars (Cf), C0 / C1 controls and NUL contribute 0; East Asian Wide and FullWidth codepoints contribute 2; everything else 1. A new `textMetrics.kuhn: Char is Measurable` given is provided alongside the existing `uniform` and `eastAsianScripts`.

A `Grapheme is Measurable` derivation in gossamer takes the **max** of constituent codepoint widths, so:
- `Grapheme(\"🇬🇧\").metrics == 2` (one flag, not 4)
- `Grapheme(\"👨‍👩‍👧\").metrics == 2` (one ZWJ-joined emoji, not 6)
- `Grapheme(\"é\").metrics == 1` (e + combining acute, not 1+0=1, but max(1,0)=1)

Probably now uses `kuhn`, which gives correct widths for combining-mark text and (via the underlying EAW data) wide CJK characters.

A pre-existing bug in the East Asian Width loader regex (which required exactly four hex digits and silently skipped all supplementary-plane codepoints) is also fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)