### PR TITLE
Wire up merino, serpentine, jacinta benchmark modules

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -137,6 +137,15 @@ trait Tests(dependencies: PublishModule*) extends BaseScalaModule:
   def scalacOptions = Task:
     settings.scalaOptions :+ s"-Xplugin:${larceny.plugin.assembly().path}"
 
+trait Benchmarks(dependencies: PublishModule*) extends BaseScalaModule:
+  def moduleId: String = moduleDir.last
+  def finalMainClass = (moduleDir / ".." / "..").last + ".Benchmarks"
+  def resources = Task.Sources(moduleDir / ".." / ".." / "res" / moduleId)
+  def compileResources = Task.Sources(moduleDir / ".." / ".." / "res" / moduleId)
+  def moduleDeps: Seq[PublishModule] = probably.cli +: sedentary.core +: dependencies
+  def sources = Task.Sources(moduleDir)
+  def consoleScalacOptions = scalacOptions()
+
 trait Bundle(dependencies: PublishModule*) extends BaseScalaModule, PublishModule:
   def sources = Task.Sources()
   def moduleDeps = dependencies
@@ -695,6 +704,7 @@ object jacinta extends Library:
   object http extends Component(core, telekinesis.core)
   object schema extends Component(core, telekinesis.core)
   object test extends Tests(time, http, schema)
+  object bench extends Benchmarks(core, quantitative.units)
 
 object kaleidoscope extends Library:
   object core extends Component(contingency.core)
@@ -724,6 +734,8 @@ object mercator extends Library:
 object merino extends Library:
   object core extends Component(turbulence.core, zephyrine.core)
   object test extends Tests(core, sedentary.core, diuretic.core, galilei.core, octogenarian.core, eucalyptus.core)
+  object bench extends Benchmarks(core, quantitative.units):
+    def mvnDeps = Seq(mvn"org.typelevel::jawn-ast:1.6.0")
 
 object metamorphose extends Library:
   object core extends Component(contingency.core)
@@ -856,6 +868,7 @@ object sedentary extends Library:
 object serpentine extends Library:
   object core extends Component(nomenclature.core, ambience.core)
   object test extends Tests(core)
+  object bench extends Benchmarks(core, quantitative.units)
 
 object spectacular extends Library:
   object core extends Component(stenography.core, inimitable.core, wisteria.core, digression.core)

--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -32,42 +32,46 @@
                                                                                                   */
 package jacinta
 
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
 import gossamer.*
-import hieroglyph.*, charEncoders.utf8
+import hellenism.*, classloaders.threadContext
+import merino.*
 import probably.*
+import quantitative.*
 import rudiments.*
-import turbulence.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.system
+import vacuous.*
 
-import unsafeExceptions.canThrowAny
+object Benchmarks extends Suite(m"Jacinta benchmarks"):
+  given device: BenchmarkDevice = LocalhostDevice
 
-object Bench extends Suite(m"Jacinta benchmarks"):
   def run(): Unit =
-    test(m"Parse a simple object with one string value"):
-      Json.parse(t"""{"foo": "bar"}""")
+    val bench = Bench()
 
-    . benchmark(duration = 3000L, warmup = 3000L)
+    bench(m"Parse a simple object with one string value")(target = 3*Second):
+      '{ parse(t"""{"foo": "bar"}""") }
 
-    test(m"Parse a simple object with one numerical value"):
-      Json.parse(t"""{"foo": 3.1415926 }""")
+    bench(m"Parse a simple object with one numerical value")(target = 3*Second):
+      '{ parse(t"""{"foo": 3.1415926 }""") }
 
-    . benchmark(duration = 3000L, warmup = 3000L)
+    bench(m"Parse true value")(target = 3*Second):
+      '{ parse(t"""{"foo": true }""") }
 
-    test(m"Parse true value"):
-      Json.parse(t"""{"foo": true }""")
+    bench(m"Parse false value")(target = 3*Second):
+      '{ parse(t"""{"foo": false }""") }
 
-    . benchmark(duration = 3000L, warmup = 3000L)
+    bench(m"Parse array of strings")(target = 3*Second):
+      '{ parse(t"""["foo", "bar", "baz", "quux", "abcd", "defg", "hijk"]""") }
 
