### PR TITLE
Replace Teletype span map with dense + sparse style arrays

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -509,6 +509,7 @@ object enigmatic extends Library:
 object escapade extends Library:
   object core extends Component(anticipation.gfx, gossamer.core, turbulence.core, anticipation.url, iridescence.core)
   object test extends Tests(core, yossarian.core)
+  object bench extends Benchmarks(core, quantitative.units)
 
 object escritoire extends Library:
   object core extends Component(gossamer.core)

--- a/lib/escapade/src/bench/escapade.Benchmarks.scala
+++ b/lib/escapade/src/bench/escapade.Benchmarks.scala
@@ -1,0 +1,178 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package escapade
+
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
+import gossamer.*
+import hellenism.*, classloaders.threadContext
+import probably.*
+import proscenium.*
+import quantitative.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.system
+import vacuous.*
+
+object Benchmarks extends Suite(m"Escapade benchmarks"):
+  sealed trait Information extends Dimension
+  sealed trait Chars[Power <: Nat] extends Units[Power, Information]
+  val Char: MetricUnit[Chars[1]] = MetricUnit(1.0)
+
+  given charDesignation: Designation[Chars[1]] = () => t"ch"
+  given decimalizer:     Decimalizer            = Decimalizer(2)
+  given device:          BenchmarkDevice        = LocalhostDevice
+  given prefixes:        Prefixes               = Prefixes(List(Kilo, Mega, Giga, Tera))
+
+  // ─── inputs ───────────────────────────────────────────────────────────────
+
+  // A short styled fragment used for chained-append benchmarks.
+  lazy val fragment: Teletype = e" ${Bold}(quick) brown ${Italic}(fox) "
+
+  // A long styled paragraph (~1k chars) for slice/render benchmarks.
+  lazy val paragraph: Teletype =
+    val sb = new _root_.java.lang.StringBuilder
+    var i = 0
+    while i < 100 do
+      sb.append("the quick brown fox jumps over the lazy dog ")
+      i += 1
+    val plain: Text = sb.toString.nn.tt
+    e"${Bold}(prefix) $plain ${Italic}(suffix)"
+
+  // A "many small spans" Teletype: each word styled differently.
+  lazy val rainbow: Teletype =
+    val red    = Chroma(0xff5555)
+    val yellow = Chroma(0xffff55)
+    val green  = Chroma(0x55ff55)
+    val cyan   = Chroma(0x55ffff)
+    val blue   = Chroma(0x5555ff)
+    val magenta = Chroma(0xff55ff)
+    var built: Teletype = Teletype.empty
+    var i = 0
+    while i < 200 do
+      val color = (i % 6) match
+        case 0 => red
+        case 1 => yellow
+        case 2 => green
+        case 3 => cyan
+        case 4 => blue
+        case _ => magenta
+      built = built.append(e"${Fg(color)}(word$i) ")
+      i += 1
+    built
+
+  // ─── helpers used inside quoted bench bodies ──────────────────────────────
+
+  def appendN(base: Teletype, suffix: Teletype, n: Int): Teletype =
+    var acc = base
+    var i = 0
+    while i < n do
+      acc = acc.append(suffix)
+      i += 1
+    acc
+
+  def buildInterpolation(): Teletype =
+    e"${Bold}(${Fg(Chroma(0xffaa00))}(header)): the ${Italic}(quick) ${Bold}(brown)"
+    + e" ${Fg(Chroma(0x55aaff))}(fox) jumps over the ${Underline}(lazy ${Strike}(dog))"
+
+  def renderTrueColor(t: Teletype): Text =
+    t.render(termcapDefinitions.xtermTrueColor)
+
+  def renderXterm256(t: Teletype): Text =
+    t.render(termcapDefinitions.xterm256)
+
+  def render(input: Teletype): Text = renderTrueColor(input)
+
+  def run(): Unit =
+    val bench = Bench()
+
+    val fragSize  = fragment.plain.length*Char
+    val paraSize  = paragraph.plain.length*Char
+    val rainSize  = rainbow.plain.length*Char
+
+    // ─── concat ─────────────────────────────────────────────────────────────
+
+    suite(m"Concatenate 10 fragments"):
+      bench(m"append Teletype × 10")
+       (target = 1*Second, operationSize = fragSize*10, baseline = Baseline(compare = Min)):
+        '{ escapade.Benchmarks.appendN(escapade.Benchmarks.fragment, escapade.Benchmarks.fragment, 10) }
+
+    suite(m"Concatenate 100 fragments"):
+      bench(m"append Teletype × 100")
+       (target = 1*Second, operationSize = fragSize*100, baseline = Baseline(compare = Min)):
+        '{ escapade.Benchmarks.appendN(escapade.Benchmarks.fragment, escapade.Benchmarks.fragment, 100) }
+
+    suite(m"Concatenate 1000 fragments"):
+      bench(m"append Teletype × 1000")
+       (target = 1*Second, operationSize = fragSize*1000, baseline = Baseline(compare = Min)):
+        '{ escapade.Benchmarks.appendN(escapade.Benchmarks.fragment, escapade.Benchmarks.fragment, 1000) }
+
+    // ─── slice ──────────────────────────────────────────────────────────────
+
+    suite(m"Slice (dropChars / takeChars on long styled text)"):
+      bench(m"dropChars(100) on a ~4.5k-char paragraph")
+       (target = 1*Second, operationSize = paraSize, baseline = Baseline(compare = Min)):
+        '{ escapade.Benchmarks.paragraph.dropChars(100) }
+
+      bench(m"takeChars(half) on a ~4.5k-char paragraph")
+       (target = 1*Second, operationSize = paraSize):
+        '{ escapade.Benchmarks.paragraph.takeChars(escapade.Benchmarks.paragraph.plain.length/2) }
+
+      bench(m"dropChars(100) on a 200-coloured-words rainbow")
+       (target = 1*Second, operationSize = rainSize):
+        '{ escapade.Benchmarks.rainbow.dropChars(100) }
+
+    // ─── render ─────────────────────────────────────────────────────────────
+
+    suite(m"Render (Teletype → Text)"):
+      bench(m"render long paragraph (true colour)")
+       (target = 1*Second, operationSize = paraSize, baseline = Baseline(compare = Min)):
+        '{ escapade.Benchmarks.renderTrueColor(escapade.Benchmarks.paragraph) }
+
+      bench(m"render long paragraph (xterm-256)")(target = 1*Second, operationSize = paraSize):
+        '{ escapade.Benchmarks.renderXterm256(escapade.Benchmarks.paragraph) }
+
+      bench(m"render 200-coloured-words rainbow (true colour)")
+       (target = 1*Second, operationSize = rainSize):
+        '{ escapade.Benchmarks.renderTrueColor(escapade.Benchmarks.rainbow) }
+
+    // ─── build (interpolator) ───────────────────────────────────────────────
+
+    suite(m"Build (e\"...\" interpolation)"):
+      bench(m"interpolate a nested-markup expression")
+       (target = 1*Second, baseline = Baseline(compare = Min)):
+        '{ escapade.Benchmarks.buildInterpolation() }

--- a/lib/escapade/src/core/escapade.Ansi.scala
+++ b/lib/escapade/src/core/escapade.Ansi.scala
@@ -136,7 +136,7 @@ object Ansi extends Ansi2:
       val triggerLink = linkArmed
       while i < text.plain.length do
         plain.append(text.plain.s.charAt(i))
-        var combined = StyleWord.combine(outer, text.styles(i))
+        var combined = StyleWord.combine(outer, text.styleAt(i))
         if i == 0 && triggerLink then combined = combined | StyleWord.HyperlinkChange
         styles += combined
         i += 1
@@ -269,8 +269,13 @@ object Ansi extends Ansi2:
       val tail = if state.linkArmed then StyleWord.HyperlinkChange else 0L
       state.styles += tail
 
+      val plainText = state.plain.toString.tt
+      val denseStyles = IArray.unsafeFromArray(state.styles.toArray)
+      val (newStyles, newBoundaries) = Teletype.compressIfBeneficial(plainText, denseStyles)
+
       Teletype
-        ( state.plain.toString.tt,
-          IArray.unsafeFromArray(state.styles.toArray),
+        ( plainText,
+          newStyles,
           state.hyperlinks.toMap,
-          state.insertions.to(TreeMap) )
+          state.insertions.to(TreeMap),
+          newBoundaries )

--- a/lib/escapade/src/core/escapade.Ansi.scala
+++ b/lib/escapade/src/core/escapade.Ansi.scala
@@ -34,6 +34,8 @@ package escapade
 
 import language.experimental.pureFunctions
 
+import scala.collection.mutable as scm
+
 import anticipation.*
 import contextual.*
 import contingency.*
@@ -85,22 +87,61 @@ object Ansi extends Ansi2:
     case Markup(transform: Transform)
     case Escape(on: Text, off: Text)
 
-  case class Frame(bracket: Char, start: Int, transform: Transform)
+  case class Frame(bracket: Char)
 
+  class State:
+    val plain: StringBuilder = StringBuilder()
+    val styles: scm.ArrayBuffer[Long] = scm.ArrayBuffer.empty
+    val hyperlinks: scm.HashMap[Int, Text] = scm.HashMap.empty
+    val insertions: scm.TreeMap[Int, Text] = scm.TreeMap.empty
+    var last: Optional[Transform] = Unset
+    var stack: List[Frame] = Nil
+    var styleStack: List[TextStyle] = Nil
+    var currentStyle: TextStyle = TextStyle()
 
-  case class State
-    ( text:       Text                         = t"",
-      last:       Option[Transform]            = None,
-      stack:      List[Frame]                  = Nil,
-      spans:      TreeMap[CharSpan, Transform] = TreeMap(),
-      insertions: TreeMap[Int, Text]           = TreeMap() ):
+    def appendChar(char: Char): Unit =
+      plain.append(char)
+      styles += currentStyle.styleWord
 
-    def add(span: CharSpan, transform: Transform): State =
-      copy(spans = spans.updated(span, spans.get(span).fold(transform)(transform.andThen(_))))
+    def appendChars(text: Text): Unit =
+      var i = 0
+      val s = text.s
+      while i < s.length do
+        appendChar(s.charAt(i))
+        i += 1
 
