### PR TITLE
Migrate Yossarian's screen cells from Char to Grapheme

### DIFF
--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import fulminate.*
 import gossamer.*
+import hieroglyph.*, textMetrics.wideCharacterWidth
 import hypotenuse.*
 import kaleidoscope.*
 import proscenium.*
@@ -70,8 +71,15 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
     val escBuffer = StringBuilder()
     val buffer2: Screen = buffer.copy()
 
+    // Pre-compute UAX #29 grapheme boundaries for the whole input. Normal-
+    // state printable handling walks this array to find the smallest
+    // boundary > index, extracts the substring as a Grapheme, and advances
+    // recursion to that boundary. Escape-state handling stays char-by-char.
+    val boundaries: IArray[Int] = GraphemeBreak.boundaries(input)
+    var boundaryCursor: Int = 0
+
     var pendingWrap: Boolean = state.pendingWrap
-    var lastChar: Char = ' '
+    var lastGrapheme: Grapheme = Grapheme(" ")
 
     object cursor:
       private var index: Ordinal = state.cursor
@@ -117,10 +125,12 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
     import Context.{Normal, Escape, Csi, Csi2, Osc, Osc2, EatString, EatString2}
 
-    def wipe(cursor: Ordinal): Unit = buffer2.set(cursor, ' ', style, link)
+    def wipe(cursor: Ordinal): Unit = buffer2.set(cursor, Grapheme(" "), style, link)
 
-    def set(x: Ordinal, y: Ordinal, char: Char, style: Style = style, link: Text = link): Unit =
-      buffer2.set(x, y, char, style, link)
+    def set(x: Ordinal, y: Ordinal, grapheme: Grapheme, style: Style = style, link: Text = link)
+    :   Unit =
+
+      buffer2.set(x, y, grapheme, style, link)
 
     def cuu(n: Int): Unit = cursor.y = cursor.y - n
     def cud(n: Int): Unit = cursor.y = cursor.y + n
@@ -153,9 +163,9 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         raise(PtyEscapeError(BadCsiParameter(n, t"ED")))
 
     def el(n: Int): Unit = n match
-      case 0 => for x <- cursor.x.n0 until buffer2.width do set(x.z, cursor.y, ' ')
-      case 1 => for x <- 0 to cursor.x.n0 do set(x.z, cursor.y, ' ')
-      case 2 => for x <- 0 until buffer2.width do set(x.z, cursor.y, ' ')
+      case 0 => for x <- cursor.x.n0 until buffer2.width do set(x.z, cursor.y, Grapheme(" "))
+      case 1 => for x <- 0 to cursor.x.n0 do set(x.z, cursor.y, Grapheme(" "))
+      case 2 => for x <- 0 until buffer2.width do set(x.z, cursor.y, Grapheme(" "))
       case n => raise(PtyEscapeError(BadCsiParameter(n, t"EL")))
 
     def title(text: Text): Unit = state2 = state2.copy(title = text)
@@ -197,22 +207,49 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
     def focus(value: Boolean): Unit = state2 = state2.copy(focus = value)
     def bcp(value: Boolean): Unit = state2 = state2.copy(bracketedPasteMode = value)
 
-    def writeChar(char: Char): Unit =
-      if pendingWrap then
-        cursor.x = Prim
-        ind()
-      set(cursor.x, cursor.y, char)
-      lastChar = char
-      if cursor.x.n0 == buffer2.width - 1
-      then pendingWrap = true
+    def writeGrapheme(grapheme: Grapheme): Unit =
+      val w = grapheme.metrics
+
+      if w == 0 then
+        // Combining mark / zero-width: attach to the cell on the left. If
+        // that cell is the trailing half of a wide grapheme, attach to the
+        // wide leading cell two columns back.
+        val targetX: Ordinal =
+          if cursor.x == Prim then Prim
+          else
+            val left = cursor.x - 1
+            if buffer2.isWideTrailing(left, cursor.y) && left > Prim then left - 1
+            else left
+
+        val current = buffer2.grapheme(targetX, cursor.y)
+        val base = if current.text.s.isEmpty then Grapheme(" ") else current
+        buffer2.set(targetX, cursor.y, Grapheme(base.text.s + grapheme.text.s), style, link)
       else
