### PR TITLE
Repair Sedentary; add operationSize and Prefixes

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -862,8 +862,8 @@ object scintillate extends Library:
   object test extends Tests(server, servlet)
 
 object sedentary extends Library:
-  object core extends Component(superlunary.jvm, anthology.bundle, diuretic.core)
-  object test extends Tests(core, quantitative.units)
+  object core extends Component(superlunary.jvm, anthology.bundle, diuretic.core, quantitative.units)
+  object test extends Tests(core)
 
 object serpentine extends Library:
   object core extends Component(nomenclature.core, ambience.core)

--- a/build.mill
+++ b/build.mill
@@ -735,7 +735,12 @@ object merino extends Library:
   object core extends Component(turbulence.core, zephyrine.core)
   object test extends Tests(core, sedentary.core, diuretic.core, galilei.core, octogenarian.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):
-    def mvnDeps = Seq(mvn"org.typelevel::jawn-ast:1.6.0")
+    def mvnDeps = Seq(
+      mvn"org.typelevel::jawn-ast:1.6.0",
+      mvn"io.circe::circe-parser:0.14.13",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.30.7",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-circe:2.30.7"
+    )
 
 object metamorphose extends Library:
   object core extends Component(contingency.core)

--- a/lib/merino/src/bench/merino.Benchmarks.scala
+++ b/lib/merino/src/bench/merino.Benchmarks.scala
@@ -41,6 +41,7 @@ import fulminate.*
 import gossamer.*
 import hellenism.*, classloaders.threadContext
 import probably.*
+import proscenium.*
 import quantitative.*
 import rudiments.*
 import sedentary.*
@@ -49,64 +50,80 @@ import temporaryDirectories.system
 import vacuous.*
 
 object Benchmarks extends Suite(m"Merino benchmarks"):
-  given device: BenchmarkDevice = LocalhostDevice
+  sealed trait Information extends Dimension
+  sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
+  val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+
+  given byteDesignation: Designation[Bytes[1]] = () => t"B"
+  given decimalizer:     Decimalizer            = Decimalizer(2)
+  given device:          BenchmarkDevice        = LocalhostDevice
+
+  // Auto-scale byte sizes (B → kB → MB → GB → TB) and byte rates so the
+  // table prints "1.3 GB·s¯¹" instead of "1.3×10⁹ B·s¯¹".
+  given prefixes: Prefixes = Prefixes(List(Kilo, Mega, Giga, Tera))
 
   def run(): Unit =
     val bench = Bench()
 
+    val size1 = jsonBytes1.length*Byte
+    val size2 = jsonBytes2.length*Byte
+    val size3 = jsonBytes3.length*Byte
+    val size4 = jsonBytes4.length*Byte
+    val size5 = jsonBytes5.length*Byte
+
     suite(m"Parse example 1"):
       bench(m"Parse file with Jawn")
-        (target = 1*Second, baseline = Baseline(compare = Min)):
+        (target = 1*Second, operationSize = size1, baseline = Baseline(compare = Min)):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText1)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second):
+      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size1):
         '{ JsonAst.parse(merino.Benchmarks.jsonBytes1) }
 
     suite(m"Parse example 2"):
       bench(m"Parse file with Jawn")
-        (target = 1*Second, baseline = Baseline(compare = Min)):
+        (target = 1*Second, operationSize = size2, baseline = Baseline(compare = Min)):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText2)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second):
+      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size2):
         '{ JsonAst.parse(merino.Benchmarks.jsonBytes2) }
 
     suite(m"Parse example 3"):
       bench(m"Parse file with Jawn")
-        (target = 1*Second, baseline = Baseline(compare = Min)):
+        (target = 1*Second, operationSize = size3, baseline = Baseline(compare = Min)):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText3)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second):
+      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size3):
         '{ JsonAst.parse(merino.Benchmarks.jsonBytes3) }
 
     suite(m"Parse example 4 (100 user records)"):
       bench(m"Parse file with Jawn")
-        (target = 1*Second, baseline = Baseline(compare = Min)):
+        (target = 1*Second, operationSize = size4, baseline = Baseline(compare = Min)):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText4)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second):
+      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size4):
         '{ JsonAst.parse(merino.Benchmarks.jsonBytes4) }
 
     suite(m"Parse example 5 (500 log entries)"):
       bench(m"Parse file with Jawn")
-        (target = 1*Second, baseline = Baseline(compare = Min)):
+        (target = 1*Second, operationSize = size5, baseline = Baseline(compare = Min)):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText5)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second):
+      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size5):
         '{ JsonAst.parse(merino.Benchmarks.jsonBytes5) }
 
   lazy val jsonText1: String = jsonExample1.s

--- a/lib/merino/src/bench/merino.Benchmarks.scala
+++ b/lib/merino/src/bench/merino.Benchmarks.scala
@@ -62,6 +62,14 @@ object Benchmarks extends Suite(m"Merino benchmarks"):
   // table prints "1.3 GB·s¯¹" instead of "1.3×10⁹ B·s¯¹".
   given prefixes: Prefixes = Prefixes(List(Kilo, Mega, Giga, Tera))
 
+  // Codec used by the Jsoniter benchmark to parse into a circe `Json` AST.
+  val jsoniterCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[io.circe.Json] =
+    com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.jsonCodec()
+
+  def parseWithJsoniter(text: String): io.circe.Json =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromString[io.circe.Json](text)
+      (using jsoniterCodec)
+
   def run(): Unit =
     val bench = Bench()
 