-    def add(position: Int, esc: Escape): State =
-      val insertions2 = insertions.get(position).fold(t"\e"+esc.on)(_+t"\e"+esc.on)
-      copy(insertions = insertions.updated(position, insertions2))
+    def appendTeletype(text: Teletype): Unit =
+      val outer = currentStyle.styleWord
+      val n = plain.length
+      var i = 0
+      while i < text.plain.length do
+        plain.append(text.plain.s.charAt(i))
+        styles += StyleWord.combine(outer, text.styles(i))
+        i += 1
+
+      if text.hyperlinks.nonEmpty then
+        text.hyperlinks.each { (k, v) => hyperlinks(n + k) = v }
+
+      if text.insertions.nonEmpty then
+        text.insertions.each { (k, v) => insertions(n + k) = v }
+
+    def addInsertion(position: Int, content: Text): Unit =
+      insertions.updateWith(position):
+        case None             => Some(content)
+        case Some(existing)   => Some(existing+content)
+
+    def pushFrame(bracket: Char, transform: Transform): Unit =
+      stack = Frame(bracket) :: stack
+      styleStack = currentStyle :: styleStack
+      currentStyle = transform(currentStyle)
+
+    def popFrame(): Unit =
+      stack = stack.tail
+      currentStyle = styleStack.head
+      styleStack = styleStack.tail
+
+    def applyOnce(transform: Transform): Unit =
+      currentStyle = transform(currentStyle)
 
 
   object Interpolator extends contextual.Interpolator[Input, State, Teletype]:
@@ -109,55 +150,72 @@ object Ansi extends Ansi2:
     def initial: State = State()
 
     def parse(state: State, text: Text): State =
-      state.last.fold(closures(state, text)): transform =>
-        text.at(Prim) match
-          case Bsl => closures(state.copy(last = None), text.skip(1))
+      state.last match
+        case Unset =>
+          closures(state, text)
 
-          case '[' | '(' | '<' | '«' | '{' =>
-            val frame = Frame(complement(text.at(Prim).vouch), state.text.length, transform)
-            closures(state.copy(stack = frame :: state.stack, last = None), text.skip(1))
+        case transform: Transform =>
+          text.at(Prim) match
+            case Bsl =>
+              state.last = Unset
+              closures(state, text.skip(1))
 
-          case _ =>
-            val state2 = state.add(CharSpan(state.text.length, state.text.length), transform)
-            closures(state2.copy(last = None), text)
+            case '[' | '(' | '<' | '«' | '{' =>
+              state.pushFrame(complement(text.at(Prim).vouch), transform)
+              state.last = Unset
+              closures(state, text.skip(1))
+
+            case _ =>
+              state.applyOnce(transform)
+              state.last = Unset
+              closures(state, text)
 
     private def closures(state: State, text: Text): State =
-      try state.stack.headOption.fold(state.copy(text = state.text+TextEscapes.escape(text))):
-        frame =>
+      try state.stack match
+        case Nil =>
+          state.appendChars(TextEscapes.escape(text))
+          state
+
+        case frame :: _ =>
           safely(text.where(_ == frame.bracket)).let(_.n0) match
-            case Unset => state.copy(text = state.text+text)
+            case Unset =>
+              state.appendChars(text)
+              state
 
             case index: Int =>
-              val text2 = state.text+text.keep(index)
-              val span2: CharSpan = CharSpan(frame.start, state.text.length + index)
-              val state2: State = state.add(span2, frame.transform)
-              val state3: State = state2.copy(text = text2, last = None, stack = state.stack.tail)
-              closures(state3, text.skip(index + 1))
+              state.appendChars(text.keep(index))
+              state.popFrame()
+              state.last = Unset
+              closures(state, text.skip(index + 1))
 
       catch case error: EscapeError => error match
         case EscapeError(message) => throw InterpolationError(message)
 
     def insert(state: State, value: Input): State = value match
       case Input.TextInput(text) =>
-        val textSpans: TreeMap[CharSpan, Transform] = text.spans.map:
-          case (span, transform) => (span.shift(state.text.length): CharSpan) -> transform
-
-        val textInsertions: TreeMap[Int, Text] = text.insertions.map:
-          case (position, ins) => (position + state.text.length) -> ins
-
-        state.copy(text = state.text+text.plain, last = None, spans = state.spans ++ textSpans,
-            insertions = state.insertions ++ textInsertions)
+        state.appendTeletype(text)
+        state.last = Unset
+        state
 
       case Input.Markup(transform) =>
-        state.copy(last = Some(transform))
+        state.last = transform
+        state
 
-      case esc@Input.Escape(on, off) =>
-        state.copy(last = None).add(state.text.length, esc)
+      case Input.Escape(on, _) =>
+        state.last = Unset
+        state.addInsertion(state.plain.length, t"\e"+on)
+        state
 
     def skip(state: State): State = insert(state, Input.TextInput(Teletype.empty))
 
     def complete(state: State): Teletype =
-      if !state.stack.nil
+      if state.stack.nonEmpty
       then throw InterpolationError(m"the closing brace does not match an opening brace")
 
-      Teletype(state.text, state.spans, state.insertions)
+      state.styles += 0L
+
+      Teletype
+       ( state.plain.toString.tt,
+         IArray.unsafeFromArray(state.styles.toArray),
+         state.hyperlinks.toMap,
+         state.insertions.to(TreeMap) )

--- a/lib/escapade/src/core/escapade.Ansi.scala
+++ b/lib/escapade/src/core/escapade.Ansi.scala
@@ -82,7 +82,8 @@ object Ansi extends Ansi2:
   given conceal: Stylize[Conceal.type] = _ => Stylize(_.copy(conceal = true))
   given reverse: Stylize[Reverse.type] = _ => Stylize(_.copy(reverse = true))
   given faint: Stylize[Faint.type] = _ => Stylize(_.copy(faint = true))
-  given doubleUnderline: Stylize[DoubleUnderline.type] = _ => Stylize(_.copy(doubleUnderline = true))
+  given doubleUnderline: Stylize[DoubleUnderline.type] =
+    _ => Stylize(_.copy(doubleUnderline = true))
   given blinkSlow: Stylize[BlinkSlow.type] = _ => Stylize(_.copy(blinkSlow = true))
   given blinkFast: Stylize[BlinkFast.type] = _ => Stylize(_.copy(blinkFast = true))
   given overline: Stylize[Overline.type] = _ => Stylize(_.copy(overline = true))
@@ -269,7 +270,7 @@ object Ansi extends Ansi2:
       state.styles += tail
 
       Teletype
-       ( state.plain.toString.tt,
-         IArray.unsafeFromArray(state.styles.toArray),
-         state.hyperlinks.toMap,
-         state.insertions.to(TreeMap) )
+        ( state.plain.toString.tt,
+          IArray.unsafeFromArray(state.styles.toArray),
+          state.hyperlinks.toMap,
+          state.insertions.to(TreeMap) )

--- a/lib/escapade/src/core/escapade.Ansi.scala
+++ b/lib/escapade/src/core/escapade.Ansi.scala
@@ -81,6 +81,11 @@ object Ansi extends Ansi2:
   given strike: Stylize[Strike.type] = _ => Stylize(_.copy(strike = true))
   given conceal: Stylize[Conceal.type] = _ => Stylize(_.copy(conceal = true))
   given reverse: Stylize[Reverse.type] = _ => Stylize(_.copy(reverse = true))
+  given faint: Stylize[Faint.type] = _ => Stylize(_.copy(faint = true))
+  given doubleUnderline: Stylize[DoubleUnderline.type] = _ => Stylize(_.copy(doubleUnderline = true))
+  given blinkSlow: Stylize[BlinkSlow.type] = _ => Stylize(_.copy(blinkSlow = true))
+  given blinkFast: Stylize[BlinkFast.type] = _ => Stylize(_.copy(blinkFast = true))
+  given overline: Stylize[Overline.type] = _ => Stylize(_.copy(overline = true))
 
   given hyperlink: Substitution[Input, Hyperlink, "esc"] = h => Input.Hyperlink(h.url)
 

--- a/lib/escapade/src/core/escapade.Ansi.scala
+++ b/lib/escapade/src/core/escapade.Ansi.scala
@@ -82,26 +82,39 @@ object Ansi extends Ansi2:
   given conceal: Stylize[Conceal.type] = _ => Stylize(_.copy(conceal = true))
   given reverse: Stylize[Reverse.type] = _ => Stylize(_.copy(reverse = true))
 
+  given hyperlink: Substitution[Input, Hyperlink, "esc"] = h => Input.Hyperlink(h.url)
+
   enum Input:
     case TextInput(text: Teletype)
     case Markup(transform: Transform)
     case Escape(on: Text, off: Text)
+    case Hyperlink(url: Text)
 
-  case class Frame(bracket: Char)
+  enum Pending:
+    case Style(transform: Transform)
+    case Link(url: Text)
+
+  enum Frame(val bracket: Char):
+    case Style(override val bracket: Char) extends Frame(bracket)
+    case Link(override val bracket: Char)  extends Frame(bracket)
 
   class State:
     val plain: StringBuilder = StringBuilder()
     val styles: scm.ArrayBuffer[Long] = scm.ArrayBuffer.empty
     val hyperlinks: scm.HashMap[Int, Text] = scm.HashMap.empty
     val insertions: scm.TreeMap[Int, Text] = scm.TreeMap.empty
-    var last: Optional[Transform] = Unset
+    var last: Optional[Pending] = Unset
     var stack: List[Frame] = Nil
     var styleStack: List[TextStyle] = Nil
     var currentStyle: TextStyle = TextStyle()
+    var linkArmed: Boolean = false
 
     def appendChar(char: Char): Unit =
       plain.append(char)
-      styles += currentStyle.styleWord
+      val base = currentStyle.styleWord
+      val styled = if linkArmed then base | StyleWord.HyperlinkChange else base
+      styles += styled
+      linkArmed = false
 
     def appendChars(text: Text): Unit =
       var i = 0
@@ -114,10 +127,15 @@ object Ansi extends Ansi2:
       val outer = currentStyle.styleWord
       val n = plain.length
       var i = 0
+      val triggerLink = linkArmed
       while i < text.plain.length do
         plain.append(text.plain.s.charAt(i))
