### PR TITLE
Add frontier.every[X] for enumerating every implicit in scope

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -238,7 +238,7 @@ object test extends ScalaModule:
     //eucalyptus.test,
     exegesis.test,
     exoskeleton.test,
-    //frontier.test,
+    frontier.test,
     fulminate.test,
     galilei.test,
     gastronomy.test,

--- a/lib/frontier/src/core/frontier.Every.scala
+++ b/lib/frontier/src/core/frontier.Every.scala
@@ -32,74 +32,7 @@
                                                                                                   */
 package frontier
 
-import soundness.{every as _, *}
+object Every:
+  transparent inline given default: [value] => Every[value] = ${internal.every[value]}
 
-object Tests extends Suite(m"Frontier Tests"):
-  trait Plug
-
-  object NoPlugs:
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  object OnePlug:
-    given p1: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  object TwoPlugs:
-    given p1: Plug = new Plug {}
-    given p2: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  def run(): Unit =
-    test(m"every[X] returns empty Every when no givens in scope"):
-      NoPlugs.explicit
-    . assert(_ == 0)
-
-    test(m"summon[Every[X]] returns empty Every when no givens in scope"):
-      NoPlugs.viaSummon
-    . assert(_ == 0)
-
-    test(m"every[X] with one given in scope returns 1"):
-      OnePlug.explicit
-    . assert(_ == 1)
-
-    test(m"summon[Every[X]] with one given in scope returns 1"):
-      OnePlug.viaSummon
-    . assert(_ == 1)
-
-    test(m"every[X] collects two ambiguous givens in scope"):
-      TwoPlugs.explicit
-    . assert(_ == 2)
-
-    test(m"summon[Every[X]] collects two ambiguous givens in scope"):
-      TwoPlugs.viaSummon
-    . assert(_ == 2)
-
-    test(m"every[X] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"summon[Every[X]] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = summon[Every[Widget]]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"every[X] compiles cleanly when no givens are in scope"):
-      demilitarize:
-        trait Widget
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
+case class Every[+value](values: List[value])

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -172,3 +172,46 @@ object internal:
 
           . render(termcapDefinitions.xterm256)
           . s
+
+  def every[value: Type]: Macro[Every[value]] =
+    import quotes.reflect.*
+
+    given context: core.Contexts.Context = quotes.absolve match
+      case quotes: runtime.impl.QuotesImpl => quotes.ctx
+
+    def underlying(tree: Term): Symbol = tree match
+      case Inlined(_, _, body) => underlying(body)
+      case Apply(fun, _)       => underlying(fun)
+      case TypeApply(fun, _)   => underlying(fun)
+      case Block(_, expr)      => underlying(expr)
+      case Typed(expr, _)      => underlying(expr)
+      case other               => other.symbol
+
+    def collect(ignored: List[Symbol], acc: List[Expr[value]]): List[Expr[value]] =
+      Implicits.searchIgnoring(TypeRepr.of[value])(ignored*).absolve match
+        case success: ImplicitSearchSuccess =>
+          val symbol = underlying(success.tree)
+          if symbol.isNoSymbol || ignored.contains(symbol) then acc.reverse
+          else collect(symbol :: ignored, success.tree.asExprOf[value] :: acc)
+
+        case failure: ImplicitSearchFailure =>
+          failure.asInstanceOf[ast.tpd.Tree].tpe match
+            case ambiguous: typer.Implicits.AmbiguousImplicits =>
+              val tree1 = ambiguous.alt1.tree.asInstanceOf[Term]
+              val tree2 = ambiguous.alt2.tree.asInstanceOf[Term]
+              val symbol1 = underlying(tree1)
+              val symbol2 = underlying(tree2)
+
+              val unusable =
+                symbol1.isNoSymbol || symbol2.isNoSymbol
+                || ignored.contains(symbol1) || ignored.contains(symbol2)
+
+              if unusable then acc.reverse
+              else collect
+                ( symbol1 :: symbol2 :: ignored,
+                  tree2.asExprOf[value] :: tree1.asExprOf[value] :: acc )
+
+            case _ =>
+              acc.reverse
+
+    '{Every[value](${Expr.ofList(collect(Nil, Nil))})}

--- a/lib/frontier/src/core/frontier_core.scala
+++ b/lib/frontier/src/core/frontier_core.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package frontier
 
+inline def every[value]: Every[value] = ${internal.every[value]}
+
 package context:
   transparent inline given explainMissingContext: [any] => any = internal.explanation[any]

--- a/lib/frontier/src/core/soundness_frontier_core.scala
+++ b/lib/frontier/src/core/soundness_frontier_core.scala
@@ -34,5 +34,7 @@ package soundness
 
 import frontier.*
 
+export frontier.Every
+
 package context:
   transparent inline given explainMissingContext: [any] => any = internal.explanation[any]


### PR DESCRIPTION
Frontier now provides `frontier.every[X]` and a matching `Every[X]` type
for collecting every contextual instance of a given type visible at the
call site, rather than the single unambiguous best match returned by
`summon`. The macro walks dotc's `Implicits.searchIgnoring` repeatedly
and extracts both alternatives from any `AmbiguousImplicits` result, so
sibling givens that would normally cause a summon ambiguity are all
collected.

### `frontier.every[X]` and `Every[X]`

Two surface forms — an explicit method and an auto-summoned given on
`Every`'s companion:

```scala
import frontier.*

trait Plugin
given p1: Plugin = new Plugin {}
given p2: Plugin = new Plugin {}

val all:  Every[Plugin] = every[Plugin]   // explicit
val also: Every[Plugin] = summon          // via Every.default
all.values.length                          // 2
```

The macro repeatedly invokes `Implicits.searchIgnoring`, adding each
resolved symbol (and both alternatives of any `AmbiguousImplicits`
failure) to the ignore set, until search is exhausted.

`every` is exposed at the `frontier.*` package level but is **not**
re-exported into the `soundness.*` umbrella, because `anamnesis`
already provides a top-level `every[entity]`. Under the umbrella
import, qualify as `frontier.every[X]` or `import frontier.every`
directly.