@@ -72,59 +80,89 @@ object Benchmarks extends Suite(m"Merino benchmarks"):
     val size5 = jsonBytes5.length*Byte
 
     suite(m"Parse example 1"):
-      bench(m"Parse file with Jawn")
+      bench(m"Parse file with Merino")
         (target = 1*Second, operationSize = size1, baseline = Baseline(compare = Min)):
+        '{ JsonAst.parse(merino.Benchmarks.jsonBytes1) }
+
+      bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size1):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText1)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size1):
-        '{ JsonAst.parse(merino.Benchmarks.jsonBytes1) }
+      bench(m"Parse file with Circe")(target = 1*Second, operationSize = size1):
+        '{ io.circe.parser.parse(merino.Benchmarks.jsonText1) }
+
+      bench(m"Parse file with Jsoniter")(target = 1*Second, operationSize = size1):
+        '{ merino.Benchmarks.parseWithJsoniter(merino.Benchmarks.jsonText1) }
 
     suite(m"Parse example 2"):
-      bench(m"Parse file with Jawn")
+      bench(m"Parse file with Merino")
         (target = 1*Second, operationSize = size2, baseline = Baseline(compare = Min)):
+        '{ JsonAst.parse(merino.Benchmarks.jsonBytes2) }
+
+      bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size2):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText2)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size2):
-        '{ JsonAst.parse(merino.Benchmarks.jsonBytes2) }
+      bench(m"Parse file with Circe")(target = 1*Second, operationSize = size2):
+        '{ io.circe.parser.parse(merino.Benchmarks.jsonText2) }
+
+      bench(m"Parse file with Jsoniter")(target = 1*Second, operationSize = size2):
+        '{ merino.Benchmarks.parseWithJsoniter(merino.Benchmarks.jsonText2) }
 
     suite(m"Parse example 3"):
-      bench(m"Parse file with Jawn")
+      bench(m"Parse file with Merino")
         (target = 1*Second, operationSize = size3, baseline = Baseline(compare = Min)):
+        '{ JsonAst.parse(merino.Benchmarks.jsonBytes3) }
+
+      bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size3):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText3)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size3):
-        '{ JsonAst.parse(merino.Benchmarks.jsonBytes3) }
+      bench(m"Parse file with Circe")(target = 1*Second, operationSize = size3):
+        '{ io.circe.parser.parse(merino.Benchmarks.jsonText3) }
+
+      bench(m"Parse file with Jsoniter")(target = 1*Second, operationSize = size3):
+        '{ merino.Benchmarks.parseWithJsoniter(merino.Benchmarks.jsonText3) }
 
     suite(m"Parse example 4 (100 user records)"):
-      bench(m"Parse file with Jawn")
+      bench(m"Parse file with Merino")
         (target = 1*Second, operationSize = size4, baseline = Baseline(compare = Min)):
+        '{ JsonAst.parse(merino.Benchmarks.jsonBytes4) }
+
+      bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size4):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText4)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size4):
-        '{ JsonAst.parse(merino.Benchmarks.jsonBytes4) }
+      bench(m"Parse file with Circe")(target = 1*Second, operationSize = size4):
+        '{ io.circe.parser.parse(merino.Benchmarks.jsonText4) }
+
+      bench(m"Parse file with Jsoniter")(target = 1*Second, operationSize = size4):
+        '{ merino.Benchmarks.parseWithJsoniter(merino.Benchmarks.jsonText4) }
 
     suite(m"Parse example 5 (500 log entries)"):
-      bench(m"Parse file with Jawn")
+      bench(m"Parse file with Merino")
         (target = 1*Second, operationSize = size5, baseline = Baseline(compare = Min)):
+        '{ JsonAst.parse(merino.Benchmarks.jsonBytes5) }
+
+      bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size5):
         '{
             import org.typelevel.jawn.ast.JParser
             JParser.parseFromString(merino.Benchmarks.jsonText5)
           }
 
-      bench(m"Parse file with Merino")(target = 1*Second, operationSize = size5):
-        '{ JsonAst.parse(merino.Benchmarks.jsonBytes5) }
+      bench(m"Parse file with Circe")(target = 1*Second, operationSize = size5):
+        '{ io.circe.parser.parse(merino.Benchmarks.jsonText5) }
+
+      bench(m"Parse file with Jsoniter")(target = 1*Second, operationSize = size5):
+        '{ merino.Benchmarks.parseWithJsoniter(merino.Benchmarks.jsonText5) }
 
   lazy val jsonText1: String = jsonExample1.s
   lazy val jsonText2: String = jsonExample2.s

--- a/lib/probably/src/core/probably.Benchmark.scala
+++ b/lib/probably/src/core/probably.Benchmark.scala
@@ -44,6 +44,7 @@ object Benchmark:
 case class Benchmark
   ( nanoseconds: Long,
     iterations:  Long,
+    runs:        Int,
     mean:        Double,
     min:         Double,
     max:         Double,
@@ -51,15 +52,60 @@ case class Benchmark
     confidence:  Benchmark.Percentiles,
     baseline:    Optional[Baseline] ):
 