-        styles += StyleWord.combine(outer, text.styles(i))
+        var combined = StyleWord.combine(outer, text.styles(i))
+        if i == 0 && triggerLink then combined = combined | StyleWord.HyperlinkChange
+        styles += combined
         i += 1
+
+      if triggerLink then linkArmed = false
 
       if text.hyperlinks.nonEmpty then
         text.hyperlinks.each { (k, v) => hyperlinks(n + k) = v }
@@ -130,15 +148,26 @@ object Ansi extends Ansi2:
         case None             => Some(content)
         case Some(existing)   => Some(existing+content)
 
-    def pushFrame(bracket: Char, transform: Transform): Unit =
-      stack = Frame(bracket) :: stack
+    def pushStyleFrame(bracket: Char, transform: Transform): Unit =
+      stack = Frame.Style(bracket) :: stack
       styleStack = currentStyle :: styleStack
       currentStyle = transform(currentStyle)
 
+    def pushLinkFrame(bracket: Char, url: Text): Unit =
+      stack = Frame.Link(bracket) :: stack
+      hyperlinks(plain.length) = url
+      linkArmed = true
+
     def popFrame(): Unit =
-      stack = stack.tail
-      currentStyle = styleStack.head
-      styleStack = styleStack.tail
+      stack.head match
+        case _: Frame.Style =>
+          stack = stack.tail
+          currentStyle = styleStack.head
+          styleStack = styleStack.tail
+
+        case _: Frame.Link =>
+          stack = stack.tail
+          linkArmed = true
 
     def applyOnce(transform: Transform): Unit =
       currentStyle = transform(currentStyle)
@@ -154,19 +183,34 @@ object Ansi extends Ansi2:
         case Unset =>
           closures(state, text)
 
-        case transform: Transform =>
+        case Pending.Style(transform) =>
           text.at(Prim) match
             case Bsl =>
               state.last = Unset
               closures(state, text.skip(1))
 
             case '[' | '(' | '<' | '«' | '{' =>
-              state.pushFrame(complement(text.at(Prim).vouch), transform)
+              state.pushStyleFrame(complement(text.at(Prim).vouch), transform)
               state.last = Unset
               closures(state, text.skip(1))
 
             case _ =>
               state.applyOnce(transform)
+              state.last = Unset
+              closures(state, text)
+
+        case Pending.Link(url) =>
+          text.at(Prim) match
+            case Bsl =>
+              state.last = Unset
+              closures(state, text.skip(1))
+
+            case '[' | '(' | '<' | '«' | '{' =>
+              state.pushLinkFrame(complement(text.at(Prim).vouch), url)
+              state.last = Unset
+              closures(state, text.skip(1))
+
+            case _ =>
               state.last = Unset
               closures(state, text)
 
@@ -198,12 +242,16 @@ object Ansi extends Ansi2:
         state
 
       case Input.Markup(transform) =>
-        state.last = transform
+        state.last = Pending.Style(transform)
         state
 
       case Input.Escape(on, _) =>
         state.last = Unset
         state.addInsertion(state.plain.length, t"\e"+on)
+        state
+
+      case Input.Hyperlink(url) =>
+        state.last = Pending.Link(url)
         state
 
     def skip(state: State): State = insert(state, Input.TextInput(Teletype.empty))
@@ -212,7 +260,8 @@ object Ansi extends Ansi2:
       if state.stack.nonEmpty
       then throw InterpolationError(m"the closing brace does not match an opening brace")
 
