### PR TITLE
Surface .aspire(...) outcomes as AspirePass/AspireFail statuses

### DIFF
--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -73,6 +73,10 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       def highlight:   Color in Srgb = accent(yellow)
       def pass:        Color in Srgb = theme.spectrum.green.in[Srgb]
       def fail:        Color in Srgb = red
+      def aspirePass:  Color in Srgb =
+        mix(theme.spectrum.green.in[Srgb], theme.spectrum.cyan.in[Srgb], 0.5)
+
+      def aspireFail:  Color in Srgb = subdue(yellow, 0.5)
       def detail:      Color in Srgb = blue
       def background:  Color in Srgb = theme.background.in[Srgb]
       def foreground:  Color in Srgb = theme.foreground.in[Srgb]

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -60,8 +60,10 @@ object Report:
     def include(report: Report, testId: TestId, verdict: Verdict): Report =
       val report2 = report.addVerdict(testId, verdict)
       verdict match
-        case Verdict.Pass(_) => report2
-        case Verdict.Fail(_) => report2
+        case Verdict.Pass(_)       => report2
+        case Verdict.Fail(_)       => report2
+        case Verdict.AspirePass(_) => report2
+        case Verdict.AspireFail(_) => report2
 
         case Verdict.Throws(error, _) =>
           report2.addDetail(testId, Verdict.Detail.Throws(StackTrace(error)))
@@ -76,8 +78,8 @@ class Report(using Environment)(using palette: TestPalette):
 
   given measurable: Char is Measurable:
     def width(char: Char): Int = char match
-      case '✓' | '✗' | '⎇' => 1
-      case _               => metrics.width(char)
+      case '✓' | '✗' | '⎇' | '↑' | '↓' => 1
+      case _                            => metrics.width(char)
 
   private var failure: Optional[(Throwable, Set[TestId])] = Unset
   private var pass: Boolean = false
@@ -123,6 +125,8 @@ class Report(using Environment)(using palette: TestPalette):
           else if buffer.all(_.typed[Verdict.Fail]) then Status.Fail
           else if buffer.all(_.typed[Verdict.Throws]) then Status.Throws
           else if buffer.all(_.typed[Verdict.CheckThrows]) then Status.CheckThrows
+          else if buffer.all(_.typed[Verdict.AspirePass]) then Status.AspirePass
+          else if buffer.all(_.typed[Verdict.AspireFail]) then Status.AspireFail
           else Status.Mixed
 
         val min: Long = buffer.map(_.duration).min
@@ -157,7 +161,7 @@ class Report(using Environment)(using palette: TestPalette):
     this.also(details(testId) = details(testId).append(info))
 
   enum Status:
-    case Pass, Fail, Throws, CheckThrows, Mixed, Suite, Bench
+    case Pass, Fail, Throws, CheckThrows, Mixed, Suite, Bench, AspirePass, AspireFail
 
     private val nbsp = '\u00a0'
 
@@ -169,6 +173,8 @@ class Report(using Environment)(using palette: TestPalette):
       case Mixed       => e"${Bg(palette.mixed)}($Bold(${Fg(palette.black)}( ? )))"
       case Suite       => e"   "
       case Bench       => e"${Bg(palette.benchmark)}($Bold(${Fg(palette.black)}($nbsp*$nbsp)))"
+      case AspirePass  => e"${Bg(palette.aspirePass)}($Bold(${Fg(palette.black)}( ↑ )))"
+      case AspireFail  => e"${Bg(palette.aspireFail)}($Bold(${Fg(palette.black)}( ↓ )))"
 
     def describe: Teletype = this match
       case Pass        => e"Pass"
@@ -178,6 +184,8 @@ class Report(using Environment)(using palette: TestPalette):
       case Mixed       => e"Mixed"
       case Suite       => e"Suite"
       case Bench       => e"Benchmark"
+      case AspirePass  => e"Aspire passed"
+      case AspireFail  => e"Aspire failed"
 
   val unitsSeq: List[Teletype] =
     List(e"${Fg(palette.cold)}(µs)", e"${Fg(palette.warm)}(ms)", e"${Fg(palette.hot)}(s) ")
@@ -215,12 +223,14 @@ class Report(using Environment)(using palette: TestPalette):
     val summaryLines = lines.summaries
     val totals = summaryLines.groupBy(_.status).view.mapValues(_.size).to(Map) - Status.Suite
     val passed: Int = totals.getOrElse(Status.Pass, 0) + totals.getOrElse(Status.Bench, 0)
+    val aspirePassed: Int = totals.getOrElse(Status.AspirePass, 0)
+    val aspireFailed: Int = totals.getOrElse(Status.AspireFail, 0)
     val total: Int = totals.values.sum
-    val failed: Int = total - passed
-    if total == passed && failure.absent then pass = true
+    val failed: Int = total - passed - aspirePassed - aspireFailed
+    if failed == 0 && failure.absent then pass = true
 
     if total == 0 then Out.println(t"No tests were run.")