-  def zScore(percentile: Benchmark.Percentiles): Double = percentile match
-    case 80 => 0.842
-    case 85 => 1.036
-    case 90 => 1.282
-    case 95 => 1.645
-    case 96 => 1.751
-    case 97 => 1.881
-    case 98 => 2.054
-    case 99 => 2.326
+  // One-sided quantiles of Student's t-distribution, used for CI half-widths
+  // computed from `runs` independent measurement-run means with df = runs - 1.
+  // For df ≥ 30 the t-distribution is within ~4% of the standard normal, so we
+  // fall through to the normal quantiles. For an out-of-table df we round down
+  // to the nearest tabulated value, giving a slightly wider (more conservative)
+  // CI rather than a tighter one.
+  def tQuantile(percentile: Benchmark.Percentiles, df: Int): Double =
+    if df <= 4 then percentile match
+      case 80 => 0.941
+      case 85 => 1.190
+      case 90 => 1.533
+      case 95 => 2.132
+      case 96 => 2.333
+      case 97 => 2.601
+      case 98 => 2.999
+      case 99 => 3.747
+    else if df <= 9 then percentile match
+      case 80 => 0.883
+      case 85 => 1.100
+      case 90 => 1.383
+      case 95 => 1.833
+      case 96 => 1.973
+      case 97 => 2.167
+      case 98 => 2.398
+      case 99 => 2.821
+    else if df <= 19 then percentile match
+      case 80 => 0.861
+      case 85 => 1.066
+      case 90 => 1.328
+      case 95 => 1.729
+      case 96 => 1.850
+      case 97 => 2.012
+      case 98 => 2.205
+      case 99 => 2.539
+    else if df <= 29 then percentile match
+      case 80 => 0.854
+      case 85 => 1.055
+      case 90 => 1.311
+      case 95 => 1.699
+      case 96 => 1.815
+      case 97 => 1.967
+      case 98 => 2.150
+      case 99 => 2.462
+    else percentile match
+      case 80 => 0.842
+      case 85 => 1.036
+      case 90 => 1.282
+      case 95 => 1.645
+      case 96 => 1.751
+      case 97 => 1.881
+      case 98 => 2.054
+      case 99 => 2.326
 
-  def confidenceInterval: Long = (zScore(confidence)*sd/math.sqrt(iterations.toDouble)).toLong
+  def confidenceInterval: Long =
+    (tQuantile(confidence, runs - 1)*sd/math.sqrt(runs.toDouble)).toLong
+
   def throughput: Long = (1000000000.0/mean).toLong

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -116,7 +116,7 @@ class Report(using Environment)(using palette: TestPalette):
         if suite.absent then rest
         else Summary(Status.Suite, suite.option.get.id, 0, 0, 0, 0) :: rest
 
-      case Bench(testId, bench@Benchmark(_, _, _, _, _, _, _, _)) =>
+      case Bench(testId, bench@Benchmark(_, _, _, _, _, _, _, _, _)) =>
         List(Summary(Status.Bench, testId, 0, 0, 0, 0))
 
       case Test(testId, buffer) =>

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -116,7 +116,7 @@ class Report(using Environment)(using palette: TestPalette):
         if suite.absent then rest
         else Summary(Status.Suite, suite.option.get.id, 0, 0, 0, 0) :: rest
 
-      case Bench(testId, bench@Benchmark(_, _, _, _, _, _, _, _, _)) =>
+      case Bench(testId, bench@Benchmark(_, _, _, _, _, _, _, _, _, _, _)) =>
         List(Summary(Status.Bench, testId, 0, 0, 0, 0))
 
       case Test(testId, buffer) =>
@@ -569,6 +569,13 @@ class Report(using Environment)(using palette: TestPalette):
 
           Column(e"$Bold(Throughput)", textAlign = TextAlignment.Right): s =>
             e"${frequency(s.benchmark)}")
+        ::: (
+          if benchmarks.exists(_.benchmark.operationSize.present) then List(
+            Column(e"$Bold(Size)", textAlign = TextAlignment.Right):
+              (s: ReportLine.Bench) => s.benchmark.operationSize.lay(e"")(t => e"$t"),
+            Column(e"$Bold(Rate)", textAlign = TextAlignment.Right):
+              (s: ReportLine.Bench) => s.benchmark.operationRate.lay(e"")(t => e"$t"))
+          else Nil)
         ::: comparisons.map: comparison =>
           import Baseline.*
           val baseline = comparison.benchmark.baseline.vouch

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -582,8 +582,11 @@ class Report(using Environment)(using palette: TestPalette):
               def metric(value: Double) = if baseline.metric == Temporal then value else 1/value
 
               val value = baseline.compare match
-                case Compare.Min => metric(bench.benchmark.min)
-                case Compare.Max => metric(bench.benchmark.max)
+                case Compare.Min =>
+                  operations(metric(bench.benchmark.min), metric(comparison.benchmark.min))
+
+                case Compare.Max =>
+                  operations(metric(bench.benchmark.max), metric(comparison.benchmark.max))
 
                 case Compare.Mean =>
                   operations(metric(bench.benchmark.mean), metric(comparison.benchmark.mean))

--- a/lib/quantitative/src/core/quantitative.Prefixes.scala
+++ b/lib/quantitative/src/core/quantitative.Prefixes.scala
@@ -32,43 +32,18 @@
                                                                                                   */
 package quantitative
 
-import anticipation.*
-import gossamer.*
 import prepositional.*
-import proscenium.*
-import symbolism.*
 