-      state.styles += 0L
+      val tail = if state.linkArmed then StyleWord.HyperlinkChange else 0L
+      state.styles += tail
 
       Teletype
        ( state.plain.toString.tt,

--- a/lib/escapade/src/core/escapade.Hyperlink.scala
+++ b/lib/escapade/src/core/escapade.Hyperlink.scala
@@ -1,0 +1,37 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package escapade
+
+import anticipation.*
+
+case class Hyperlink(url: Text)

--- a/lib/escapade/src/core/escapade.StyleWord.scala
+++ b/lib/escapade/src/core/escapade.StyleWord.scala
@@ -1,0 +1,126 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package escapade
+
+import language.experimental.pureFunctions
+
+import anticipation.*
+import gossamer.*
+
+opaque type StyleWord = Long
+
+object StyleWord:
+  final val FgMask:           Long = 0x0000000000ffffffL
+  final val BgMask:           Long = 0x0000ffffff000000L
+  final val FgSet:            Long = 1L << 48
+  final val BgSet:            Long = 1L << 49
+  final val Bold:             Long = 1L << 50
+  final val Faint:            Long = 1L << 51
+  final val Italic:           Long = 1L << 52
+  final val Underline:        Long = 1L << 53
+  final val DoubleUnderline:  Long = 1L << 54
+  final val BlinkSlow:        Long = 1L << 55
+  final val BlinkFast:        Long = 1L << 56
+  final val Reverse:          Long = 1L << 57
+  final val Conceal:          Long = 1L << 58
+  final val Strike:           Long = 1L << 59
+  final val Overline:         Long = 1L << 60
+  final val HyperlinkChange:  Long = 1L << 61
+
+  final val FlagsMask: Long =
+    FgSet | BgSet | Bold | Faint | Italic | Underline | DoubleUnderline | BlinkSlow | BlinkFast
+    | Reverse | Conceal | Strike | Overline | HyperlinkChange
+
+  val Default: StyleWord = 0L
+
+  inline def apply(raw: Long): StyleWord = raw
+
+  def emitDiff(buffer: StringBuilder, prev: Long, next: Long, depth: ColorDepth): Unit =
+    val diff = prev^next
+
+    if (diff & (FgMask | FgSet)) != 0 then
+      if (next & FgSet) == 0 then buffer.add(t"\e[39m")
+      else buffer.add(Fg(Chroma((next & FgMask).toInt)).ansi(depth))
+
+    if (diff & (BgMask | BgSet)) != 0 then
+      if (next & BgSet) == 0 then buffer.add(t"\e[49m")
+      else buffer.add(Bg(Chroma(((next & BgMask) >>> 24).toInt)).ansi(depth))
+
+    val flagDiff = diff & (FlagsMask & ~(FgSet | BgSet | HyperlinkChange))
+    if flagDiff != 0 then
+      if (flagDiff & Bold)            != 0 then buffer.add(if (next & Bold)            != 0 then t"\e[1m"  else t"\e[22m")
+      if (flagDiff & Faint)           != 0 then buffer.add(if (next & Faint)           != 0 then t"\e[2m"  else t"\e[22m")
+      if (flagDiff & Italic)          != 0 then buffer.add(if (next & Italic)          != 0 then t"\e[3m"  else t"\e[23m")
+      if (flagDiff & Underline)       != 0 then buffer.add(if (next & Underline)       != 0 then t"\e[4m"  else t"\e[24m")
+      if (flagDiff & DoubleUnderline) != 0 then buffer.add(if (next & DoubleUnderline) != 0 then t"\e[21m" else t"\e[24m")
+      if (flagDiff & BlinkSlow)       != 0 then buffer.add(if (next & BlinkSlow)       != 0 then t"\e[5m"  else t"\e[25m")
+      if (flagDiff & BlinkFast)       != 0 then buffer.add(if (next & BlinkFast)       != 0 then t"\e[6m"  else t"\e[25m")
+      if (flagDiff & Reverse)         != 0 then buffer.add(if (next & Reverse)         != 0 then t"\e[7m"  else t"\e[27m")
+      if (flagDiff & Conceal)         != 0 then buffer.add(if (next & Conceal)         != 0 then t"\e[8m"  else t"\e[28m")
+      if (flagDiff & Strike)          != 0 then buffer.add(if (next & Strike)          != 0 then t"\e[9m"  else t"\e[29m")
+      if (flagDiff & Overline)        != 0 then buffer.add(if (next & Overline)        != 0 then t"\e[53m" else t"\e[55m")
+
+extension (style: StyleWord)
+  inline def raw: Long = style
+
+  inline def fgRgb: Int = (style & StyleWord.FgMask).toInt
+  inline def bgRgb: Int = ((style & StyleWord.BgMask) >>> 24).toInt
+  inline def hasFg: Boolean = (style & StyleWord.FgSet) != 0
+  inline def hasBg: Boolean = (style & StyleWord.BgSet) != 0
+
+  inline def isBold:            Boolean = (style & StyleWord.Bold)            != 0
+  inline def isFaint:           Boolean = (style & StyleWord.Faint)           != 0
+  inline def isItalic:          Boolean = (style & StyleWord.Italic)          != 0
+  inline def isUnderline:       Boolean = (style & StyleWord.Underline)       != 0
+  inline def isDoubleUnderline: Boolean = (style & StyleWord.DoubleUnderline) != 0
+  inline def isBlinkSlow:       Boolean = (style & StyleWord.BlinkSlow)       != 0
+  inline def isBlinkFast:       Boolean = (style & StyleWord.BlinkFast)       != 0
+  inline def isReverse:         Boolean = (style & StyleWord.Reverse)         != 0
+  inline def isConceal:         Boolean = (style & StyleWord.Conceal)         != 0
+  inline def isStrike:          Boolean = (style & StyleWord.Strike)          != 0
+  inline def isOverline:        Boolean = (style & StyleWord.Overline)        != 0
+  inline def hasHyperlinkChange: Boolean = (style & StyleWord.HyperlinkChange) != 0
+
+  inline def withFg(rgb: Int): StyleWord =
+    (style & ~StyleWord.FgMask) | (rgb.toLong & 0xffffffL) | StyleWord.FgSet
+
+  inline def withBg(rgb: Int): StyleWord =
+    (style & ~StyleWord.BgMask) | ((rgb.toLong & 0xffffffL) << 24) | StyleWord.BgSet
+
+  inline def clearFg: StyleWord = style & ~(StyleWord.FgMask | StyleWord.FgSet)
+  inline def clearBg: StyleWord = style & ~(StyleWord.BgMask | StyleWord.BgSet)
+
+  inline def withBit(bit: Long): StyleWord = style | bit
+  inline def withoutBit(bit: Long): StyleWord = style & ~bit
+
+  inline def applyTransform(mask: Long, bits: Long): StyleWord = (style & ~mask) | bits

--- a/lib/escapade/src/core/escapade.StyleWord.scala
+++ b/lib/escapade/src/core/escapade.StyleWord.scala
@@ -65,6 +65,19 @@ object StyleWord:
 
   inline def apply(raw: Long): StyleWord = raw
 
+  def combine(outer: Long, inner: Long): Long =
+    val flagsOnly = ~(FgMask | BgMask | FgSet | BgSet)
+    val combinedFlags = (outer | inner) & flagsOnly
+    val fgBits =
+      if (inner & FgSet) != 0 then inner & (FgMask | FgSet)
+      else if (outer & FgSet) != 0 then outer & (FgMask | FgSet)
+      else 0L
+    val bgBits =
+      if (inner & BgSet) != 0 then inner & (BgMask | BgSet)
+      else if (outer & BgSet) != 0 then outer & (BgMask | BgSet)
+      else 0L
+    combinedFlags | fgBits | bgBits
+
   def emitDiff(buffer: StringBuilder, prev: Long, next: Long, depth: ColorDepth): Unit =
     val diff = prev^next
 

--- a/lib/escapade/src/core/escapade.StyleWord.scala
+++ b/lib/escapade/src/core/escapade.StyleWord.scala
@@ -78,16 +78,16 @@ object StyleWord:
 
     val flagDiff = diff & (FlagsMask & ~(FgSet | BgSet | HyperlinkChange))
     if flagDiff != 0 then
-      if (flagDiff & Bold)            != 0 then buffer.add(if (next & Bold)            != 0 then t"\e[1m"  else t"\e[22m")
-      if (flagDiff & Faint)           != 0 then buffer.add(if (next & Faint)           != 0 then t"\e[2m"  else t"\e[22m")
       if (flagDiff & Italic)          != 0 then buffer.add(if (next & Italic)          != 0 then t"\e[3m"  else t"\e[23m")
+      if (flagDiff & Bold)            != 0 then buffer.add(if (next & Bold)            != 0 then t"\e[1m"  else t"\e[22m")
+      if (flagDiff & Reverse)         != 0 then buffer.add(if (next & Reverse)         != 0 then t"\e[7m"  else t"\e[27m")
       if (flagDiff & Underline)       != 0 then buffer.add(if (next & Underline)       != 0 then t"\e[4m"  else t"\e[24m")
+      if (flagDiff & Conceal)         != 0 then buffer.add(if (next & Conceal)         != 0 then t"\e[8m"  else t"\e[28m")
+      if (flagDiff & Strike)          != 0 then buffer.add(if (next & Strike)          != 0 then t"\e[9m"  else t"\e[29m")
+      if (flagDiff & Faint)           != 0 then buffer.add(if (next & Faint)           != 0 then t"\e[2m"  else t"\e[22m")
       if (flagDiff & DoubleUnderline) != 0 then buffer.add(if (next & DoubleUnderline) != 0 then t"\e[21m" else t"\e[24m")
       if (flagDiff & BlinkSlow)       != 0 then buffer.add(if (next & BlinkSlow)       != 0 then t"\e[5m"  else t"\e[25m")
       if (flagDiff & BlinkFast)       != 0 then buffer.add(if (next & BlinkFast)       != 0 then t"\e[6m"  else t"\e[25m")
-      if (flagDiff & Reverse)         != 0 then buffer.add(if (next & Reverse)         != 0 then t"\e[7m"  else t"\e[27m")
-      if (flagDiff & Conceal)         != 0 then buffer.add(if (next & Conceal)         != 0 then t"\e[8m"  else t"\e[28m")
-      if (flagDiff & Strike)          != 0 then buffer.add(if (next & Strike)          != 0 then t"\e[9m"  else t"\e[29m")
       if (flagDiff & Overline)        != 0 then buffer.add(if (next & Overline)        != 0 then t"\e[53m" else t"\e[55m")
 
 extension (style: StyleWord)

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -49,6 +49,11 @@ import turbulence.*
 import vacuous.*
 
 object Teletype:
+  // Heuristic: convert a dense styles array to sparse iff
+  //   runs * SparseThreshold <= plain.length
+  // (i.e., text is at least ~SparseThreshold× longer than the run count)
+  inline val SparseThreshold = 2
+
   given add: NotGiven[Teletype is Textual] => Teletype is Addable:
     type Operand = Teletype
     type Result = Teletype
@@ -91,7 +96,7 @@ object Teletype:
       array.indices.each: index =>
         array(index) = lambda(array(index))
 
-      Teletype(new String(array).tt, text.styles, text.hyperlinks, text.insertions)
+      Teletype(new String(array).tt, text.styles, text.hyperlinks, text.insertions, text.boundaries)
 
     def segment(text: Teletype, interval: Interval): Teletype =
       text.dropChars(interval.start.n0).takeChars(interval.size)
@@ -107,7 +112,9 @@ object Teletype:
     def show[value: Teletypeable](value: value) = value.teletype
     def builder(size: Optional[Int] = Unset): TeletypeBuilder = TeletypeBuilder(size)
 
-  val empty: Teletype = new Teletype(t"", IArray(0L), Map.empty, TreeMap.empty)
+  // Empty Teletype: dense form with no chars and one trailing entry.
+  val empty: Teletype =
+    new Teletype(t"", IArray(0L), Map.empty, TreeMap.empty, IArray.empty[Int])
 
   given joinable: Teletype is Joinable = _.fold(empty)(_ + _)
   given printable: Teletype is Printable = _.render(_)
@@ -131,21 +138,116 @@ object Teletype:
 
   given ordering: Ordering[Teletype] = Ordering.by(_.plain)
 
+  // Build a Teletype from text with no styling. Always sparse (1 run).
   def apply(text: Text): Teletype =
-    val styles = IArray.fill(text.length + 1)(0L)
-    new Teletype(text, styles, Map.empty, TreeMap.empty)
+    new Teletype(text, IArray(0L, 0L), Map.empty, TreeMap.empty, IArray(0))
 
+  // Build a Teletype with a single uniform style applied to all chars.
   def styled[value: Showable](value: value)(transform: Ansi.Transform): Teletype =
     val text: Text = value.show
     val styled: Long = transform(TextStyle()).styleWord
-    val styles = IArray.tabulate(text.length + 1) { i => if i < text.length then styled else 0L }
-    new Teletype(text, styles, Map.empty, TreeMap.empty)
+    if text.length == 0 then
+      new Teletype(t"", IArray(styled, 0L), Map.empty, TreeMap.empty, IArray(0))
+    else
+      new Teletype(text, IArray(styled, 0L), Map.empty, TreeMap.empty, IArray(0))
 
+  // Compress a dense styles array into sparse form if it would benefit.
+  // Returns the resulting (styles, boundaries) pair.
+  def compressIfBeneficial(plain: Text, denseStyles: IArray[Long])
+  :     (IArray[Long], IArray[Int]) =
+
+    val n = plain.length
+    if n == 0 then
+      (IArray(if denseStyles.length > 0 then denseStyles(0) else 0L), IArray.empty[Int])
+    else
+      // Count runs
+      var runs = 1
+      var i = 1
+      while i < n do
+        if denseStyles(i) != denseStyles(i - 1) then runs += 1
+        i += 1
+
+      if runs * SparseThreshold > n then
+        // Keep dense
+        (denseStyles, IArray.empty[Int])
+      else
+        // Convert to sparse
+        val newStyles = new Array[Long](runs + 1)
+        val newBoundaries = new Array[Int](runs)
+        newBoundaries(0) = 0
+        newStyles(0) = denseStyles(0)
+        var src = 1
+        var dst = 1
+        while src < n do
+          if denseStyles(src) != denseStyles(src - 1) then
+            newBoundaries(dst) = src
+            newStyles(dst) = denseStyles(src)
+            dst += 1
+          src += 1
+        newStyles(runs) = denseStyles(n)  // trailing
+        (IArray.unsafeFromArray(newStyles), IArray.unsafeFromArray(newBoundaries))
+
+
+// `boundaries` is the run-start array for the sparse form; empty for the dense form.
+// Dense:  styles.length == plain.length + 1; styles(i) is the style for char i (0 ≤ i < length)
+//         and styles(length) is the trailing style.
+// Sparse: styles.length == boundaries.length + 1; boundaries(i) is the start position of run i
+//         (boundaries(0) == 0). Run i covers [boundaries(i), nextStart) where nextStart is
+//         boundaries(i+1) or plain.length for the last run. styles(boundaries.length) is the
+//         trailing style.
 case class Teletype
   ( plain:      Text,
     styles:     IArray[Long],
     hyperlinks: Map[Int, Text]            = Map.empty,
-    insertions: TreeMap[Int, Text]        = TreeMap.empty ):
+    insertions: TreeMap[Int, Text]        = TreeMap.empty,
+    boundaries: IArray[Int]               = IArray.empty[Int] ):
+
+  inline def isDense: Boolean = boundaries.length == 0
+
+  // Style at position p (0 ≤ p ≤ plain.length, where length means "trailing").
+  def styleAt(p: Int): Long =
+    if isDense then styles(p)
+    else if p >= plain.length then styles(boundaries.length)
+    else
+      // Binary search for the run that contains p.
+      var lo = 0
+      var hi = boundaries.length
+      while lo + 1 < hi do
+        val mid = (lo + hi) >>> 1
+        if boundaries(mid) <= p then lo = mid else hi = mid
+      styles(lo)
+
+  // Trailing style (the style after the last char; used for joins).
+  inline def trailingStyle: Long =
+    if isDense then styles(plain.length) else styles(boundaries.length)
+
+  // Convert to sparse form's (styles, boundaries) representation.
+  // For an already-sparse Teletype this is O(1); for a dense one it's O(plain.length).
+  def asSparseArrays: (IArray[Long], IArray[Int]) =
+    if !isDense then (styles, boundaries)
+    else if plain.length == 0 then (IArray(if styles.length > 0 then styles(0) else 0L), IArray(0))
+    else
+      val n = plain.length
+      // Count runs
+      var runs = 1
+      var i = 1
+      while i < n do
+        if styles(i) != styles(i - 1) then runs += 1
+        i += 1
+      val newStyles = new Array[Long](runs + 1)
+      val newBoundaries = new Array[Int](runs)
+      newBoundaries(0) = 0
+      newStyles(0) = styles(0)
+      var src = 1
+      var dst = 1
+      while src < n do
+        if styles(src) != styles(src - 1) then
+          newBoundaries(dst) = src
+          newStyles(dst) = styles(src)
+          dst += 1
+        src += 1
+      newStyles(runs) = styles(n)
+      (IArray.unsafeFromArray(newStyles), IArray.unsafeFromArray(newBoundaries))
 
   def explicit: Text = render(termcapDefinitions.xtermTrueColor).bind: char =>
     if char.toInt == 27 then t"\\e" else char.show