-    test(m"Parse false value"):
-      Json.parse(t"""{"foo": false }""")
+    bench(m"Parse array of numbers")(target = 3*Second):
+      '{ parse(t"""[12345.6789, 98765.4321, 142536.475869]""") }
 
-    . benchmark(duration = 3000L, warmup = 3000L)
-
-    test(m"Parse array of strings"):
-      Json.parse(t"""["foo", "bar", "baz", "quux", "abcd", "defg", "hijk"]""")
-
-    . benchmark(duration = 3000L, warmup = 3000L)
-
-    test(m"Parse array of numbers"):
-      Json.parse(t"""[12345.6789, 98765.4321, 142536.475869]""")
-
-    . benchmark(duration = 3000L, warmup = 3000L)
+  def parse(text: Text): Json = unsafely:
+    Json(JsonAst.parse(text.s.getBytes("UTF-8").nn.immutable(using Unsafe)))

--- a/lib/merino/src/bench/merino.Benchmarks.scala
+++ b/lib/merino/src/bench/merino.Benchmarks.scala
@@ -32,66 +32,62 @@
                                                                                                   */
 package merino
 
-import ambience.*, environments.system
-import anticipation.* //, interfaces.paths.galileiApi
-import eucalyptus.*
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
 import gossamer.*
-import hieroglyph.*, characterEncodings.utf8, badEncodingHandlers.strict
-import parasite.*, monitors.global
+import hellenism.*, classloaders.threadContext
+import hieroglyph.*, charEncoders.utf8
 import probably.*
-import rudiments.*
-import turbulence.*, stdios.virtualMachine
+import quantitative.*
+import sedentary.*
+import superlunary.*, embeddings.automatic
+import symbolism.*
+import temporaryDirectories.system
 
-import LogFormat.standardAnsi
-import unsafeExceptions.canThrowAny
+object Benchmarks extends Suite(m"Merino benchmarks"):
+  given device: BenchmarkDevice = LocalhostDevice
 
-val OutSink = Out.sink
-given log: Log({ case _ => OutSink })
-
-object Benchmarks extends Suite(m"Merino tests"):
   def run(): Unit =
+    val bench = Bench()
+
     suite(m"Parse example 1"):
-      test(m"Parse file with Jawn"):
-        import org.typelevel.jawn.*, ast.*
-        JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(jsonExample1).nn)
+      bench(m"Parse file with Jawn")
+        (target = 1*Second, baseline = Baseline(compare = Min)):
+        '{
+            import org.typelevel.jawn.ast.JParser
+            JParser.parseFromString(${jsonExample1}.s)
+          }
 
-      . benchmark
-        ( warmup = 1000L, duration = 1000L, baseline = Baseline(compare = Min), confidence = 99 )
-
-      test(m"Parse file with Merino"):
-        JsonAst.parse(jsonExample1.nn.immutable(using Unsafe))
-
-      . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)
+      bench(m"Parse file with Merino")(target = 1*Second):
+        '{ JsonAst.parse(summon[CharEncoder].encoded(${jsonExample1})) }
 
     suite(m"Parse example 2"):
-      test(m"Parse file with Jawn"):
-        import org.typelevel.jawn.*, ast.*
-        JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(jsonExample2).nn)
+      bench(m"Parse file with Jawn")
+        (target = 1*Second, baseline = Baseline(compare = Min)):
+        '{
+            import org.typelevel.jawn.ast.JParser
+            JParser.parseFromString(${jsonExample2}.s)
+          }
 
-      . benchmark
-        ( warmup = 1000L, duration = 1000L, baseline = Baseline(compare = Min), confidence = 99 )
-
-      test(m"Parse file with Merino"):
-        JsonAst.parse(jsonExample2.nn.immutable(using Unsafe))
-
-      . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)
+      bench(m"Parse file with Merino")(target = 1*Second):
+        '{ JsonAst.parse(summon[CharEncoder].encoded(${jsonExample2})) }
 
     suite(m"Parse example 3"):
-      test(m"Parse file with Jawn"):
-        import org.typelevel.jawn.*, ast.*
-        JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(jsonExample3).nn)
+      bench(m"Parse file with Jawn")
+        (target = 1*Second, baseline = Baseline(compare = Min)):
+        '{
+            import org.typelevel.jawn.ast.JParser
+            JParser.parseFromString(${jsonExample3}.s)
+          }
 