-object internal2:
-  trait Protoquantity:
-    extension [units <: Measure](quantity: Quantity[units])
-      transparent inline def in[units2[power <: Nat] <: Units[power, ?]]: Any =
-        ${quantitative.internal.norm[units, units2]('quantity)}
+object Prefixes:
+  def apply[units](prefixes: List[Metric], minimum: Double = 1.0): Prefixes on units =
+    new Prefixes(prefixes, minimum):
+      type Plane = units
 
-      transparent inline def invert: Any = Quantity[Measure](1.0)/quantity
-
-
-      inline def normalize[units2 <: Measure](using normalizable: units is Normalizable to units2)
-      :   Quantity[units2] =
-
-        normalizable.normalize(quantity)
-
-
-      inline def sqrt(using root: Quantity[units] is Rootable[2]): root.Result = root.root(quantity)
-      inline def cbrt(using root: Quantity[units] is Rootable[3]): root.Result = root.root(quantity)
-      inline def units: Map[Text, Int] = ${quantitative.internal.collectUnits[units]}
-
-      inline def express(using Decimalizer): Text = compiletime.summonFrom:
-        case prefixes: (Prefixes `on` `units`) =>
-          val prefix = prefixes.select(quantity.value)
-          val scaled = quantity.value/math.pow(prefix.base.toDouble, prefix.exponent.toDouble)
-          t"$scaled ${prefix.symbol.tt}${Quantity.expressUnits(units)}"
-
-        case prefixes: Prefixes =>
-          val prefix = prefixes.select(quantity.value)
-          val scaled = quantity.value/math.pow(prefix.base.toDouble, prefix.exponent.toDouble)
-          t"$scaled ${prefix.symbol.tt}${Quantity.expressUnits(units)}"
-
-        case _ =>
-          t"${quantity.value} ${Quantity.expressUnits(units)}"
-
-      inline def dimension: Text = ${quantitative.internal.describe[units]}
+class Prefixes(val prefixes: List[Metric], val minimum: Double) extends Planar:
+  def select(value: Double): Metric =
+    if value == 0.0 then NoPrefix else
+      val abs = math.abs(value)
+      val candidates = (NoPrefix :: prefixes).sortBy(-_.exponent)
+      val chosen = candidates.find: prefix =>
+        abs/math.pow(prefix.base.toDouble, prefix.exponent.toDouble) >= minimum
+      chosen.getOrElse(candidates.last)

--- a/lib/quantitative/src/core/soundness_quantitative_core.scala
+++ b/lib/quantitative/src/core/soundness_quantitative_core.scala
@@ -38,9 +38,9 @@ export
       Designation, Dimension, Distance, Distributive, Exa, Exbi, Fahrenheit, Femto, Gibi, Giga,
       Heat, Hecto, Kelvins, Kibi, Kilo, Kilograms, Luminosity, Mass, Measure, Mebi, Mega, Metres,
       Metric, MetricUnit, Micro, Milli, Moles, Nano, NoPrefix, Normalizable, Pebi, Peta, Pico,
-      Principal, Quantifiable, Quantity, Quecto, Quetta, Rankine, Ratio, Redesignation, Ronna,
-      Ronto, Seconds, Tebi, Temperature, TemperatureScale, Tera, Time, Units, Yobi, Yocto, Yotta,
-      Zebi, Zepto, Zetta }
+      Prefixes, Principal, Quantifiable, Quantity, Quecto, Quetta, Rankine, Ratio, Redesignation,
+      Ronna, Ronto, Seconds, Tebi, Temperature, TemperatureScale, Tera, Time, Units, Yobi, Yocto,
+      Yotta, Zebi, Zepto, Zetta }
 
 package temperatureScales:
   export quantitative.temperatureScales.{celsius, fahrenheit, kelvin, rankine}

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -37,6 +37,8 @@ import soundness.*
 import language.strictEquality
 import language.experimental.into
 
+import autopsies.contrastExpectations
+
 given decimalizer: Decimalizer = Decimalizer(3)
 
 object Tests extends Suite(m"Quantitative Tests"):
@@ -391,3 +393,76 @@ object Tests extends Suite(m"Quantitative Tests"):
       test(m"Standard deviation of some values"):
         List(1*Second, 2*Second, 3*Second).std.vouch
       . assert(_ == (2/3.0).sqrt*Second)