@@ -153,41 +255,102 @@ case class Teletype
   @targetName("add")
   def append(text: Text): Teletype =
     if text.length == 0 then this else
-      val tail = styles(plain.length)
-      val newLength = plain.length + text.length + 1
-      val arr = new Array[Long](newLength)
-      var i = 0
-      while i < plain.length do
-        arr(i) = styles(i)
-        i += 1
-      while i < newLength do
-        arr(i) = tail
-        i += 1
-      Teletype(t"$plain$text", IArray.unsafeFromArray(arr), hyperlinks, insertions)
+      val tail = trailingStyle
+      val combinedPlain = t"$plain$text"
+      if isDense then
+        // Stay dense: extend styles array with the trailing style
+        val newLength = plain.length + text.length + 1
+        val arr = new Array[Long](newLength)
+        var i = 0
+        while i < plain.length do
+          arr(i) = styles(i)
+          i += 1
+        while i < newLength do
+          arr(i) = tail
+          i += 1
+        Teletype(combinedPlain, IArray.unsafeFromArray(arr), hyperlinks, insertions, IArray.empty[Int])
+      else
+        // Stay sparse: the new chars become part of the last run (since trailing style = last run style)
+        // unless the last run's style differs from the trailing style — but that can't happen because
+        // styles(boundaries.length-1) is the last run's style, and styles(boundaries.length) is trailing.
+        // They may differ. If so, we need a new run for the appended text.
+        val k = boundaries.length
+        val lastRunStyle = styles(k - 1)
+        if lastRunStyle == tail then
+          // Just extend plain; runs unchanged
+          Teletype(combinedPlain, styles, hyperlinks, insertions, boundaries)
+        else
+          // Add a new run starting at plain.length, with style = tail
+          val newBoundaries = new Array[Int](k + 1)
+          val newStyles = new Array[Long](k + 2)
+          System.arraycopy(boundaries.asInstanceOf[Array[Int]], 0, newBoundaries, 0, k)
+          newBoundaries(k) = plain.length
+          System.arraycopy(styles.asInstanceOf[Array[Long]], 0, newStyles, 0, k)
+          newStyles(k) = tail
+          newStyles(k + 1) = tail
+          Teletype
+            ( combinedPlain,
+              IArray.unsafeFromArray(newStyles),
+              hyperlinks,
+              insertions,
+              IArray.unsafeFromArray(newBoundaries) )
 
   @targetName("add2")
   def append(that: Teletype): Teletype =
     if that.plain.length == 0 then this else if plain.length == 0 then that else
-      val n = plain.length
-      val newLength = n + that.plain.length + 1
-      val arr = new Array[Long](newLength)
-      var i = 0
-      while i < n do
-        arr(i) = styles(i)
-        i += 1
-      var j = 0
-      while j < that.styles.length do
-        arr(i) = that.styles(j)
-        i += 1
-        j += 1
+      val aN = plain.length
+      val combinedPlain = plain+that.plain
 
       val shiftedLinks = if that.hyperlinks.isEmpty then hyperlinks else
-        hyperlinks ++ that.hyperlinks.map((k, v) => (k + n) -> v)
+        hyperlinks ++ that.hyperlinks.map((k, v) => (k + aN) -> v)
 
       val shiftedInsertions = if that.insertions.isEmpty then insertions else
-        insertions ++ that.insertions.map((k, v) => (k + n) -> v)
+        insertions ++ that.insertions.map((k, v) => (k + aN) -> v)
 
-      Teletype(plain+that.plain, IArray.unsafeFromArray(arr), shiftedLinks, shiftedInsertions)
+      if isDense && that.isDense then
+        // Both dense — direct array copy
+        val newLength = aN + that.plain.length + 1
+        val arr = new Array[Long](newLength)
+        System.arraycopy(styles.asInstanceOf[Array[Long]], 0, arr, 0, aN)
+        System.arraycopy
+          (that.styles.asInstanceOf[Array[Long]], 0, arr, aN, that.styles.length)
+        Teletype
+          ( combinedPlain,
+            IArray.unsafeFromArray(arr),
+            shiftedLinks,
+            shiftedInsertions,
+            IArray.empty[Int] )
+      else
+        // At least one is sparse — combine in sparse form.
+        val (aStyles, aBoundaries) = asSparseArrays
+        val (bStyles, bBoundaries) = that.asSparseArrays
+        val aK = aBoundaries.length
+        val bK = bBoundaries.length
+        val aLastStyle = aStyles(aK - 1)
+        val bFirstStyle = bStyles(0)
+        val merge = aLastStyle == bFirstStyle
+        val newK = aK + bK - (if merge then 1 else 0)
+        val newBoundariesArr = new Array[Int](newK)
+        val newStylesArr = new Array[Long](newK + 1)
+        // Copy A's runs
+        System.arraycopy(aBoundaries.asInstanceOf[Array[Int]], 0, newBoundariesArr, 0, aK)
+        System.arraycopy(aStyles.asInstanceOf[Array[Long]], 0, newStylesArr, 0, aK)
+        // Copy B's runs (shifted by aN), optionally skipping the first if merging
+        var bi = if merge then 1 else 0
+        var ni = aK
+        while bi < bK do
+          newBoundariesArr(ni) = bBoundaries(bi) + aN
+          newStylesArr(ni) = bStyles(bi)
+          bi += 1
+          ni += 1
+        // Trailing style is B's trailing
+        newStylesArr(newK) = bStyles(bK)
+        Teletype
+          ( combinedPlain,
+            IArray.unsafeFromArray(newStylesArr),
+            shiftedLinks,
+            shiftedInsertions,
+            IArray.unsafeFromArray(newBoundariesArr) )
 
   def dropChars(n: Int, dir: Bidi = Ltr): Teletype = dir match
     case Rtl => takeChars(plain.length - n)
@@ -195,15 +358,51 @@ case class Teletype
     case Ltr =>
       val keepLength = plain.length - n
       if keepLength <= 0 then Teletype.empty
+      else if n <= 0 then this
       else
-        val arr = new Array[Long](keepLength + 1)
-        var i = 0
-        while i <= keepLength do
-          arr(i) = styles(n + i)
-          i += 1
         val newHyperlinks = hyperlinks.collect { case (k, v) if k >= n => (k - n) -> v }
-        val newInsertions = insertions.collect { case (k, v) if k >= n => (k - n) -> v }.to(TreeMap)
-        Teletype(plain.skip(n), IArray.unsafeFromArray(arr), newHyperlinks, newInsertions)
+        val newInsertions =
+          insertions.collect { case (k, v) if k >= n => (k - n) -> v }.to(TreeMap)
+        if isDense then
+          val arr = new Array[Long](keepLength + 1)
+          var i = 0
+          while i <= keepLength do
+            arr(i) = styles(n + i)
+            i += 1
+          Teletype
+            ( plain.skip(n),
+              IArray.unsafeFromArray(arr),
+              newHyperlinks,
+              newInsertions,
+              IArray.empty[Int] )
+        else
+          // Sparse: find the run that contains position n; drop earlier runs;
+          // adjust the first kept run's boundary to 0; shift all other boundaries by -n.
+          val k = boundaries.length
+          // Binary search for the run at position n
+          var lo = 0
+          var hi = k
+          while lo + 1 < hi do
+            val mid = (lo + hi) >>> 1
+            if boundaries(mid) <= n then lo = mid else hi = mid
+          val firstRun = lo
+          val newK = k - firstRun
+          val newBoundariesArr = new Array[Int](newK)
+          val newStylesArr = new Array[Long](newK + 1)
+          newBoundariesArr(0) = 0
+          newStylesArr(0) = styles(firstRun)
+          var i = 1
+          while i < newK do
+            newBoundariesArr(i) = boundaries(firstRun + i) - n
+            newStylesArr(i) = styles(firstRun + i)
+            i += 1
+          newStylesArr(newK) = styles(k)  // trailing
+          Teletype
+            ( plain.skip(n),
+              IArray.unsafeFromArray(newStylesArr),
+              newHyperlinks,
+              newInsertions,
+              IArray.unsafeFromArray(newBoundariesArr) )
 
   def takeChars(n: Int, dir: Bidi = Ltr): Teletype = dir match
     case Rtl => dropChars(plain.length - n)
@@ -212,37 +411,97 @@ case class Teletype
       if n <= 0 then Teletype.empty
       else if n >= plain.length then this
       else
-        val arr = new Array[Long](n + 1)
-        var i = 0
-        while i < n do
-          arr(i) = styles(i)
-          i += 1
-        arr(n) = 0L
         val newHyperlinks = hyperlinks.filter((k, _) => k < n)
         val newInsertions = insertions.rangeUntil(n)
-        Teletype(plain.keep(n), IArray.unsafeFromArray(arr), newHyperlinks, newInsertions)
+        if isDense then
+          val arr = new Array[Long](n + 1)
+          var i = 0
+          while i < n do
+            arr(i) = styles(i)
+            i += 1
+          arr(n) = 0L
+          Teletype
+            ( plain.keep(n),
+              IArray.unsafeFromArray(arr),
+              newHyperlinks,
+              newInsertions,
+              IArray.empty[Int] )
+        else
+          // Sparse: keep runs whose start is < n; trim the last kept run; trailing style = 0L.
+          val k = boundaries.length
+          // Binary search for the last run whose start is < n
+          var lo = 0
+          var hi = k
+          while lo + 1 < hi do
+            val mid = (lo + hi) >>> 1
+            if boundaries(mid) < n then lo = mid else hi = mid
+          val lastRun = lo
+          val newK = lastRun + 1
+          val newBoundariesArr = new Array[Int](newK)
+          val newStylesArr = new Array[Long](newK + 1)
+          var i = 0
+          while i < newK do
+            newBoundariesArr(i) = boundaries(i)
+            newStylesArr(i) = styles(i)
+            i += 1
+          newStylesArr(newK) = 0L  // trailing reset
+          Teletype
+            ( plain.keep(n),
+              IArray.unsafeFromArray(newStylesArr),
+              newHyperlinks,
+              newInsertions,
+              IArray.unsafeFromArray(newBoundariesArr) )
 
   def render(termcap: Termcap): Text =
     if !termcap.ansi then plain else
       val buffer = StringBuilder()
       val depth = termcap.color