-      . benchmark
-        ( warmup = 1000L, duration = 1000L, baseline = Baseline(compare = Min), confidence = 99 )
+      bench(m"Parse file with Merino")(target = 1*Second):
+        '{ JsonAst.parse(summon[CharEncoder].encoded(${jsonExample3})) }
 
-      test(m"Parse file with Merino"):
-        JsonAst.parse(jsonExample3.nn.immutable(using Unsafe))
-
-      . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)
-
-private given realm: Realm = Realm(t"tests")
-
-lazy val jsonExample1 = """
+  val jsonExample1: Text = t"""
 
 {"web-app": {
   "servlet": [
@@ -181,14 +177,14 @@ lazy val jsonExample1 = """
   "taglib": {
     "taglib-uri": "cofax.tld",
     "taglib-location": "/WEB-INF/tlds/cofax.tld"}}}
-""".getData("UTF-8")
+"""
 
-val jsonExample2 = """
+  val jsonExample2: Text = t"""
 {"menu":{"id":"file","value":"File","popup":{"menuitem":[{"value":"New","onclick":"CreateNewDoc()"},
 {"value":"Open","onclick":"OpenDoc()"},{"value":"Close","onclick":"CloseDoc()"}]}}}
-""".getData("UTF-8")
+"""
 
-lazy val jsonExample3 = """
+  val jsonExample3: Text = t"""
 {"menu": {
   "header": "SVG Viewer",
     "items": [
@@ -216,4 +212,4 @@ lazy val jsonExample3 = """
         {"id": "About", "label": "About Adobe CVG Viewer..."}
     ]
 }}
-""".getData("UTF-8")
+"""

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -72,7 +72,6 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
       confidence: Optional[Benchmark.Percentiles] = Unset,
       baseline:   Optional[Baseline]              = Unset )
     ( body0: (References over Transport) ?=> Quotes ?=> Expr[Unit] )
-    [ version <: Scalac.Versions ]
     ( using System, TemporaryDirectory, Stageable over Transport in Form )
     ( using runner:    Runner[report],
             inclusion: Inclusion[report, Benchmark],

--- a/lib/serpentine/src/bench/serpentine.Benchmarks.scala
+++ b/lib/serpentine/src/bench/serpentine.Benchmarks.scala
@@ -32,55 +32,64 @@
                                                                                                   */
 package serpentine
 
-import digression.*
-import gossamer.*
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
+import hellenism.*, classloaders.threadContext
 import probably.*
-import rudiments.*
+import quantitative.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.system
 
-object Benchmarks extends Suite(m"internal Benchmarks"):
+object Benchmarks extends Suite(m"Serpentine benchmarks"):
+  given device: BenchmarkDevice = LocalhostDevice
+
   def run(): Unit =
+    val bench = Bench()
+
     suite(m"Conjunctions"):
-      test(m"Find conjunction of 2-element paths"):
-        val p1 = ^ / p"foo" / p"bar"
-        val p2 = ^ / p"foo" / p"baz"
-        p1.conjunction(p2)
+      bench(m"Find conjunction of 2-element paths")
+        (target = 500*Milli(Second), baseline = Baseline(compare = Min)):
+        '{
+            val p1 = % / "foo" / "bar"
+            val p2 = % / "foo" / "baz"
+            p1.conjunction(p2)
+          }
 
-      . benchmark
-        ( warmup   = 500L,
-          duration = 500L,
-          baseline = Baseline(ratio = Ratio.Time, compare = Compare.Min) )
+      bench(m"Find conjunction of 3-element paths")(target = 500*Milli(Second)):
+        '{
+            val p1 = % / "foo" / "bar" / "quux"
+            val p2 = % / "foo" / "baz" / "quux"
+            p1.conjunction(p2)
+          }
 
-      test(m"Find conjunction of 3-element paths"):
-        val p1 = ^ / p"foo" / p"bar" / p"quux"
-        val p2 = ^ / p"foo" / p"baz" / p"quux"
-        p1.conjunction(p2)
+      bench(m"Find conjunction of 4-element paths")(target = 500*Milli(Second)):
+        '{
+            val p1 = % / "foo" / "bar" / "quux" / "bippy"
+            val p2 = % / "foo" / "baz" / "quux" / "bop"
+            p1.conjunction(p2)
+          }
 