+
+    suite(m"Prefix-scaled rendering"):
+      sealed trait Information extends Dimension
+      sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
+      val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+      given byteDesignation: Designation[Bytes[1]] = () => t"B"
+
+      test(m"Without `Prefixes` in scope, falls back to raw rendering"):
+        (5000*Byte).show
+      . assert(_ == t"5.00×10³ B")
+
+      test(m"SI prefix scales 5000 B to kB"):
+        given Prefixes on Bytes[1] = Prefixes(List(Kilo, Mega, Giga, Tera))
+        (5000*Byte).show
+      . assert(_ == t"5.00 kB")
+
+      test(m"SI prefix scales 5_000_000 B to MB"):
+        given Prefixes on Bytes[1] = Prefixes(List(Kilo, Mega, Giga, Tera))
+        (5_000_000*Byte).show
+      . assert(_ == t"5.00 MB")
+
+      test(m"SI prefix scales 1.5×10⁹ B to GB"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kilo, Mega, Giga, Tera))
+        (1_500_000_000.0*Byte).show
+      . assert(_ == t"1.50 GB")
+
+      test(m"Default floor 1.0 keeps 500 B unscaled"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kilo, Mega, Giga))
+        (500*Byte).show
+      . assert(_ == t"500 B")
+
+      test(m"Lower floor 0.1 scales 100 B to kB"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kilo, Mega, Giga), 0.1)
+        (100*Byte).show
+      . assert(_ == t"0.100 kB")
+
+      test(m"Binary prefix scales 5000 B to KiB"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kibi, Mebi, Gibi))
+        (5000*Byte).show
+      . assert(_ == t"4.88 KiB")
+
+      test(m"Binary prefix scales 5_000_000 B to MiB"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kibi, Mebi, Gibi))
+        (5_000_000*Byte).show
+      . assert(_ == t"4.77 MiB")
+
+      test(m"Binary prefix scales 4×10⁹ B to GiB"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kibi, Mebi, Gibi))
+        (4_000_000_000.0*Byte).show
+      . assert(_ == t"3.73 GiB")
+
+      test(m"Negative value uses absolute magnitude for prefix selection"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kilo, Mega, Giga))
+        (-5000*Byte).show
+      . assert(_ == t"-5.00 kB")
+
+      test(m"Zero uses no prefix"):
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Kilo, Mega))
+        (Quantity[Bytes[1]](0.0)).show
+      . assert(_ == t"0.00 B")
+
+      test(m"Compound dimension scales as a whole"):
+        given prefixes: (Prefixes on Bytes[1] & Seconds[-1]) = Prefixes(List(Kilo, Mega, Giga))
+        ((1_500_000_000.0*Byte)/Second).show
+      . assert(_ == t"1.50 GB·s¯¹")
+
+      test(m"Value below floor with no smaller prefix falls through to lowest"):
+        // 0.5 is below the floor of 1.0 and no sub-1 prefix is configured, so
+        // no candidate satisfies the floor; the algorithm falls through to the
+        // candidate with the smallest exponent (here `NoPrefix`).
+        given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Mega, Giga), 1.0)
+        (0.5*Byte).show
+      . assert(_ == t"0.500 B")

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -49,6 +49,7 @@ import jacinta.*
 import nomenclature.*
 import prepositional.*
 import probably.*
+import quantitative.*
 import rudiments.*
 import serpentine.*
 import spectacular.*
@@ -66,11 +67,12 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
 
   inline def apply[duration: Abstractable across Durations to Long, report]
     ( name: Message )
-    ( target:     duration,
-      iterations: Optional[Int]                   = Unset,
-      warmups:    Optional[Int]                   = Unset,
-      confidence: Optional[Benchmark.Percentiles] = Unset,
-      baseline:   Optional[Baseline]              = Unset )
+    ( target:        duration,
+      operationSize: Optional[OperationSize]         = Unset,
+      iterations:    Optional[Int]                   = Unset,
+      warmups:       Optional[Int]                   = Unset,
+      confidence:    Optional[Benchmark.Percentiles] = Unset,
+      baseline:      Optional[Baseline]              = Unset )
     ( body0: (References over Transport) ?=> Quotes ?=> Expr[Any] )
     ( using System, TemporaryDirectory, Stageable over Transport in Form )
     ( using runner:    Runner[report],
@@ -172,10 +174,14 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     val min = results.min.toDouble/sample
     val max = results.max.toDouble/sample
 
+    val operationSizeText: Optional[Text] = operationSize.let(_.sizeText)
+    val operationRateText: Optional[Text] = operationSize.let: os =>
+      os.rateText((total.toDouble/count)/1e9)
+
     val benchmark =
       Benchmark
         ( total, count, runs, total.toDouble/count, min, max, sd, confidence0.or(95),
-          baseline )
+          baseline, operationSizeText, operationRateText )
 
     inclusion.include(runner.report, testId, benchmark)
 

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -133,8 +133,8 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     val sum = results.map(_.toDouble/sample - sampleMean).bi.map(_*_).sum
     val variance = sample*sum/(iterations0.or(5) - 1)
     val sd = math.sqrt(variance)
-    val min = results.min.toDouble
-    val max = results.max.toDouble
+    val min = results.min.toDouble/sample
+    val max = results.max.toDouble/sample
 
     val benchmark =
       Benchmark(total, count, total.toDouble/count, min, max, sd, confidence0.or(95), baseline)

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -87,37 +87,51 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
       val iterations2: Int = iterations0.or(5)
       val target2: Expr[Long] = Expr(target.generic/iterations2)
       ' {
-          var count: Int = 1
-          var d: Long = 0
+          var count: Long = 1L
+          var d: Long = 0L
 
-          // Run 10 times initially
-          for j <- 0 until 10 do $body0
+          // Run 10 times initially as untimed warmup
+          var w = 0
+          while w < 10 do
+            $body0
+            w += 1
 
-          // Keep doubling the count until we get one run
+          // Keep doubling the count until we get one run exceeding target
           while d < $target2 do
-            count *= 2
+            if count >= (1L << 34) then
+              throw new RuntimeException(
+                "sedentary: benchmark body produced no measurable timing after 2^34 "
+                  + "iterations; suspected dead-code elimination")
+            count *= 2L
             val t0 = jl.System.nanoTime
-            for i <- 0 until count do $body0
+            var i = 0L
+            while i < count do { $body0; i += 1L }
             d = jl.System.nanoTime - t0
 
           var rate: Double = d.toDouble/count
-          count = ($target2/rate).toInt
+          count = math.max(1L, ($target2/rate).toLong)
           val result = new Array[Long](${Expr(iterations2)} + 1)
 
-          for i <- 0 until ${Expr(5)} do
+          var c = 0
+          while c < 5 do
             val t0 = jl.System.nanoTime
-            for j <- 0 until count do $body0
+            var j = 0L
+            while j < count do { $body0; j += 1L }
             val t1 = jl.System.nanoTime - t0
             rate = t1.toDouble/count
