### PR TITLE
Show benchmark confidence interval as percent of mean

### DIFF
--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -545,8 +545,12 @@ class Report(using Environment)(using palette: TestPalette):
         benchmarks.filter(!_.benchmark.baseline.absent).to(List)
 
       def confInt(b: Benchmark): Teletype =
-        if b.confidenceInterval == 0 then e""
-        else e"${Fg(palette.accented)}(±)${showTime(b.confidenceInterval)}"
+        if b.confidenceInterval == 0 || b.mean == 0.0 then e""
+        else
+          val basisPoints = (b.confidenceInterval*10000.0/b.mean).toLong
+          val sig = (basisPoints/100).show
+          val frac = (basisPoints%100).show.pad(2, Rtl, '0')
+          e"${Fg(palette.accented)}(±)${Fg(palette.foreground)}($sig.$frac)%"
 
       def frequency(benchmark: Benchmark): Teletype =
         if benchmark.throughput == 0 then e""


### PR DESCRIPTION
Probably's benchmark report now shows the confidence interval as a percentage of the mean, rather than as an absolute time, making the column directly comparable across benchmarks running at very different scales.

The Confidence column in benchmark output previously formatted the t-distribution CI half-width in time units (µs/ms/s). It now formats as a percentage of the mean, so a row reads e.g. `P95 ±2.34%` instead of `P95 ±523.000 µs`. The underlying `Benchmark.confidenceInterval` value is unchanged; only the rendering in `Report` is affected.