-      var prev: Long = 0L
-      var i = 0
       val n = plain.length
+      var prev: Long = 0L
 
-      while i < n do
-        val s = styles(i)
+      // Emit the chars in [from, to), interleaving any insertions that fall within.
+      inline def emitText(from: Int, to: Int): Unit =
+        if from < to then
+          val ins = insertions.range(from, to)
+          if ins.isEmpty then buffer.add(plain.s.substring(from, to).nn.tt)
+          else
+            var p = from
+            ins.each: (k, v) =>
+              if p < k then buffer.add(plain.s.substring(p, k).nn.tt)
+              buffer.add(v)
+              p = k
+            if p < to then buffer.add(plain.s.substring(p, to).nn.tt)
+
+      inline def emitRunStyle(s: Long, from: Int): Unit =
         if s != prev then StyleWord.emitDiff(buffer, prev, s, depth)
-        insertions.get(i).foreach { content => buffer.add(content) }
         if (s & StyleWord.HyperlinkChange) != 0 then
-          hyperlinks.get(i) match
+          hyperlinks.get(from) match
             case Some(url) => buffer.add(t"\e]8;;$url\e\\")
             case None      => buffer.add(t"\e]8;;\e\\")
-        buffer.add(plain.s.charAt(i))
         prev = s
-        i += 1
 
-      val tail = styles(n)
+      if isDense then
+        // Dense: walk per char but coalesce consecutive equal styles into one emit.
+        var i = 0
+        while i < n do
+          val s = styles(i)
+          var j = i + 1
+          while j < n && styles(j) == s do j += 1
+          emitRunStyle(s, i)
+          emitText(i, j)
+          i = j
+      else
+        val k = boundaries.length
+        var r = 0
+        while r < k do
+          val from = boundaries(r)
+          val to = if r + 1 < k then boundaries(r + 1) else n
+          val s = styles(r)
+          emitRunStyle(s, from)
+          emitText(from, to)
+          r += 1
+
+      val tail = trailingStyle
       if tail != prev then StyleWord.emitDiff(buffer, prev, tail, depth)
       if (tail & StyleWord.HyperlinkChange) != 0 then
         hyperlinks.get(n) match

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -91,7 +91,7 @@ object Teletype:
       array.indices.each: index =>
         array(index) = lambda(array(index))
 
-      Teletype(new String(array).tt, text.spans, text.insertions)
+      Teletype(new String(array).tt, text.styles, text.hyperlinks, text.insertions)
 
     def segment(text: Teletype, interval: Interval): Teletype =
       text.dropChars(interval.start.n0).takeChars(interval.size)
@@ -107,7 +107,7 @@ object Teletype:
     def show[value: Teletypeable](value: value) = value.teletype
     def builder(size: Optional[Int] = Unset): TeletypeBuilder = TeletypeBuilder(size)
 
-  val empty: Teletype = Teletype(t"")
+  val empty: Teletype = new Teletype(t"", IArray(0L), Map.empty, TreeMap.empty)
 
   given joinable: Teletype is Joinable = _.fold(empty)(_ + _)
   given printable: Teletype is Printable = _.render(_)
@@ -131,102 +131,119 @@ object Teletype:
 
   given ordering: Ordering[Teletype] = Ordering.by(_.plain)
 
-  def apply[value: Showable](value: value)(transform: Ansi.Transform): Teletype =
+  def apply(text: Text): Teletype =
+    val styles = IArray.fill(text.length + 1)(0L)
+    new Teletype(text, styles, Map.empty, TreeMap.empty)
+
+  def styled[value: Showable](value: value)(transform: Ansi.Transform): Teletype =
     val text: Text = value.show
-    Teletype(text, TreeMap(CharSpan(0, text.length) -> transform))
+    val styled: Long = transform(TextStyle()).styleWord
+    val styles = IArray.tabulate(text.length + 1) { i => if i < text.length then styled else 0L }
+    new Teletype(text, styles, Map.empty, TreeMap.empty)
 
 case class Teletype
   ( plain:      Text,
-    spans:      TreeMap[CharSpan, Ansi.Transform] = TreeMap(),
-    insertions: TreeMap[Int, Text]                = TreeMap() ):
+    styles:     IArray[Long],
+    hyperlinks: Map[Int, Text]            = Map.empty,
+    insertions: TreeMap[Int, Text]        = TreeMap.empty ):
 
   def explicit: Text = render(termcapDefinitions.xtermTrueColor).bind: char =>
     if char.toInt == 27 then t"\\e" else char.show
 
   @targetName("add")
-  def append(text: Text): Teletype = Teletype(t"$plain$text", spans)
+  def append(text: Text): Teletype =
+    if text.length == 0 then this else
+      val tail = styles(plain.length)
+      val newLength = plain.length + text.length + 1
+      val arr = new Array[Long](newLength)
+      var i = 0
+      while i < plain.length do
+        arr(i) = styles(i)
+        i += 1
+      while i < newLength do
+        arr(i) = tail
+        i += 1
+      Teletype(t"$plain$text", IArray.unsafeFromArray(arr), hyperlinks, insertions)
 
   @targetName("add2")
-  def append(text: Teletype): Teletype =
-    val newSpans: TreeMap[CharSpan, Ansi.Transform] = text.spans.map:
-      case (span, transform) => (span.shift(plain.length): CharSpan) -> transform
+  def append(that: Teletype): Teletype =
+    if that.plain.length == 0 then this else if plain.length == 0 then that else
+      val n = plain.length
+      val newLength = n + that.plain.length + 1
+      val arr = new Array[Long](newLength)
+      var i = 0
+      while i < n do
+        arr(i) = styles(i)
+        i += 1
+      var j = 0
+      while j < that.styles.length do
+        arr(i) = that.styles(j)
+        i += 1
+        j += 1
 
-    Teletype(plain+text.plain, spans ++ newSpans)
+      val shiftedLinks = if that.hyperlinks.isEmpty then hyperlinks else
+        hyperlinks ++ that.hyperlinks.map((k, v) => (k + n) -> v)
+
+      val shiftedInsertions = if that.insertions.isEmpty then insertions else
+        insertions ++ that.insertions.map((k, v) => (k + n) -> v)
+
+      Teletype(plain+that.plain, IArray.unsafeFromArray(arr), shiftedLinks, shiftedInsertions)
 
   def dropChars(n: Int, dir: Bidi = Ltr): Teletype = dir match
     case Rtl => takeChars(plain.length - n)
 
     case Ltr =>
-      val newSpans: TreeMap[CharSpan, Ansi.Transform] =
-        spans.map:
-          case (span, transform) =>
-            val charSpan: CharSpan = span.trimLeft(n)
-            charSpan -> transform
-
-        . view.filterKeys { k => k.nil || k != CharSpan.Nowhere }.to(TreeMap)
-
-      Teletype(plain.skip(n), newSpans)
+      val keepLength = plain.length - n
+      if keepLength <= 0 then Teletype.empty
+      else
+        val arr = new Array[Long](keepLength + 1)
+        var i = 0
+        while i <= keepLength do
+          arr(i) = styles(n + i)
+          i += 1
+        val newHyperlinks = hyperlinks.collect { case (k, v) if k >= n => (k - n) -> v }
+        val newInsertions = insertions.collect { case (k, v) if k >= n => (k - n) -> v }.to(TreeMap)
+        Teletype(plain.skip(n), IArray.unsafeFromArray(arr), newHyperlinks, newInsertions)
 
   def takeChars(n: Int, dir: Bidi = Ltr): Teletype = dir match
     case Rtl => dropChars(plain.length - n)
 
     case Ltr =>
-      val newSpans: TreeMap[CharSpan, Ansi.Transform] =
-        spans.map:
-          case (span, tf) =>
-            val charSpan: CharSpan = span.takeLeft(n)
-            charSpan -> tf
-
-        . view.filterKeys { k => k.nil || k != CharSpan.Nowhere }.to(TreeMap)
-
-      Teletype(plain.keep(n), newSpans)
+      if n <= 0 then Teletype.empty
+      else if n >= plain.length then this
+      else
+        val arr = new Array[Long](n + 1)
+        var i = 0
+        while i < n do
+          arr(i) = styles(i)
+          i += 1
+        arr(n) = 0L
+        val newHyperlinks = hyperlinks.filter((k, _) => k < n)
+        val newInsertions = insertions.rangeUntil(n)
+        Teletype(plain.keep(n), IArray.unsafeFromArray(arr), newHyperlinks, newInsertions)
 
   def render(termcap: Termcap): Text =
-    val buffer = StringBuilder()
+    if !termcap.ansi then plain else
+      val buffer = StringBuilder()
+      val depth = termcap.color
+      var prev: Long = 0L
+      var i = 0
+      val n = plain.length
 
+      while i < n do
+        val s = styles(i)
+        if s != prev then StyleWord.emitDiff(buffer, prev, s, depth)
+        insertions.get(i).foreach { content => buffer.add(content) }
+        if (s & StyleWord.HyperlinkChange) != 0 then
+          hyperlinks.get(i) match
+            case Some(url) => buffer.add(t"\e]8;;$url\e\\")
+            case None      => buffer.add(t"\e]8;;\e\\")
+        buffer.add(plain.s.charAt(i))
+        prev = s
+        i += 1
 
-    @tailrec
-    def recur
-      ( spans:      TreeMap[CharSpan, Ansi.Transform],
-        position:        Int                               = 0,
-        style:      TextStyle                         = TextStyle(),
-        stack:      List[(CharSpan, TextStyle)]       = Nil,
-        insertions: TreeMap[Int, Text]                = TreeMap() )
-    :   Text =
+      val tail = styles(n)
+      if tail != prev then StyleWord.emitDiff(buffer, prev, tail, depth)
+      insertions.rangeFrom(n).values.each { content => buffer.add(content) }
 