-            count = ($target2/rate).toInt
+            count = math.max(1L, ($target2/rate).toLong)
+            c += 1
 
           result(0) = count
 
-          for i <- 1 to ${Expr(iterations2)} do
+          var m = 1
+          while m <= ${Expr(iterations2)} do
             val t0 = jl.System.nanoTime
-            for j <- 0 until count do $body0
+            var j = 0L
+            while j < count do { $body0; j += 1L }
             val t1 = jl.System.nanoTime - t0
-            result(i) = t1
+            result(m) = t1
+            m += 1
 
           result.to(List)
         }

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -71,7 +71,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
       warmups:    Optional[Int]                   = Unset,
       confidence: Optional[Benchmark.Percentiles] = Unset,
       baseline:   Optional[Baseline]              = Unset )
-    ( body0: (References over Transport) ?=> Quotes ?=> Expr[Unit] )
+    ( body0: (References over Transport) ?=> Quotes ?=> Expr[Any] )
     ( using System, TemporaryDirectory, Stageable over Transport in Form )
     ( using runner:    Runner[report],
             inclusion: Inclusion[report, Benchmark],
@@ -87,13 +87,19 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
       val iterations2: Int = iterations0.or(5)
       val target2: Expr[Long] = Expr(target.generic/iterations2)
       ' {
+          // Blackhole sink. Each body result is written here via lazySet so that
+          // the JIT cannot prove the body's value is unused and elide it. The
+          // never-true read at the end forces the AtomicReference to escape,
+          // preventing escape-analysis from scalarising the writes away.
+          val sink = new java.util.concurrent.atomic.AtomicReference[Any](null)
+
           var count: Long = 1L
           var d: Long = 0L
 
           // Run 10 times initially as untimed warmup
           var w = 0
           while w < 10 do
-            $body0
+            sink.lazySet($body0)
             w += 1
 
           // Keep doubling the count until we get one run exceeding target
@@ -105,7 +111,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
             count *= 2L
             val t0 = jl.System.nanoTime
             var i = 0L
-            while i < count do { $body0; i += 1L }
+            while i < count do { sink.lazySet($body0); i += 1L }
             d = jl.System.nanoTime - t0
 
           var rate: Double = d.toDouble/count
@@ -116,7 +122,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
           while c < 5 do
             val t0 = jl.System.nanoTime
             var j = 0L
-            while j < count do { $body0; j += 1L }
+            while j < count do { sink.lazySet($body0); j += 1L }
             val t1 = jl.System.nanoTime - t0
             rate = t1.toDouble/count
             count = math.max(1L, ($target2/rate).toLong)
@@ -128,10 +134,12 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
           while m <= ${Expr(iterations2)} do
             val t0 = jl.System.nanoTime
             var j = 0L
-            while j < count do { $body0; j += 1L }
+            while j < count do { sink.lazySet($body0); j += 1L }
             val t1 = jl.System.nanoTime - t0
             result(m) = t1
             m += 1
+
+          if jl.System.nanoTime < 0L then jl.System.err.nn.println(sink.get)
 
           result.to(List)
         }

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -141,17 +141,20 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     val results = results0.drop(1)
     val total = results.sum
     val iterations0: Optional[Int] = iterations
-    val count = sample*iterations0.or(5)
+    val runs = iterations0.or(5)
+    val count = sample*runs
     val sampleMean0 = results.map(_.toDouble/sample).mean
     val sampleMean = sampleMean0.or(0.0)
     val sum = results.map(_.toDouble/sample - sampleMean).bi.map(_*_).sum
-    val variance = sample*sum/(iterations0.or(5) - 1)
+    val variance = sum/(runs - 1)
     val sd = math.sqrt(variance)
     val min = results.min.toDouble/sample
     val max = results.max.toDouble/sample
 
     val benchmark =
-      Benchmark(total, count, total.toDouble/count, min, max, sd, confidence0.or(95), baseline)
+      Benchmark
+        ( total, count, runs, total.toDouble/count, min, max, sd, confidence0.or(95),
+          baseline )
 
     inclusion.include(runner.report, testId, benchmark)
 

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -85,6 +85,8 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     val body: (References over Transport) ?=> Quotes ?=> Expr[List[Long]] =
       val iterations0: Optional[Int] = iterations
       val iterations2: Int = iterations0.or(5)
+      val warmups0: Optional[Int] = warmups
+      val warmups2: Int = warmups0.or(iterations2)
       val target2: Expr[Long] = Expr(target.generic/iterations2)
       ' {
           // Blackhole sink. Each body result is written here via lazySet so that
@@ -118,20 +120,31 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
           count = math.max(1L, ($target2/rate).toLong)
           val result = new Array[Long](${Expr(iterations2)} + 1)
 
+          // Warmup / calibration: run `warmups` full-count batches, adjusting
+          // count run-by-run so it converges on `target2`, then pick the final
+          // count from the median of all observed rates so a single GC-affected
+          // run can't bias the measurement count.
+          val rates = new Array[Double](${Expr(warmups2)})
           var c = 0
-          while c < 5 do
+          while c < ${Expr(warmups2)} do
             val t0 = jl.System.nanoTime
             var j = 0L
             while j < count do { sink.lazySet($body0); j += 1L }
             val t1 = jl.System.nanoTime - t0