-      . benchmark(warmup = 500L, duration = 500L)
+      bench(m"Find conjunction of 5-element paths")(target = 500*Milli(Second)):
+        '{
+            val p1 = % / "foo" / "bar" / "quux" / "bippy" / "abc"
+            val p2 = % / "foo" / "baz" / "quux" / "bop" / "def"
+            p1.conjunction(p2)
+          }
 
-      test(m"Find conjunction of 4-element paths"):
-        val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy"
-        val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop"
-        p1.conjunction(p2)
+      bench(m"Find conjunction of 6-element paths")(target = 500*Milli(Second)):
+        '{
+            val p1 = % / "foo" / "bar" / "quux" / "bippy" / "abc" / "ghi"
+            val p2 = % / "foo" / "baz" / "quux" / "bop" / "def" / "jkl"
+            p1.conjunction(p2)
+          }
 
-      . benchmark(warmup = 500L, duration = 500L)
-
-      test(m"Find conjunction of 5-element paths"):
-        val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy" / p"abc"
-        val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop" / p"def"
-        p1.conjunction(p2)
-
-      . benchmark(warmup = 500L, duration = 500L)
-
-      test(m"Find conjunction of 6-element paths"):
-        val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy" / p"abc" / p"ghi"
-        val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop" / p"def" / p"jkl"
-        p1.conjunction(p2)
-
-      . benchmark(warmup = 500L, duration = 500L)
-
-      test(m"Find conjunction of 7-element paths"):
-        val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy" / p"abc" / p"ghi" / p"mno"
-        val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop" / p"def" / p"jkl" / p"pqr"
-        p1.conjunction(p2)
-
-      . benchmark(warmup = 500L, duration = 500L)
+      bench(m"Find conjunction of 7-element paths")(target = 500*Milli(Second)):
+        '{
+            val p1 = % / "foo" / "bar" / "quux" / "bippy" / "abc" / "ghi" / "mno"
+            val p2 = % / "foo" / "baz" / "quux" / "bop" / "def" / "jkl" / "pqr"
+            p1.conjunction(p2)
+          }

--- a/lib/superlunary/src/core/superlunary.Rig.scala
+++ b/lib/superlunary/src/core/superlunary.Rig.scala
@@ -82,7 +82,6 @@ trait Rig(using classloader0: Classloader) extends Targetable, Formal, Transport
 
   inline def dispatch[output]
     ( body: (References over Transport) ?=> Quotes ?=> Expr[output] )
-    [ version <: Scalac.Versions ]
     ( using codepoint:  Codepoint,
             properties: System,
             directory:  TemporaryDirectory,


### PR DESCRIPTION
## Summary

The `src/bench/` source tree in `merino`, `serpentine`, and `jacinta` was orphaned — no Mill module pointed at it, and the source files had drifted to a `.benchmark(...)` API that no longer exists. This PR adds Mill modules for each (`X.bench`), rewrites the three `*.Benchmarks.scala` files against the current `sedentary.Bench` API, and drops an unused `[version <: Scalac.Versions]` type parameter from `sedentary.Bench.apply` / `superlunary.Rig.dispatch` that was triggering a Scala 3 compiler internal assertion during inline expansion.

## Release notes

Three benchmark suites can now be invoked directly from Mill:

```sh
mill jacinta.bench.run
mill serpentine.bench.run
mill merino.bench.run
```

Each benchmark body is a `Quotes ?=> Expr[Unit]` that `sedentary.Bench` compiles to a fresh JAR via `superlunary` and runs in a separate JVM (`LocalhostDevice`), giving clean JIT-warmup measurements per benchmark.

`merino.bench` adds `org.typelevel::jawn-ast:1.6.0` as a dependency for the Jawn-vs-Merino comparisons.

The `sedentary.Bench` and `superlunary.Rig` APIs no longer have the dead `[version <: Scalac.Versions]` type parameter on `apply` / `dispatch`. The parameter was unused in both bodies and its position after a value parameter list triggered a Scala 3 compiler crash on user call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)