-    else Out.println(t"$passed passed, $failed failed, $total total")
+    else Out.println(t"$passed passed, $failed failed, $aspirePassed aspire-passed, $aspireFailed aspire-failed, $total total")
 
     def truncate(text: Text, max: Int = 800): Text =
       if text.length <= max then text else t"${text.keep(max)}…"
@@ -233,6 +243,8 @@ class Report(using Environment)(using palette: TestPalette):
       case Status.Mixed       => t"mixed"
       case Status.Suite       => t"suite"
       case Status.Bench       => t"bench"
+      case Status.AspirePass  => t"aspire-pass"
+      case Status.AspireFail  => t"aspire-fail"
 
     def formatFrame(frame: StackTrace.Frame): Text =
       val ln = frame.line.let(_.toString.tt).or(t"?")
@@ -433,9 +445,11 @@ class Report(using Environment)(using palette: TestPalette):
       if summaryLines.exists(_.count > 0) then
         val totals = summaryLines.groupBy(_.status).view.mapValues(_.size).to(Map) - Status.Suite
         val passed: Int = totals.getOrElse(Status.Pass, 0) + totals.getOrElse(Status.Bench, 0)
+        val aspirePassed: Int = totals.getOrElse(Status.AspirePass, 0)
+        val aspireFailed: Int = totals.getOrElse(Status.AspireFail, 0)
         val total: Int = totals.values.sum
-        val failed: Int = total - passed
-        if total == passed && failure.absent then pass = true
+        val failed: Int = total - passed - aspirePassed - aspireFailed
+        if failed == 0 && failure.absent then pass = true
 
         if !tabulation then
           Out.print(e"${escapes.Reset}")
@@ -480,14 +494,20 @@ class Report(using Environment)(using palette: TestPalette):
           given decimalizer: Decimalizer = Decimalizer(decimalPlaces = 1)
           val passText = e"$Bold(${Fg(palette.foreground)}($passed)) passed (${100.0*passed/total}%)"
           val failText = e"$Bold(${Fg(palette.foreground)}($failed)) failed (${100.0*failed/total}%)"
-          val allText = e"$Bold(${Fg(palette.foreground)}(${passed + failed})) total"
+          val aspirePassText =
+            e"$Bold(${Fg(palette.foreground)}($aspirePassed)) aspire-passed (${100.0*aspirePassed/total}%)"
+          val aspireFailText =
+            e"$Bold(${Fg(palette.foreground)}($aspireFailed)) aspire-failed (${100.0*aspireFailed/total}%)"
+          val allText = e"$Bold(${Fg(palette.foreground)}($total)) total"
 
-          Out.println(e" $passText, $failText, $allText")
+          if aspirePassed + aspireFailed == 0
+          then Out.println(e" $passText, $failText, $allText")
+          else Out.println(e" $passText, $failText, $aspirePassText, $aspireFailText, $allText")
           Out.println(t"─"*72)
 
         import Status.*
 
-        List(Pass, Bench, Throws, Fail, Mixed, CheckThrows).grouped(3).each: statuses =>
+        List(Pass, Bench, AspirePass, Throws, Fail, AspireFail, Mixed, CheckThrows).grouped(4).each: statuses =>
           Out.println:
             statuses.map[Teletype]: status =>
               gossamer.pad[Teletype](e"  ${status.symbol} ${status.describe}")(20)

--- a/lib/probably/src/core/probably.Test.scala
+++ b/lib/probably/src/core/probably.Test.scala
@@ -37,8 +37,10 @@ import proscenium.*
 object Test:
   extension [test](test: Test[test])
     inline def aspire(inline predicate: test => Boolean): Unit =
-      ${probably.internal.aspire[test]('test)}
+      ${probably.internal.aspire[test]('test, 'predicate)}
 
+    inline def aspire(): Unit =
+      ${probably.internal.aspire[test]('test, '{probably.internal.succeed})}
 
     inline def assert(inline predicate: test => Boolean): Unit =
       ${probably.internal.assert[test]('test, 'predicate)}

--- a/lib/probably/src/core/probably.Verdict.scala
+++ b/lib/probably/src/core/probably.Verdict.scala
@@ -49,6 +49,8 @@ enum Verdict:
   case Fail(duration: Long)
   case Throws(exception: Exception, duration: Long)
   case CheckThrows(exception: Exception, duration: Long)
+  case AspirePass(duration: Long)
+  case AspireFail(duration: Long)
 
   val timestamp: Long = System.currentTimeMillis
 

--- a/lib/probably/src/core/probably.internal.scala
+++ b/lib/probably/src/core/probably.internal.scala
@@ -49,12 +49,15 @@ import vacuous.*
 
 object internal:
   private def handle[test: Type, result: Type]
-    ( test:      Expr[Test[test]],
-      predicate: Expr[test => Boolean],
-      action:    Expr[Trial[test] => result] )
+    ( test:         Expr[Test[test]],
+      predicate:    Expr[test => Boolean],
+      action:       Expr[Trial[test] => result],
+      aspirational: Boolean )
   :   Macro[result] =
 
     import quotes.reflect.*
+
+    val aspirationalExpr: Expr[Boolean] = Expr(aspirational)
 
     Expr.summon[Runner[?]].getOrElse(halt(m"No `Runner` instance is available")).absolve match
       case '{$runner: Runner[report]} =>
@@ -105,7 +108,8 @@ object internal:
                     Some($expr),
                     $inclusion,
                     $inclusion2,
-                    decompose )
+                    decompose,
+                    $aspirationalExpr )
               }
 
           case _ =>