-            rate = t1.toDouble/count
-            count = math.max(1L, ($target2/rate).toLong)
+            rates(c) = t1.toDouble/count
+            count = math.max(1L, ($target2/rates(c)).toLong)
             c += 1
+          java.util.Arrays.sort(rates)
+          count = math.max(1L, ($target2/rates(rates.length/2)).toLong)
 
           result(0) = count
 
           var m = 1
           while m <= ${Expr(iterations2)} do
+            // Trigger a young-gen collection between runs so a GC pause is less
+            // likely to land inside a measurement window. SerialGC honours this
+            // hint promptly.
+            jl.System.gc()
             val t0 = jl.System.nanoTime
             var j = 0L
             while j < count do { sink.lazySet($body0); j += 1L }

--- a/lib/sedentary/src/core/sedentary.OperationSize.scala
+++ b/lib/sedentary/src/core/sedentary.OperationSize.scala
@@ -30,85 +30,28 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package probably
+package sedentary
 
 import anticipation.*
+import gossamer.*
+import prepositional.*
+import quantitative.*
+import symbolism.*
 import vacuous.*
 
-object Benchmark:
-  given inclusion: Inclusion[Report, Benchmark]:
-    def include(report: Report, testId: TestId, benchmark: Benchmark): Report =
-      report.addBenchmark(testId, benchmark)
+case class OperationSize(sizeText: Text, rateText: Double => Text)
 
-  type Percentiles = 80 | 85 | 90 | 95 | 96 | 97 | 98 | 99
+object OperationSize:
+  // Captures the `Decimalizer` available where `Quantity` is used as an
+  // `operationSize` argument to `Bench.apply`. The captured closure renders
+  // both the per-operation size text and (later, given a measured mean time)
+  // the throughput rate text, so `Bench.apply` itself doesn't need to be
+  // generic over the unit or carry a `Decimalizer` of its own.
+  inline given conversion: [size <: Measure] => Decimalizer
+        =>  Conversion[Quantity[size], OperationSize] = quantity =>
 
-case class Benchmark
-  ( nanoseconds:    Long,
-    iterations:     Long,
-    runs:           Int,
-    mean:           Double,
-    min:            Double,
-    max:            Double,
-    sd:             Double,
-    confidence:     Benchmark.Percentiles,
-    baseline:       Optional[Baseline],
-    operationSize:  Optional[Text] = Unset,
-    operationRate:  Optional[Text] = Unset ):
-
-  // One-sided quantiles of Student's t-distribution, used for CI half-widths
-  // computed from `runs` independent measurement-run means with df = runs - 1.
-  // For df ≥ 30 the t-distribution is within ~4% of the standard normal, so we
-  // fall through to the normal quantiles. For an out-of-table df we round down
-  // to the nearest tabulated value, giving a slightly wider (more conservative)
-  // CI rather than a tighter one.
-  def tQuantile(percentile: Benchmark.Percentiles, df: Int): Double =
-    if df <= 4 then percentile match
-      case 80 => 0.941
-      case 85 => 1.190
-      case 90 => 1.533
-      case 95 => 2.132
-      case 96 => 2.333
-      case 97 => 2.601
-      case 98 => 2.999
-      case 99 => 3.747
-    else if df <= 9 then percentile match
-      case 80 => 0.883
-      case 85 => 1.100
-      case 90 => 1.383
-      case 95 => 1.833
-      case 96 => 1.973
-      case 97 => 2.167
-      case 98 => 2.398
-      case 99 => 2.821
-    else if df <= 19 then percentile match
-      case 80 => 0.861
-      case 85 => 1.066
-      case 90 => 1.328
-      case 95 => 1.729
-      case 96 => 1.850
-      case 97 => 2.012
-      case 98 => 2.205
-      case 99 => 2.539
-    else if df <= 29 then percentile match
-      case 80 => 0.854
-      case 85 => 1.055
-      case 90 => 1.311
-      case 95 => 1.699
-      case 96 => 1.815
-      case 97 => 1.967
-      case 98 => 2.150
-      case 99 => 2.462
-    else percentile match
-      case 80 => 0.842
-      case 85 => 1.036
-      case 90 => 1.282
-      case 95 => 1.645
-      case 96 => 1.751
-      case 97 => 1.881
-      case 98 => 2.054
-      case 99 => 2.326
-
-  def confidenceInterval: Long =
-    (tQuantile(confidence, runs - 1)*sd/math.sqrt(runs.toDouble)).toLong
-
-  def throughput: Long = (1000000000.0/mean).toLong
+    OperationSize
+      ( quantity.express,
+        meanSeconds =>
+          val rate: Quantity[size & Seconds[-1]] = Quantity(quantity.value/meanSeconds)
+          rate.express )

--- a/lib/sedentary/src/core/soundness_sedentary_core.scala
+++ b/lib/sedentary/src/core/soundness_sedentary_core.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export sedentary.{Bench, BenchError, BenchmarkDevice, LocalhostDevice, NetworkDevice}
+export sedentary.{Bench, BenchError, BenchmarkDevice, LocalhostDevice, NetworkDevice,
+    OperationSize}