-      inline def addSpan(): Text =
-        val newInsertions = addText(position, spans.head(0).start, insertions)
-        val newStyle = spans.head(1)(style)
-        style.addChanges(buffer, newStyle, termcap.color)
-        val newStack = if spans.head(0).nil then stack else (spans.head(0) -> style) :: stack
-        recur(spans.tail, spans.head(0).start, newStyle, newStack, newInsertions)
-
-      @tailrec
-      def addText(from: Int, to: Int, insertions: TreeMap[Int, Text]): TreeMap[Int, Text] =
-        if insertions.nil then
-          buffer.add(plain.segment(from.max(0).z thru to.max(0).u))
-          insertions
-        else if insertions.head(0) < to then
-          buffer.add(plain.segment(position.z thru insertions.head(0).u))
-          buffer.add(insertions.head(1))
-          addText(insertions.head(0), to, insertions.tail)
-        else
-          buffer.add(plain.segment(from.z thru to.u))
-          insertions
-
-      if stack.nil then
-        if spans.nil then
-          val remaining = addText(position, plain.length, insertions)
-          remaining.values.each(buffer.add(_))
-          buffer.text
-        else addSpan()
-      else
-        if spans.nil || stack.head(0).end <= spans.head(0).start then
-          val newInsertions = addText(position, stack.head(0).end, insertions)
-          val newStyle = stack.head(1)
-          style.addChanges(buffer, newStyle, termcap.color)
-          recur(spans, stack.head(0).end, newStyle, stack.tail, newInsertions)
-        else addSpan()
-
-
-    if termcap.ansi then recur(spans, insertions = insertions) else plain
+      buffer.text

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -244,6 +244,10 @@ case class Teletype
 
       val tail = styles(n)
       if tail != prev then StyleWord.emitDiff(buffer, prev, tail, depth)
+      if (tail & StyleWord.HyperlinkChange) != 0 then
+        hyperlinks.get(n) match
+          case Some(url) => buffer.add(t"\e]8;;$url\e\\")
+          case None      => buffer.add(t"\e]8;;\e\\")
       insertions.rangeFrom(n).values.each { content => buffer.add(content) }
 
       buffer.text

--- a/lib/escapade/src/core/escapade.TeletypeBuilder.scala
+++ b/lib/escapade/src/core/escapade.TeletypeBuilder.scala
@@ -61,7 +61,7 @@ class TeletypeBuilder(size: Optional[Int] = Unset) extends Builder[Teletype]:
     builder.append(text.plain.s)
     var i = 0
     while i < text.plain.length do
-      styles += text.styles(i)
+      styles += text.styleAt(i)
       i += 1
 
     text.hyperlinks.each { (k, v) => hyperlinks(k + offset) = v }
@@ -77,8 +77,13 @@ class TeletypeBuilder(size: Optional[Int] = Unset) extends Builder[Teletype]:
   protected def result(): Teletype =
     styles += 0L
 
+    val plainText = builder.toString.tt
+    val denseStyles = IArray.unsafeFromArray(styles.toArray)
+    val (newStyles, newBoundaries) = Teletype.compressIfBeneficial(plainText, denseStyles)
+
     Teletype
-      ( builder.toString.tt,
-        IArray.unsafeFromArray(styles.toArray),
+      ( plainText,
+        newStyles,
         hyperlinks.toMap,
-        insertions.to(TreeMap) )
+        insertions.to(TreeMap),
+        newBoundaries )

--- a/lib/escapade/src/core/escapade.TeletypeBuilder.scala
+++ b/lib/escapade/src/core/escapade.TeletypeBuilder.scala
@@ -42,8 +42,9 @@ import vacuous.*
 
 class TeletypeBuilder(size: Optional[Int] = Unset) extends Builder[Teletype]:
   private val builder: StringBuilder = StringBuilder()
-  private val spans: scm.Map[CharSpan, Ansi.Transform] = scm.HashMap()
-  private val insertions: scm.Map[Int, Text] = scm.HashMap()
+  private val styles: scm.ArrayBuffer[Long] = scm.ArrayBuffer.empty
+  private val hyperlinks: scm.HashMap[Int, Text] = scm.HashMap()
+  private val insertions: scm.TreeMap[Int, Text] = scm.TreeMap()
 
   private var offset: Int = 0
 
@@ -52,18 +53,32 @@ class TeletypeBuilder(size: Optional[Int] = Unset) extends Builder[Teletype]:
   protected def wipe(): Unit =
     offset = 0
     builder.clear()
-    spans.clear()
+    styles.clear()
+    hyperlinks.clear()
     insertions.clear()
 
   protected def put(text: Teletype): Unit =
     builder.append(text.plain.s)
-    text.spans.each { (span, value) => spans(span.shift(offset)) = value }
-    text.insertions.each { (position, value) => insertions(position + offset) = value }
-    offset += text.length
+    var i = 0
+    while i < text.plain.length do
+      styles += text.styles(i)
+      i += 1
+
+    text.hyperlinks.each { (k, v) => hyperlinks(k + offset) = v }
+    text.insertions.each { (k, v) => insertions(k + offset) = v }
+
+    offset += text.plain.length
 
   protected def putChar(char: Char): Unit =
     builder.append(char)
+    styles += 0L
     offset += 1
 
   protected def result(): Teletype =
-    Teletype(builder.toString.tt, spans.to(TreeMap), insertions.to(TreeMap))
+    styles += 0L
+
+    Teletype
+     ( builder.toString.tt,
+       IArray.unsafeFromArray(styles.toArray),
+       hyperlinks.toMap,
+       insertions.to(TreeMap) )

--- a/lib/escapade/src/core/escapade.TeletypeBuilder.scala
+++ b/lib/escapade/src/core/escapade.TeletypeBuilder.scala
@@ -78,7 +78,7 @@ class TeletypeBuilder(size: Optional[Int] = Unset) extends Builder[Teletype]:
     styles += 0L
 
     Teletype
-     ( builder.toString.tt,
-       IArray.unsafeFromArray(styles.toArray),
-       hyperlinks.toMap,
-       insertions.to(TreeMap) )
+      ( builder.toString.tt,
+        IArray.unsafeFromArray(styles.toArray),
+        hyperlinks.toMap,
+        insertions.to(TreeMap) )

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -77,7 +77,8 @@ object Teletypeable:
         do
           val fg = graphical.pixel(graphic, x, y)
           val bg = graphical.pixel(graphic, x, y + 1)
-          append(Teletype(t"▀", TreeMap((CharSpan(0, 1), { _ => TextStyle(fg, bg) }))))
+          val styled = TextStyle(fg, bg).styleWord
+          append(Teletype(t"▀", IArray(styled, 0L)))
 
         append(e"\n")
 
@@ -164,10 +165,10 @@ object Teletypeable:
     e"$className${Fg(Chroma(0x808080))}( ⌗ )$methodName"
 
   given double: (decimalizer: Decimalizer) => Double is Teletypeable = double =>
-    Teletype(decimalizer.decimalize(double))(_.copy(fg = Chroma(0xffd600)))
+    Teletype.styled(decimalizer.decimalize(double))(_.copy(fg = Chroma(0xffd600)))
 
   given throwable: Throwable is Teletypeable = throwable =>
-    Teletype[String]
+    Teletype.styled[String]
       (throwable.getClass.getName.nn.show.cut(t".").last.s)(_.copy(fg = Chroma(0xdc133b)))
 
 trait Teletypeable extends Typeclass:

--- a/lib/escapade/src/core/escapade.TextStyle.scala
+++ b/lib/escapade/src/core/escapade.TextStyle.scala
@@ -35,8 +35,6 @@ package escapade
 import language.experimental.pureFunctions
 
 import anticipation.*
-import gossamer.*
-import spectacular.*
 import vacuous.*
 
 object TextStyle:

--- a/lib/escapade/src/core/escapade.TextStyle.scala
+++ b/lib/escapade/src/core/escapade.TextStyle.scala
@@ -43,23 +43,33 @@ object TextStyle:
   val esc: Char = 27.toChar
 
 case class TextStyle
-  ( fg:        Optional[Chroma] = Unset,
-    bg:        Optional[Chroma] = Unset,
-    italic:    Boolean          = false,
-    bold:      Boolean          = false,
-    reverse:   Boolean          = false,
-    underline: Boolean          = false,
-    conceal:   Boolean          = false,
-    strike:    Boolean          = false ):
+  ( fg:              Optional[Chroma] = Unset,
+    bg:              Optional[Chroma] = Unset,
+    italic:          Boolean          = false,
+    bold:            Boolean          = false,
+    reverse:         Boolean          = false,
+    underline:       Boolean          = false,
+    conceal:         Boolean          = false,
+    strike:          Boolean          = false,
+    faint:           Boolean          = false,
+    doubleUnderline: Boolean          = false,
+    blinkSlow:       Boolean          = false,
+    blinkFast:       Boolean          = false,
+    overline:        Boolean          = false ):
 
   def styleWord: Long =
     var s: Long = 0L
-    if italic    then s |= StyleWord.Italic
-    if bold      then s |= StyleWord.Bold
-    if reverse   then s |= StyleWord.Reverse
-    if underline then s |= StyleWord.Underline
-    if conceal   then s |= StyleWord.Conceal
-    if strike    then s |= StyleWord.Strike
+    if italic          then s |= StyleWord.Italic
+    if bold            then s |= StyleWord.Bold
+    if reverse         then s |= StyleWord.Reverse
+    if underline       then s |= StyleWord.Underline
+    if conceal         then s |= StyleWord.Conceal
+    if strike          then s |= StyleWord.Strike
+    if faint           then s |= StyleWord.Faint
+    if doubleUnderline then s |= StyleWord.DoubleUnderline
+    if blinkSlow       then s |= StyleWord.BlinkSlow
+    if blinkFast       then s |= StyleWord.BlinkFast
+    if overline        then s |= StyleWord.Overline
     fg.let: c =>
       s = s | (c.underlying.toLong & 0xffffffL) | StyleWord.FgSet
     bg.let: c =>

--- a/lib/escapade/src/core/escapade.TextStyle.scala
+++ b/lib/escapade/src/core/escapade.TextStyle.scala
@@ -52,22 +52,19 @@ case class TextStyle
     conceal:   Boolean          = false,
     strike:    Boolean          = false ):
 