@@ -119,7 +123,8 @@ object internal:
                       None,
                       $inclusion,
                       $inclusion2,
-                      Decomposable.any[test] ) )
+                      Decomposable.any[test],
+                      $aspirationalExpr ) )
               }
 
         else
@@ -133,18 +138,19 @@ object internal:
                     None,
                     $inclusion,
                     $inclusion2,
-                    Decomposable.any[test] ) )
+                    Decomposable.any[test],
+                    $aspirationalExpr ) )
             }
 
 
   def check[test: Type](test: Expr[Test[test]], predicate: Expr[test => Boolean]): Macro[test] =
-    handle[test, test](test, predicate, '{(t: Trial[test]) => t.get})
+    handle[test, test](test, predicate, '{(t: Trial[test]) => t.get}, false)
 
   def assert[test: Type](test: Expr[Test[test]], predicate: Expr[test => Boolean]): Macro[Unit] =
-    handle[test, Unit](test, predicate, '{_ => ()})
+    handle[test, Unit](test, predicate, '{_ => ()}, false)
 
-  def aspire[test: Type](test: Expr[Test[test]]): Macro[Unit] =
-    handle[test, Unit](test, '{_ => true}, '{_ => ()})
+  def aspire[test: Type](test: Expr[Test[test]], predicate: Expr[test => Boolean]): Macro[Unit] =
+    handle[test, Unit](test, predicate, '{_ => ()}, true)
 
   def succeed: Any => Boolean = (value: Any) => true
 
@@ -158,7 +164,8 @@ object internal:
       exp:          Option[test],
       inc:          Inclusion[report, Verdict],
       inc2:         Inclusion[report, Verdict.Detail],
-      decomposable: test is Decomposable )
+      decomposable: test is Decomposable,
+      aspirational: Boolean )
   :   result =
 
     runner.run(test).pipe: run =>
@@ -166,10 +173,13 @@ object internal:
         case Trial.Throws(err, duration, map) =>
           val exception: Exception = try err() catch case exc: Exception => exc
           if !map.nil then inc2.include(runner.report, test.id, Verdict.Detail.Captures(map))
-          Verdict.Throws(exception, duration)
+          if aspirational then Verdict.AspireFail(duration)
+          else Verdict.Throws(exception, duration)
 
         case Trial.Returns(value, duration, map) =>
-          try if predicate(value) then Verdict.Pass(duration) else
+          try if predicate(value) then
+            if aspirational then Verdict.AspirePass(duration) else Verdict.Pass(duration)
+          else
             exp match
               case Some(exp) =>
                 inc2.include
@@ -187,8 +197,10 @@ object internal:
             if !map.nil
             then inc2.include(runner.report, test.id, Verdict.Detail.Captures(map))
 
-            Verdict.Fail(duration)
-          catch case error: Exception => Verdict.CheckThrows(error, duration)
+            if aspirational then Verdict.AspireFail(duration) else Verdict.Fail(duration)
+          catch case error: Exception =>
+            if aspirational then Verdict.AspireFail(duration)
+            else Verdict.CheckThrows(error, duration)
 
       inc.include(runner.report, test.id, verdict)
       result(run)

--- a/lib/probably/src/core/probably_core.scala
+++ b/lib/probably/src/core/probably_core.scala
@@ -66,6 +66,8 @@ type TestPalette = Palette:
   def detail: Color in Srgb
   def pass: Color in Srgb
   def fail: Color in Srgb
+  def aspirePass: Color in Srgb
+  def aspireFail: Color in Srgb
   def subdued: Color in Srgb
 
 extension [left](left: left)


### PR DESCRIPTION
Tests run with `.aspire(...)` now evaluate their predicate and surface the outcome as one of two new test statuses, so aspirational tests are no longer indistinguishable from real passes in the report.

`.aspire(predicate)` previously ignored its predicate and always recorded as a regular pass. It now evaluates the predicate and reports the result as one of two new statuses:

- **`AspirePass`** — symbol `↑`, teal-green. The aspiration's predicate returned `true`. This is a signal that the test could be promoted to `.assert(...)`.
- **`AspireFail`** — symbol `↓`, muted yellow. The predicate returned `false`, or the test or predicate threw. The aspiration is acknowledged but the suite continues to pass.

Both statuses appear in the report legend and the per-suite summary, and neither contributes to the `failed` count or causes the suite to exit non-zero.

```scala
class MySuite extends Suite(m"my suite"):
  def run(): Unit =
    test(m"flaky behaviour we'd like to fix some day"):
      computeSomething()
    .aspire(_ == 42)
```

A no-arg `.aspire()` overload is also available, mirroring `.assert()` and `.check()`, for use cases where there's no meaningful predicate.