### PR DESCRIPTION
Several methodology bugs in Sedentary's benchmark harness are corrected. The "vs baseline" column on benchmarks using `Compare.Min` or `Compare.Max` now actually compares against the baseline (previously it showed the current bench's own score with no comparison applied). The reported `σ` and confidence intervals now reflect between-run variability via a t-distribution on the genuinely independent run means, rather than treating every individual iteration as an independent sample (which understated the CI by roughly √sample). The body's return value is piped through a blackhole sink so HotSpot can't elide the work being measured, and the timing loop now errors out rather than hangs on a body that's been eliminated. The previously-unused `warmups` parameter is now honoured, the measurement count is picked from the median of warmup rates rather than the last one, and `System.gc()` is invoked between measurement runs. A new optional `operationSize` parameter — taking any `Quantity[U <: Measure]` like `100*Byte` or `1*Mebi(Byte)` — adds Size and Rate columns to the report, and a new `Prefixes` typeclass in quantitative makes `Quantity.show` pick an SI/IEC prefix based on the value's magnitude so rates print as `1.4 GB·s¯¹` rather than `1.4×10⁹ B·s¯¹`.

## Sedentary benchmark harness fixes

The benchmark harness had several methodology bugs that produced
plausible-looking but misleading numbers. After this PR you should
expect:

### `Compare.Min` and `Compare.Max` baseline columns now compare

Previously these branches returned the current bench's own min/max with
no `operations(...)` applied, so a bench like

```scala
bench(m"Parse with Merino")(target = 1*Second, baseline = Baseline(compare = Min)):
  '{ JsonAst.parse(jsonBytes) }
```

…displayed a column of fixed `~5×10⁻⁹` values regardless of the
comparison. The column now shows the speedup ratio (or arithmetic
difference, depending on `mode`) against the baseline entry.

### `σ` is the between-run stdev rather than √sample times larger

`σ` was computed as `√(sample × Σ(xᵢ/sample − x̄)² / (k−1))`, where
`xᵢ` is one measurement run's total time and `sample` is the per-run
iteration count. The `× sample` factor inflated `σ` by roughly √sample
(often 100–1000×). The fix removes the factor and reports the sample
stdev of the per-iteration averages across runs.

### Confidence interval is a t-CI on the actual independent observations

`confidenceInterval` was `z·sd/√(sample·k)`, treating every body
invocation as an independent draw. With only 5 measurement runs the
genuinely independent observations are the 5 run means, so the CI now
uses Student's t with `df = runs − 1` and divides by `√runs`.

### The harness can no longer hang on a JIT-eliminated body

The capacity-finding loop (`count *= 2`) used `Int`, so a body that
HotSpot could eliminate would quietly overflow `count` to a
non-positive value and loop forever at zero work. `count` is now `Long`
and the harness aborts with a `RuntimeException` if it exceeds 2³⁴
iterations without producing a measurable timing.

### Body return values are piped through a blackhole sink

The body parameter was `Expr[Unit]`, so values produced by quoted
bodies like `'{ parse(...) }` were silently discarded and HotSpot
escape analysis could elide allocations along the call path. The body
type is now `Expr[Any]` and each iteration's result is written to an
`AtomicReference` via `lazySet`, with a never-taken read at the end to
keep the sink reachable. Existing benchmarks compile unchanged because
`Expr[+T]` is covariant.

### `warmups` parameter is now honoured

`warmups: Optional[Int]` was declared on `Bench.apply` but ignored; the
calibration phase always ran 5 runs. It now controls the warmup-run
count and defaults to `iterations`. The measurement `count` is also
picked from the **median** of the warmup rates rather than the last
rate, so a single GC-affected warmup can no longer bias measurement
sizing.

### `System.gc()` is called between measurement runs

To reduce the chance of a GC pause landing inside one of the (default
five) measurement windows.

### New `operationSize` parameter for throughput display

Benchmarks can now declare what one operation represents:

```scala
bench(m"Parse JSON")(target = 1*Second, operationSize = 1024*Byte):
  '{ JsonAst.parse(jsonBytes) }
```

The report grows two columns — `Size` (the per-operation size) and
`Rate` (size divided by mean iteration time) — rendered via the
`Showable` typeclass that quantitative provides for any
`Quantity[U <: Measure]`. The new columns only appear in suites that
use the parameter.

The parameter takes any `Quantity[U]` via an implicit conversion to a
new `OperationSize` wrapper, so callers that don't use it are
unaffected. Callers that do use it must have a `Decimalizer` in scope
to determine decimal precision (the conversion is gated on it).

### `case class Benchmark` has new fields

`Benchmark` gains `runs: Int`, `operationSize: Optional[Text]`, and
`operationRate: Optional[Text]`. Pattern matches like
`Benchmark(_, _, _, _, _, _, _, _)` need three extra wildcards.

## Quantitative: `Prefixes` typeclass for prefix scaling

Quantitative had no mechanism for picking a prefix at render time
based on a value's magnitude — `(1.4e9*Byte/Second).show` printed
`1.4×10⁹ B·s¯¹` rather than `1.4 GB·s¯¹`. `Prefixes` is a new `Planar`
typeclass instance:

```scala
given (Prefixes on Bytes[1] & Seconds[-1]) =
  Prefixes(List(Kilo, Mega, Giga, Tera))

(1.4e9*Byte/Second).show  // "1.40 GB·s¯¹"
```

Constructor takes a list of `Metric` prefixes and a `minimum: Double`
floor (default `1.0`). The chosen prefix is the one producing the
smallest scaled value still ≥ `minimum`. `NoPrefix` is added to the
candidate set automatically. SI prefixes (`Kilo`, `Mega`, `Giga`, `Tera`)
and IEC binary prefixes (`Kibi`, `Mebi`, `Gibi`, `Tebi`) work
interchangeably. Without a `Prefixes` given in scope, `.express` /
`.show` keep their existing unscaled rendering.