### PR TITLE
Enable Scala 3 optimizer (-opt / -opt-inline)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,7 +71,9 @@ object settings:
     "-language:experimental.saferExceptions",
     "-language:experimental.strictEqualityPatternMatching",
     "-language:experimental.subCases",
-    "-language:experimental.multiSpreads"
+    "-language:experimental.multiSpreads",
+    "-opt",
+    "-opt-inline:**"
   )
 
   val scalaOptionsCC = scalaOptions ++ Seq("-Ycc-new")

--- a/build.mill
+++ b/build.mill
@@ -1,6 +1,6 @@
 //| mill-version: 1.1.5
 //| mill-jvm-version: temurin:25
-//| mill-jvm-opts: ["-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
+//| mill-jvm-opts: ["-Xmx12g", "-XX:NonProfiledCodeHeapSize=250m", "-XX:ReservedCodeCacheSize=500m"]
 
                                                                                                   /*
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓


### PR DESCRIPTION
Soundness now compiles with the Scala 3.8.3 optimizer enabled, applying both non-inlining simplifications and cross-package inlining. Library bytecode is more aggressively optimized; XML parsing through Xylophone is 10–50% faster on the bundled benchmarks, HTML parsing through Honeycomb is ~2–5% faster, and JSON parsing through Merino and ANSI handling through Escapade are within run-to-run noise. The optimizer's inlining phase requires more JVM heap, so the Mill server now starts with `-Xmx12g`.

### Scala 3 optimizer enabled

The build now passes `-opt` and `-opt-inline:**` to the Scala compiler:

```scala
// build.mill — settings.scalaOptions
"-opt",
"-opt-inline:**"
```

These flags propagate through `BaseScalaModule.scalacOptions` and the `Component` / `Tests` / `Benchmarks` traits, so every module in the build benefits from intra- and cross-package inlining.

Throughput deltas measured on the bundled benchmarks (single runs, macOS / temurin 25):

| Module    | Effect on its own benchmarks                          |
|-----------|-------------------------------------------------------|
| Xylophone | **+10% to +50%** across all five parse examples       |
| Honeycomb | +2% to +5% on small/typical pages, neutral on large   |
| Merino    | within ±3% — run-to-run noise                         |
| Escapade  | small regressions on `Teletype` concatenation         |

The Mill server JVM now requests `-Xmx12g` because the inlining phase exhausts the default heap on Soundness's ~280-module DAG.

> **Note on benchmark-body inlining.** Sedentary compiles benchmark bodies in a forked JVM via Superlunary using only `-experimental`, so the optimizer currently affects *library* bytecode only — not the benchmark bodies that call into it. To get the full optimizer effect at measurement time, `sedentary.Bench` would need to compile bodies with `-opt` too.