-        cursor.x = cursor.x + 1
+        if pendingWrap then
+          cursor.x = Prim
+          ind()
+
+        // A wide grapheme at the right edge can't fit; wrap first.
+        if w == 2 && cursor.x.n0 >= buffer2.width - 1 then
+          cursor.x = Prim
+          ind()
+
+        buffer2.set(cursor.x, cursor.y, grapheme, style, link)
+
+        if w == 2 then
+          buffer2.set(cursor.x + 1, cursor.y, Grapheme(""), style, link)
+
+        lastGrapheme = grapheme
+
+        if cursor.x.n0 == buffer2.width - w then pendingWrap = true
+        else
+          cursor.x = cursor.x + w
 
     def rep(n: Int): Unit =
       val count = if n == 0 then 1 else n
       var i = 0
       while i < count do
-        writeChar(lastChar)
+        writeGrapheme(lastGrapheme)
         i += 1
 
     def ht(): Unit =
@@ -226,12 +263,12 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
       val shift = n.min(width - col)
       var i = width - 1
       while i >= col + shift do
-        buffer2.set(i.z, row.z, buffer2.char((i - shift).z, row.z),
+        buffer2.set(i.z, row.z, buffer2.grapheme((i - shift).z, row.z),
             buffer2.style((i - shift).z, row.z), buffer2.link((i - shift).z, row.z))
         i -= 1
       var j = col
       while j < col + shift do
-        buffer2.set(j.z, row.z, ' ', style, link)
+        buffer2.set(j.z, row.z, Grapheme(" "), style, link)
         j += 1
 
     def dch(n: Int): Unit =
@@ -241,12 +278,12 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
       val shift = n.min(width - col)
       var i = col
       while i < width - shift do
-        buffer2.set(i.z, row.z, buffer2.char((i + shift).z, row.z),
+        buffer2.set(i.z, row.z, buffer2.grapheme((i + shift).z, row.z),
             buffer2.style((i + shift).z, row.z), buffer2.link((i + shift).z, row.z))
         i += 1
       var j = width - shift
       while j < width do
-        buffer2.set(j.z, row.z, ' ', style, link)
+        buffer2.set(j.z, row.z, Grapheme(" "), style, link)
         j += 1
 
     def ech(n: Int): Unit =
@@ -255,7 +292,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
       val end = (col + n).min(buffer2.width)
       var i = col
       while i < end do
-        buffer2.set(i.z, row.z, ' ', style, link)
+        buffer2.set(i.z, row.z, Grapheme(" "), style, link)
         i += 1
 
     def il(n: Int): Unit =
@@ -271,7 +308,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         while r >= top + shift do
           var c = 0
           while c < width do
-            buffer2.set(c.z, r.z, buffer2.char(c.z, (r - shift).z),
+            buffer2.set(c.z, r.z, buffer2.grapheme(c.z, (r - shift).z),
                 buffer2.style(c.z, (r - shift).z), buffer2.link(c.z, (r - shift).z))
             c += 1
           r -= 1
@@ -279,7 +316,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         while rr < top + shift do
           var c = 0
           while c < width do
-            buffer2.set(c.z, rr.z, ' ', style, link)
+            buffer2.set(c.z, rr.z, Grapheme(" "), style, link)
             c += 1
           rr += 1
 
@@ -294,7 +331,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         while r <= bottom - shift do
           var c = 0
           while c < width do
-            buffer2.set(c.z, r.z, buffer2.char(c.z, (r + shift).z),
+            buffer2.set(c.z, r.z, buffer2.grapheme(c.z, (r + shift).z),
                 buffer2.style(c.z, (r + shift).z), buffer2.link(c.z, (r + shift).z))
             c += 1
           r += 1
@@ -302,7 +339,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         while rr <= bottom do
           var c = 0
           while c < width do
-            buffer2.set(c.z, rr.z, ' ', style, link)
+            buffer2.set(c.z, rr.z, Grapheme(" "), style, link)
             c += 1
           rr += 1
 
@@ -495,9 +532,17 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
         cursor.x = Prim
         proceed(Normal)
 
-      inline def put(char: Char): Pty =
-        writeChar(char)
-        proceed(Normal)
+      // Find the next grapheme boundary > index, extract that cluster from
+      // the input, and feed it to writeGrapheme. The boundary cursor only
+      // advances forwards (matching recur's monotonic index walk), so amortised
+      // cost is O(1) per character.
+      inline def putGrapheme(): Pty =
+        while boundaryCursor < boundaries.length && boundaries(boundaryCursor) <= index
+        do boundaryCursor += 1
+
+        val end = boundaries(boundaryCursor)
+        writeGrapheme(Grapheme(input.s.substring(index, end).nn))
+        recur(end, Normal)
 
       if index >= input.length
       then Pty(buffer2,
@@ -542,7 +587,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
               case '\u001d' => proceed(Normal) // gs()
               case '\u001e' => proceed(Normal) // rs()
               case '\u001f' => proceed(Normal) // us()
-              case ch       => put(ch)
+              case _        => putGrapheme()
 
           case Escape =>
             current match

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -42,31 +42,71 @@ import vacuous.*
 object internal:
   opaque type Style = Long
 
+  object Screen:
+    def apply(width: Int, height: Int): Screen =
+      val graphemes = Array.fill[Grapheme](width*height)(Grapheme(" "))
+      val styles = Array.fill[Style](width*height)(Style())
+      val links = Array.fill[Text](width*height)(t"")
+      new Screen(width, styles, graphemes, links)
 
+  // A cell-aligned screen buffer. Each cell holds one grapheme cluster (per
+  // UAX #29) — an ASCII character, an East-Asian-Wide CJK glyph, an emoji, or
+  // a base + combining marks. Wide graphemes occupy two adjacent cells: the
+  // leading cell holds the grapheme; the trailing cell holds an empty
+  // Grapheme("") sentinel, distinguishable via isWideTrailing.
   class Screen
-       (val width: Int,
-        styleBuffer: Array[Style],
-        charBuffer: Array[Char],
-        linkBuffer: Array[Text]):
+    ( val width:      Int,
+      styleBuffer:    Array[Style],
+      graphemeBuffer: Array[Grapheme],
+      linkBuffer:     Array[Text] ):
 
-    def capacity: Int = charBuffer.length
+    def capacity: Int = graphemeBuffer.length
     def height: Int = capacity/width
     def offset(x: Ordinal, y: Ordinal): Int = y.n0*width + x.n0
     def style(x: Ordinal, y: Ordinal): Style = styleBuffer(offset(x, y))
-    def char(x: Ordinal, y: Ordinal): Char = charBuffer(offset(x, y))
     def link(x: Ordinal, y: Ordinal): Text = linkBuffer(offset(x, y))
-    def line: Screen = new Screen(charBuffer.length, styleBuffer, charBuffer, linkBuffer)
-    def render: Text = String(charBuffer).grouped(width).to(List).map(_.tt).join(t"\n")
+
+    // The grapheme stored at this cell. An empty Grapheme("") value marks the
+    // trailing half of a wide character whose leading cell is at column x-1.
+    def grapheme(x: Ordinal, y: Ordinal): Grapheme = graphemeBuffer(offset(x, y))
+
+    // First Char of the cell's grapheme, or ' ' for trailing-half cells.
+    // Convenience accessor for narrow-ASCII assertions.
+    def char(x: Ordinal, y: Ordinal): Char =
+      val s = graphemeBuffer(offset(x, y)).text.s
+      if s.isEmpty then ' ' else s.charAt(0)
+
+    // True if this cell is the trailing half of a wide grapheme stored in the
+    // cell to the left.
+    def isWideTrailing(x: Ordinal, y: Ordinal): Boolean =
+      graphemeBuffer(offset(x, y)).text.s.isEmpty
+
+    def line: Screen =
+      new Screen(graphemeBuffer.length, styleBuffer, graphemeBuffer, linkBuffer)
+
+    def render: Text =
+      val sb = StringBuilder()
+      var y = 0
+      while y < height do
+        var x = 0
+        while x < width do
+          val s = graphemeBuffer(y*width + x).text.s
+          if s.nonEmpty then sb.append(s)
+          x += 1
+
+        if y < height - 1 then sb.append('\n')
+        y += 1
+
+      sb.text
 
     def find(text: Text): Optional[Screen] = line.render.s.indexOf(text.s) match
       case -1 => Unset
 
       case index =>
         new Screen
-         (text.length,
-          styleBuffer.slice(index, index + text.length),
-          charBuffer.slice(index, index + text.length),
-          linkBuffer.slice(index, index + text.length))
+          ( text.length, styleBuffer.slice(index, index + text.length),
+            graphemeBuffer.slice(index, index + text.length),
+            linkBuffer.slice(index, index + text.length) )
 
     def styles: IArray[Style] = styleBuffer.clone().immutable(using Unsafe)
 
@@ -83,42 +123,34 @@ object internal:
       val destination = if n < 0 then regionStart + offset else regionStart
 
       System.arraycopy(styleBuffer, source, styleBuffer, destination, length)
-      System.arraycopy(charBuffer, source, charBuffer, destination, length)
+      System.arraycopy(graphemeBuffer, source, graphemeBuffer, destination, length)
       System.arraycopy(linkBuffer, source, linkBuffer, destination, length)
 
       val fillStart = if n < 0 then regionStart else regionStart + length
 
       for i <- 0 until offset do
         styleBuffer(fillStart + i) = Style()
-        charBuffer(fillStart + i) = ' '
+        graphemeBuffer(fillStart + i) = Grapheme(" ")
         linkBuffer(fillStart + i) = t""
 
-    def set(x: Ordinal, y: Ordinal, char: Char, style: Style, link: Text): Unit =
+    def set(x: Ordinal, y: Ordinal, grapheme: Grapheme, style: Style, link: Text): Unit =
       styleBuffer(offset(x, y)) = style
-      charBuffer(offset(x, y)) = char
+      graphemeBuffer(offset(x, y)) = grapheme
       linkBuffer(offset(x, y)) = link
 
-    def set(cursor: Ordinal, char: Char, style: Style, link: Text): Unit =
+    def set(cursor: Ordinal, grapheme: Grapheme, style: Style, link: Text): Unit =
       styleBuffer(cursor.n0) = style
-      charBuffer(cursor.n0) = char
+      graphemeBuffer(cursor.n0) = grapheme
       linkBuffer(cursor.n0) = link
 
     def copy(): Screen =
       val styles = new Array[Style](capacity)
       System.arraycopy(styleBuffer, 0, styles, 0, styles.length)
-      val chars = new Array[Char](capacity)
-      System.arraycopy(charBuffer, 0, chars, 0, chars.length)
+      val graphemes = new Array[Grapheme](capacity)
+      System.arraycopy(graphemeBuffer, 0, graphemes, 0, graphemes.length)
       val links = new Array[Text](capacity)
       System.arraycopy(linkBuffer, 0, links, 0, links.length)
-      new Screen(width, styles, chars, links)
-
-
-  object Screen:
-    def apply(width: Int, height: Int): Screen =
-      val chars = Array.fill[Char](width*height)(' ')
-      val styles = Array.fill[Style](width*height)(Style())
-      val links = Array.fill[Text](width*height)(t"")
-      new Screen(width, styles, chars, links)
+      new Screen(width, styles, graphemes, links)
 
 
   extension (style: Style)

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -41,31 +41,32 @@ import vacuous.*
 
 object internal:
   opaque type Style = Long
-  opaque type Screen = (Int, Array[Style], Array[Char], Array[Text])
 
 
-  extension (buffer: Screen)
-    def width: Int = buffer(0)
+  class Screen
+       (val width: Int,
+        styleBuffer: Array[Style],
+        charBuffer: Array[Char],
+        linkBuffer: Array[Text]):
 
-    def styleBuffer: Array[Style] = buffer(1)
-    def charBuffer: Array[Char] = buffer(2)
-    def linkBuffer: Array[Text] = buffer(3)
     def capacity: Int = charBuffer.length
     def height: Int = capacity/width
     def offset(x: Ordinal, y: Ordinal): Int = y.n0*width + x.n0
     def style(x: Ordinal, y: Ordinal): Style = styleBuffer(offset(x, y))
     def char(x: Ordinal, y: Ordinal): Char = charBuffer(offset(x, y))
     def link(x: Ordinal, y: Ordinal): Text = linkBuffer(offset(x, y))
-    def line: Screen = (charBuffer.length, styleBuffer, charBuffer, linkBuffer)
+    def line: Screen = new Screen(charBuffer.length, styleBuffer, charBuffer, linkBuffer)
     def render: Text = String(charBuffer).grouped(width).to(List).map(_.tt).join(t"\n")
 
     def find(text: Text): Optional[Screen] = line.render.s.indexOf(text.s) match
       case -1 => Unset
 
       case index =>
-        ( text.length, styleBuffer.slice(index, index + text.length),
+        new Screen
+         (text.length,
+          styleBuffer.slice(index, index + text.length),
           charBuffer.slice(index, index + text.length),
-          linkBuffer.slice(index, index + text.length) )
+          linkBuffer.slice(index, index + text.length))
 
     def styles: IArray[Style] = styleBuffer.clone().immutable(using Unsafe)
 
@@ -109,7 +110,7 @@ object internal:
       System.arraycopy(charBuffer, 0, chars, 0, chars.length)
       val links = new Array[Text](capacity)
       System.arraycopy(linkBuffer, 0, links, 0, links.length)
-      (width, styles, chars, links)
+      new Screen(width, styles, chars, links)
 
 
   object Screen:
@@ -117,7 +118,7 @@ object internal:
       val chars = Array.fill[Char](width*height)(' ')
       val styles = Array.fill[Style](width*height)(Style())
       val links = Array.fill[Text](width*height)(t"")
-      (width, styles, chars, links)
+      new Screen(width, styles, chars, links)
 
 
   extension (style: Style)

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -482,33 +482,43 @@ object Tests extends Suite(m"Yossarian Tests"):
         take(row(pty, Prim), 4)
       . assert(_ == t"main")
 
-    suite(m"vttest §wide: Grapheme width [grapheme]"):
+    suite(m"vttest §wide: Grapheme width"):
       test(m"a wide CJK character occupies 2 cells"):
-        // '中' (U+4E2D) is East-Asian-Wide. Two cells should render it; the
-        // next character should land at column 2. Yossarian today stores it
-        // as a single Char in cell 0, and the next char lands at column 1.
+        // '中' (U+4E2D) is East-Asian-Wide. The leading cell holds the
+        // grapheme; the trailing cell is the wide-trailing sentinel; X lands
+        // at column 2.
         val pty = Pty24x80().consume(t"中X")
-        pty.buffer.char(Sec, Prim)
-      . assert(_ == 'X')
+        ( pty.buffer.grapheme(Prim, Prim),
+          pty.buffer.isWideTrailing(Sec, Prim),
+          pty.buffer.char(Ter, Prim) )
+      . assert(_ == (Grapheme("中"), true, 'X'))
 
       test(m"a combining mark attaches to the previous cell, no advance"):
-        // 'a' + COMBINING ACUTE ACCENT (U+0301) is one grapheme. Cursor
-        // should be at column 1 after writing it; the combining mark should
-        // NOT take its own cell. Aspirational until grapheme support lands.
-        val pty = Pty24x80().consume(t"áX")
+        // 'a' + COMBINING ACUTE ACCENT (U+0301) is one grapheme; cursor is
+        // at column 2 after writing 'áX'; X lands at column 1.
+        val pty = Pty24x80().consume(t"áX")
         (pty.cursor, pty.buffer.char(Sec, Prim))
-      . aspire(_ == (Sec, 'X'))
+      . assert(_ == (Ter, 'X'))
 
       test(m"single-codepoint emoji occupies 2 cells"):
-        // '😀' (U+1F600) is Extended_Pictographic and should be width 2.
-        // Aspirational until grapheme support lands.
+        // '😀' (U+1F600) is Extended_Pictographic and is width 2; X
+        // lands at column 2.
         val pty = Pty24x80().consume(t"😀X")
-        pty.buffer.char(Sec, Prim)
-      . aspire(_ == 'X')
+        pty.buffer.char(Ter, Prim)
+      . assert(_ == 'X')
 
       test(m"ZWJ family emoji '👨‍👩‍👧' occupies 2 cells as a single grapheme"):
-        // Three emoji codepoints joined by U+200D should collapse to one
-        // 2-cell grapheme. Aspirational until grapheme support lands.
+        // Three emoji codepoints joined by U+200D collapse to one 2-cell
+        // grapheme; X lands at column 2.
         val pty = Pty24x80().consume(t"👨‍👩‍👧X")
-        pty.buffer.char(Sec, Prim)
-      . aspire(_ == 'X')
+        pty.buffer.char(Ter, Prim)
+      . assert(_ == 'X')
+
+      test(m"wide character at the right edge wraps to next row"):
+        // A wide char with one column left wraps before writing; the leading
+        // cell at the previous right edge stays blank.
+        val pty = Pty24x80().consume(t"$Esc[1;80H中")
+        ( pty.buffer.char(79.z, Prim),
+          pty.buffer.grapheme(Prim, Sec),
+          pty.buffer.isWideTrailing(Sec, Sec) )
+      . assert(_ == (' ', Grapheme("中"), true))


### PR DESCRIPTION
Yossarian's `Screen` previously stored one `Char` per cell, which meant non-BMP codepoints occupied two cells as surrogate halves, East-Asian-Wide CJK glyphs took only one cell, ZWJ-joined family emoji and regional-indicator flag pairs all over-counted, and combining marks attached to nothing. The vttest scaffold's four `[grapheme]` tests pinned this gap. With Grapheme + GraphemeBreak now in main, this PR replaces the cell representation and routes input through proper grapheme segmentation.

## What changed for users

The `Screen` opaque type is now a regular `class` (the four-tuple encoding required public field accessors and helper extension methods that a normal class doesn't need). Each cell now holds one `Grapheme` instead of one `Char`. Wide graphemes occupy two adjacent cells: the leading cell holds the cluster; the trailing cell holds an empty `Grapheme("")` sentinel detectable via the new `Screen.isWideTrailing(x, y)`. Combining marks attach to the previous cell's grapheme without advancing the cursor.

```scala
import yossarian.*, denominative.*, gossamer.*
import strategies.throwUnsafely

val pty = Pty(80, 24).consume(t"中文😀X")
pty.buffer.grapheme(Prim, Prim)        // Grapheme("中")
pty.buffer.isWideTrailing(Sec, Prim)   // true (wide trailing half)
pty.buffer.grapheme(Ter, Prim)         // Grapheme("文")
pty.buffer.grapheme(Quin, Prim)        // Grapheme("😀") (occupies cells 4-5)
pty.buffer.char(Sept, Prim)            // 'X' (column 6)
```

`Screen.char(x, y): Char` is preserved as a convenience accessor — it returns the first char of the cell's grapheme, or `' '` for trailing-half cells, so existing narrow-ASCII test assertions and downstream consumers keep working unchanged.

## How it works

`consume(input)` precomputes the input's UAX #29 grapheme boundaries once via `GraphemeBreak.boundaries(input)`. The Normal-state printable branch walks the boundary array (a monotonic cursor gives amortised O(1) per char), extracts one cluster at a time, and feeds it to `writeGrapheme`. Control-byte handling and the CSI/OSC/DCS state machines stay byte-indexed — escape sequences are always ASCII, and OSC string payloads are accumulated into a `StringBuilder` whose UTF-16-aware text conversion handles surrogate pairs correctly downstream.

`writeGrapheme` uses Hieroglyph's `wideCharacterWidth` measurable (via the derived `Grapheme is Measurable` in Gossamer) to dispatch on width 0 / 1 / 2:

- width 0 (combining mark): attach to the cell on the left, skipping over a trailing-half sentinel to reach the wide leading cell. No cursor advance.
- width 1: write the cell, advance one column (or set `pendingWrap` at the right edge).
- width 2: if at the right edge, wrap first (matching xterm — wide glyphs aren't split). Write the leading cell with the grapheme, the trailing cell with the `""` sentinel, advance two columns.

`rep(n)` (CSI b — REP) was updated to use a new `lastGrapheme: Grapheme` field instead of `lastChar: Char` so it correctly repeats wide and combined clusters.

`Screen.scroll`, `ich`, `dch`, `il`, `dl`, and `ech` shift cells one-at-a-time with `buffer2.grapheme(...)`; trailing-half sentinels move along with their leading cell on plain shifts.

## Tests

Four `[grapheme]` tests in the vttest suite (CJK wide, combining mark, single-codepoint emoji, ZWJ family emoji) now use real assertions instead of `aspire`. A new test covers wide-char-at-right-edge wrap behaviour. All 80 tests pass; `escapade.core` still compiles unchanged.

## Commits

1. **Convert Screen from opaque type to class** — purely representational; no behaviour change.
2. **Migrate Yossarian's screen cells from Char to Grapheme** — the substantive change.