-  import escapes.*
-  import TextStyle.esc
-
-  private def italicEsc: Text = if italic then styles.Italic.on else styles.Italic.off
-  private def boldEsc: Text = if bold then styles.Bold.on else styles.Bold.off
-  private def reverseEsc: Text = if reverse then styles.Reverse.on else styles.Reverse.off
-  private def underlineEsc: Text = if underline then styles.Underline.on else styles.Underline.off
-  private def concealEsc: Text = if conceal then styles.Conceal.on else styles.Conceal.off
-  private def strikeEsc: Text = if strike then styles.Strike.on else styles.Strike.off
+  def styleWord: Long =
+    var s: Long = 0L
+    if italic    then s |= StyleWord.Italic
+    if bold      then s |= StyleWord.Bold
+    if reverse   then s |= StyleWord.Reverse
+    if underline then s |= StyleWord.Underline
+    if conceal   then s |= StyleWord.Conceal
+    if strike    then s |= StyleWord.Strike
+    fg.let: c =>
+      s = s | (c.underlying.toLong & 0xffffffL) | StyleWord.FgSet
+    bg.let: c =>
+      s = s | ((c.underlying.toLong & 0xffffffL) << 24) | StyleWord.BgSet
+    s
 
   def addChanges(buffer: StringBuilder, next: TextStyle, colorDepth: ColorDepth): Unit =
-    if fg != next.fg then buffer.add(next.fg.let(Fg(_).ansi(colorDepth)).or(t"$esc[39m"))
-    if bg != next.bg then buffer.add(next.bg.let(Bg(_).ansi(colorDepth)).or(t"$esc[49m"))
-    if italic != next.italic then buffer.add(t"${esc}${next.italicEsc}")
-    if bold != next.bold then buffer.add(t"${esc}${next.boldEsc}")
-    if reverse != next.reverse then buffer.add(t"${esc}${next.reverseEsc}")
-    if underline != next.underline then buffer.add(t"${esc}${next.underlineEsc}")
-    if conceal != next.conceal then buffer.add(t"${esc}${next.concealEsc}")
-    if strike != next.strike then buffer.add(t"${esc}${next.strikeEsc}")
+    StyleWord.emitDiff(buffer, styleWord, next.styleWord, colorDepth)

--- a/lib/escapade/src/core/escapade_core.scala
+++ b/lib/escapade/src/core/escapade_core.scala
@@ -48,6 +48,11 @@ object Underline
 object Strike
 object Reverse
 object Conceal
+object Faint
+object DoubleUnderline
+object BlinkSlow
+object BlinkFast
+object Overline
 
 extension (inline context: StringContext)
   transparent inline def e(inline parts: Any*): Teletype =

--- a/lib/escapade/src/test/escapade_test.scala
+++ b/lib/escapade/src/test/escapade_test.scala
@@ -978,10 +978,12 @@ object Tests extends Suite(m"Escapade tests"):
         (rendered.contains(t"[1m"), rendered.contains(t"[3m"))
       . assert(_ == ((true, true)))
 
-      test(m"styles array length is plain.length + 1"):
-        e"$Bold(abc)def".styles.length
-      . assert(_ == 7)
+      test(m"styleAt returns the correct style for each position"):
+        val tt = e"$Bold(abc)def"
+        val boldBit = StyleWord.Bold
+        ((tt.styleAt(0) & boldBit) != 0, (tt.styleAt(3) & boldBit) != 0)
+      . assert(_ == ((true, false)))
 
-      test(m"append concatenates styles arrays correctly"):
-        e"$Bold(hi)".append(e"$Italic(yo)").styles.length
-      . assert(_ == 5)
+      test(m"trailing style is reset after styled prefix"):
+        e"$Bold(abc)def".trailingStyle
+      . assert(_ == 0L)

--- a/lib/escapade/src/test/escapade_test.scala
+++ b/lib/escapade/src/test/escapade_test.scala
@@ -900,3 +900,88 @@ object Tests extends Suite(m"Escapade tests"):
       test(m"styled text is at the expected screen position"):
         emulate(e"abc$Bold(def)ghi").buffer.char(3.z, 0.z)
       . assert(_ == 'd')
+
+    // ─── hyperlinks (OSC 8) ────────────────────────────────────────────────
+
+    suite(m"Hyperlinks"):
+      test(m"open emits OSC 8 with url"):
+        emit(e"${Hyperlink(t"https://example.com")}[here]").contains(t"\e]8;;https://example.com\e\\")
+      . assert(_ == true)
+
+      test(m"close emits empty OSC 8 after the link"):
+        emit(e"${Hyperlink(t"https://example.com")}[here] more").contains(t"\e]8;;\e\\")
+      . assert(_ == true)
+
+      test(m"link contents are the visible text"):
+        e"a${Hyperlink(t"https://x.test")}[middle]b".plain
+      . assert(_ == t"amiddleb")
+
+      test(m"link at end of text emits trailing close"):
+        emit(e"${Hyperlink(t"https://x.test")}[link]").contains(t"]8;;")
+      . assert(_ == true)
+
+      test(m"basic termcap drops hyperlink escapes"):
+        plainRender(e"${Hyperlink(t"https://x.test")}[link]")
+      . assert(_ == t"link")
+
+      test(m"styled text inside a hyperlink keeps both"):
+        val rendered = emit(e"${Hyperlink(t"https://x.test")}[$Bold(bold link)]")
+        (rendered.contains(t"\e[1m"), rendered.contains(t"\e]8;;https://x.test"))
+      . assert(_ == ((true, true)))
+
+      test(m"hyperlink stored at correct position"):
+        e"hi ${Hyperlink(t"https://x.test")}[click]".hyperlinks(3)
+      . assert(_ == t"https://x.test")
+
+    // ─── new style attributes ─────────────────────────────────────────────
+
+    suite(m"New style attributes"):
+      test(m"faint emits SGR 2"):
+        emit(e"$Faint(x)").contains(t"\e[2m")
+      . assert(_ == true)
+
+      test(m"double-underline emits SGR 21"):
+        emit(e"$DoubleUnderline(x)").contains(t"\e[21m")
+      . assert(_ == true)
+
+      test(m"blink-slow emits SGR 5"):
+        emit(e"$BlinkSlow(x)").contains(t"\e[5m")
+      . assert(_ == true)
+
+      test(m"blink-fast emits SGR 6"):
+        emit(e"$BlinkFast(x)").contains(t"\e[6m")
+      . assert(_ == true)
+
+      test(m"overline emits SGR 53"):
+        emit(e"$Overline(x)").contains(t"\e[53m")
+      . assert(_ == true)
+
+      test(m"overline closes with SGR 55"):
+        emit(e"a$Overline(b)c").contains(t"\e[55m")
+      . assert(_ == true)
+
+      test(m"plain renderer drops new attributes"):
+        plainRender(e"a$Faint($Overline(b))c")
+      . assert(_ == t"abc")
+
+    // ─── concat invariant ──────────────────────────────────────────────────
+
+    suite(m"Concat invariant"):
+      test(m"plain text of append matches concatenation of plains"):
+        val a = e"$Bold(hello) "
+        val b = e"$Italic(world)"
+        a.append(b).plain
+      . assert(_ == t"hello world")
+
+      test(m"appended teletype carries both left and right SGR codes"):
+        val rendered = emit(e"$Bold(hello) ".append(e"$Italic(world)"))
+        (rendered.contains(t"[1m"), rendered.contains(t"[3m"))
+      . assert(_ == ((true, true)))
+
+      test(m"styles array length is plain.length + 1"):
+        e"$Bold(abc)def".styles.length
+      . assert(_ == 7)
+
+      test(m"append concatenates styles arrays correctly"):
+        e"$Bold(hi)".append(e"$Italic(yo)").styles.length
+      . assert(_ == 5)


### PR DESCRIPTION
Replaces the `TreeMap[CharSpan, Ansi.Transform]` style representation in Escapade's `Teletype` with a packed-Long `StyleWord` per character (or per run, when run-length compression is beneficial), introduces hyperlink support via OSC 8, adds five new style attributes (faint, double-underline, slow/fast blink, overline), and lands a benchmark suite for measuring the hot paths. Most operations (append, slice, render) are now significantly faster on lightly or moderately styled text and dramatically faster on densely styled "many small spans" content; chained `append` of small fragments is the one regression and should now be done via `TeletypeBuilder`.

## Highlights for users

- A new `Hyperlink(url)` markup is recognised by the `e"..."` interpolator:

  ```scala
  e"click ${Hyperlink(t"https://example.com")}[here] now"
  ```

  renders to OSC 8 sequences in capable terminals and to plain text under `termcapDefinitions.basic`.

- Five new attribute markers — `Faint`, `DoubleUnderline`, `BlinkSlow`, `BlinkFast`, `Overline` — are usable wherever `Bold`, `Italic`, etc. already work:

  ```scala
  e"a $Overline(banner) z"
  e"$Faint(secondary)"
  ```

- The opaque `StyleWord` type packs foreground/background colour and all style flags into a single 64-bit value, with a free `emitDiff` helper for comparing two style words and emitting only the SGR codes that differ.

- A new `escapade.bench` Mill module (`mill escapade.bench.run`) exercises concatenation, slicing, rendering, and interpolation across representative inputs.

- The `Teletype` case class now exposes both representations as fields: `styles: IArray[Long]` plus a `boundaries: IArray[Int]` (empty for the dense form). A heuristic at construction time chooses the form based on the run density.

## Migration notes

- The old curried `Teletype.apply[T: Showable](value)(transform)` factory has been renamed to `Teletype.styled` to disambiguate it from the single-argument `Teletype(text)`. Direct callers (rare; mostly the built-in `Teletypeable` instances for `Double` and `Throwable`) should switch to `Teletype.styled(...)`.

- `Teletype.spans` is gone. If you were inspecting the internal span map, read `styles` and `boundaries` instead, or use `styleAt(position)` to look up the style at a specific character.

- For loops that build a `Teletype` by repeatedly calling `.append(...)` on an accumulator, prefer `TeletypeBuilder` — chained `append` is now O(L²) where the old TreeMap merge was sub-linear in the run count.