### PR TITLE
Finish Mandible's stack analysis and linearize singleton calls

### DIFF
--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -1375,9 +1375,14 @@ object Bytecode:
         case Wide() | Breakpoint | Impdep1 | Impdep2 => stack
         case _: Opcode => stack
 
-case class Bytecode(sourceFile: Optional[Text], instructions: List[Bytecode.Instruction]):
+case class Bytecode
+  ( sourceFile:   Optional[Text],
+    instructions: List[Bytecode.Instruction],
+    maxStack:     Int,
+    maxLocals:    Int ):
+
   def embed(codepoint: Codepoint): Bytecode =
     val instructions2 = instructions.map: instruction =>
       instruction.copy(line = instruction.line.let(_ + codepoint.line - 1))
 
-    Bytecode(codepoint.source.cut(t"/").last, instructions2)
+    copy(sourceFile = codepoint.source.cut(t"/").last, instructions = instructions2)

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -39,7 +39,6 @@ import java.lang.classfile.instruction as jlci
 import scala.reflect.*
 
 import anticipation.*
-import contingency.*
 import digression.*
 import escapade.*
 import escritoire.*
@@ -163,8 +162,6 @@ object Bytecode:
   case class Instruction
     ( opcode: Opcode, line: Optional[Int], stack: Optional[List[Frame]], offset: Int )
 
-  case class Linearized(depth: Int, source: Text, instruction: Instruction)
-
   object Linearized:
     given teletypeable: (palette: BytecodePalette) => List[Linearized] is Teletypeable = lines =>
       lines.map: line =>
@@ -176,6 +173,8 @@ object Bytecode:
         e"$indent$src${line.instruction.opcode.teletype}"
 
       . join(e"\n")
+
+  case class Linearized(depth: Int, source: Text, instruction: Instruction)
 
   object Opcode:
     private def typeKindToFrame(kind: jlc.TypeKind): Frame = kind match
@@ -1486,12 +1485,11 @@ case class Bytecode
         case Invokeinterface(owner, _, descriptor, _)   => (owner, descriptor)
         case _                                          => (t"", t"")
 
-      if owner == t"" then None else
-        priorStacks.get(instr.offset).flatMap: pre =>
-          val argCount = Bytecode.Descriptor.parse(descriptor).args.size
-          if pre.size <= argCount then None
-          else pre.drop(argCount).head match
-            case Bytecode.Frame.L(name) if name == owner => Some(instr.offset)
-            case _                                       => None
-
+      if owner == t"" then None
+      else priorStacks.get(instr.offset).flatMap: pre =>
+        val argCount = Bytecode.Descriptor.parse(descriptor).args.size
+        if pre.size <= argCount then None
+        else pre.drop(argCount).head match
+          case Bytecode.Frame.L(name) if name == owner => Some(instr.offset)
+          case _                                       => None
     . toSet

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -136,6 +136,18 @@ object Bytecode:
     ( opcode: Opcode, line: Optional[Int], stack: Optional[List[Frame]], offset: Int )
 
   object Opcode:
+    private def typeKindToFrame(kind: jlc.TypeKind): Frame = kind match
+      case jlc.TypeKind.BOOLEAN   => Frame.Z
+      case jlc.TypeKind.BYTE      => Frame.B
+      case jlc.TypeKind.CHAR      => Frame.C
+      case jlc.TypeKind.SHORT     => Frame.S
+      case jlc.TypeKind.INT       => Frame.I
+      case jlc.TypeKind.LONG      => Frame.J
+      case jlc.TypeKind.FLOAT     => Frame.F
+      case jlc.TypeKind.DOUBLE    => Frame.D
+      case jlc.TypeKind.REFERENCE => Frame.L(t"?")
+      case jlc.TypeKind.VOID      => panic(m"void TypeKind has no Frame representation")
+
     def apply(source: jlc.Instruction): Opcode = source match
       case invocation: jlci.InvokeInstruction =>
         val classname = invocation.owner.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
@@ -163,6 +175,28 @@ object Bytecode:
           case 179 => Putstatic(classname, name, descriptor)
           case 180 => Getfield(classname, name, descriptor)
           case 181 => Putfield(classname, name, descriptor)
+
+      case typeCheck: jlci.TypeCheckInstruction =>
+        val classname = typeCheck.`type`.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
+
+        source.opcode.nn.bytecode.absolve match
+          case 192 => Checkcast(classname)
+          case 193 => Instanceof(classname)
+
+      case newObject: jlci.NewObjectInstruction =>
+        val classname = newObject.className.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
+        New(classname)
+
+      case newRefArray: jlci.NewReferenceArrayInstruction =>
+        val classname = newRefArray.componentType.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
+        Anewarray(classname)
+
+      case newMultiArray: jlci.NewMultiArrayInstruction =>
+        val classname = newMultiArray.arrayType.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
+        Multianewarray(classname, newMultiArray.dimensions)
+
+      case newPrimArray: jlci.NewPrimitiveArrayInstruction =>
+        Newarray(typeKindToFrame(newPrimArray.typeKind.nn))
 
       case other =>
         source.opcode.nn.bytecode match
@@ -344,17 +378,11 @@ object Bytecode:
           case 175 => Dreturn
           case 176 => Areturn
           case 177 => Return
-          case 187 => New(0)
-          case 188 => Newarray(0)
-          case 189 => Anewarray(0)
           case 190 => Arraylength
           case 191 => Athrow
-          case 192 => Checkcast(0)
-          case 193 => Instanceof(0)
           case 194 => Monitorenter
           case 195 => Monitorexit
           case 196 => Wide()
-          case 197 => Multianewarray(0, 0)
           case 198 => Ifnull(0)
           case 199 => Ifnonnull(0)
           case 200 => GotoW(0)
@@ -568,17 +596,19 @@ object Bytecode:
         val owner2 = StackTrace.rewrite(owner.s)
         val field2 = StackTrace.rewrite(field.s, true)
         t"put·field $owner2 ⌗ $field2"
-      case New(_)               => t"new"
-      case Newarray(_)          => t"new·array"
-      case Anewarray(_)         => t"a·new·array"
+      case New(cls)             => t"new ${StackTrace.rewrite(cls.s)}"
+      case Newarray(element)    => t"new·array $element"
+      case Anewarray(cls)       => t"a·new·array ${StackTrace.rewrite(cls.s)}"
       case Arraylength          => t"array·length"
       case Athrow               => t"a·throw"
-      case Checkcast(_)         => t"check·cast"
-      case Instanceof(_)        => t"instance·of"
+      case Checkcast(cls)       => t"check·cast ${StackTrace.rewrite(cls.s)}"
+      case Instanceof(cls)      => t"instance·of ${StackTrace.rewrite(cls.s)}"
       case Monitorenter         => t"monitor·enter"
       case Monitorexit          => t"monitor·exit"
       case Wide()               => t"wide"
-      case Multianewarray(_, _) => t"multi·a·new·array"
+
+      case Multianewarray(cls, dims) =>
+        t"multi·a·new·array ${StackTrace.rewrite(cls.s)} $dims"
       case Ifnull(_)            => t"if·null"
       case Ifnonnull(_)         => t"if·!null"
       case GotoW(_)             => t"gotoʷ"
@@ -850,17 +880,17 @@ object Bytecode:
     case Invokestatic(owner: Text, method: Text, descriptor: Text)
     case Invokeinterface(owner: Text, method: Text, descriptor: Text, count: Byte)
     case Invokedynamic(method: Text, descriptor: Text)
-    case New(index: Short)
-    case Newarray(atype: Byte)
-    case Anewarray(index: Short)
+    case New(className: Text)
+    case Newarray(elementType: Frame)
+    case Anewarray(componentClass: Text)
     case Arraylength
     case Athrow
-    case Checkcast(index: Short)
-    case Instanceof(index: Short)
+    case Checkcast(className: Text)
+    case Instanceof(className: Text)
     case Monitorenter
     case Monitorexit
     case Wide()
-    case Multianewarray(index: Short, dimensions: Byte)
+    case Multianewarray(arrayClass: Text, dimensions: Int)
     case Ifnull(branch: Short)
     case Ifnonnull(branch: Short)
     case GotoW(branch: Int)

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -81,10 +81,56 @@ object Bytecode:
       case L(name)      => t"*$name"
       case other        => other.toString.tt
 
+    def parseOne(text: Text, cursor: Int): (Frame, Int) =
+      val s = text.s
+      s.charAt(cursor) match
+        case 'Z' => (Z, cursor + 1)
+        case 'B' => (B, cursor + 1)
+        case 'C' => (C, cursor + 1)
+        case 'S' => (S, cursor + 1)
+        case 'I' => (I, cursor + 1)
+        case 'J' => (J, cursor + 1)
+        case 'F' => (F, cursor + 1)
+        case 'D' => (D, cursor + 1)
+
+        case '[' =>
+          val (inner, end) = parseOne(text, cursor + 1)
+          (Array(inner), end)
+
+        case 'L' =>
+          val end = s.indexOf(';', cursor + 1)
+          val name = s.substring(cursor + 1, end).nn.replace('/', '.').nn.tt
+          (L(name), end + 1)
+
+        case other =>
+          panic(m"unexpected character '${other.toString.tt}' in descriptor")
+
+    def fromFieldDescriptor(descriptor: Text): Frame = parseOne(descriptor, 0)._1
+
   enum Frame:
     case Z, B, C, S, I, J, F, D
     case L(name: Text)
     case Array(frame: Frame)
+
+  object Descriptor:
+    def parse(descriptor: Text): Descriptor =
+      val s = descriptor.s
+      assert(s.charAt(0) == '(', "method descriptor must start with '('")
+      val argsBuf = scala.collection.mutable.ListBuffer.empty[Frame]
+      var cursor = 1
+
+      while s.charAt(cursor) != ')' do
+        val (frame, next) = Frame.parseOne(descriptor, cursor)
+        argsBuf += frame
+        cursor = next
+
+      cursor += 1
+      val result: Optional[Frame] =
+        if s.charAt(cursor) == 'V' then Unset else Frame.parseOne(descriptor, cursor)._1
+
+      Descriptor(argsBuf.toList, result)
+
+  case class Descriptor(args: List[Frame], result: Optional[Frame])
 
   case class Instruction
     ( opcode: Opcode, line: Optional[Int], stack: Optional[List[Frame]], offset: Int )
@@ -92,18 +138,31 @@ object Bytecode:
   object Opcode:
     def apply(source: jlc.Instruction): Opcode = source match
       case invocation: jlci.InvokeInstruction =>
-        val classname = invocation.owner.nn.name.nn.stringValue.nn.replace("/", ".").nn
-        val method = invocation.name.nn.stringValue.nn
+        val classname = invocation.owner.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
+        val method = invocation.name.nn.stringValue.nn.tt
+        val descriptor = invocation.`type`.nn.stringValue.nn.tt
 
         source.opcode.nn.bytecode.absolve match
-          case 182 => Invokevirtual(classname, method)
-          case 183 => Invokespecial(classname, method)
-          case 184 => Invokestatic(classname, method)
-          case 185 => Invokeinterface(classname, method, 0)
+          case 182 => Invokevirtual(classname, method, descriptor)
+          case 183 => Invokespecial(classname, method, descriptor)
+          case 184 => Invokestatic(classname, method, descriptor)
+          case 185 => Invokeinterface(classname, method, descriptor, invocation.count.toByte)
 
       case invocation: jlci.InvokeDynamicInstruction =>
         val method = StackTrace.rewrite(invocation.name.nn.stringValue.nn, true)
-        Invokedynamic(method)
+        val descriptor = invocation.`type`.nn.stringValue.nn.tt
+        Invokedynamic(method, descriptor)
+
+      case field: jlci.FieldInstruction =>
+        val classname = field.owner.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
+        val name = field.name.nn.stringValue.nn.tt
+        val descriptor = field.`type`.nn.stringValue.nn.tt
+
+        source.opcode.nn.bytecode.absolve match
+          case 178 => Getstatic(classname, name, descriptor)
+          case 179 => Putstatic(classname, name, descriptor)
+          case 180 => Getfield(classname, name, descriptor)
+          case 181 => Putfield(classname, name, descriptor)
 
       case other =>
         source.opcode.nn.bytecode match
@@ -285,10 +344,6 @@ object Bytecode:
           case 175 => Dreturn
           case 176 => Areturn
           case 177 => Return
-          case 178 => Getstatic(0)
-          case 179 => Putstatic(0)
-          case 180 => Getfield(0)
-          case 181 => Putfield(0)
           case 187 => New(0)
           case 188 => Newarray(0)
           case 189 => Anewarray(0)
@@ -493,10 +548,26 @@ object Bytecode:
       case Dreturn              => t"d·return"
       case Areturn              => t"a·return"
       case Return               => t"return"
-      case Getstatic(_)         => t"get·static"
-      case Putstatic(_)         => t"put·static"
-      case Getfield(_)          => t"get·field"
-      case Putfield(_)          => t"put·field"
+
+      case Getstatic(owner, field, _) =>
+        val owner2 = StackTrace.rewrite(owner.s)
+        val field2 = StackTrace.rewrite(field.s, true)
+        t"get·static $owner2 . $field2"
+
+      case Putstatic(owner, field, _) =>
+        val owner2 = StackTrace.rewrite(owner.s)
+        val field2 = StackTrace.rewrite(field.s, true)
+        t"put·static $owner2 . $field2"
+
+      case Getfield(owner, field, _) =>
+        val owner2 = StackTrace.rewrite(owner.s)
+        val field2 = StackTrace.rewrite(field.s, true)
+        t"get·field $owner2 ⌗ $field2"
+
+      case Putfield(owner, field, _) =>
+        val owner2 = StackTrace.rewrite(owner.s)
+        val field2 = StackTrace.rewrite(field.s, true)
+        t"put·field $owner2 ⌗ $field2"
       case New(_)               => t"new"
       case Newarray(_)          => t"new·array"
       case Anewarray(_)         => t"a·new·array"
@@ -567,27 +638,27 @@ object Bytecode:
       case Impdep1              => t"imp·dep₁"
       case Impdep2              => t"imp·dep₂"
 
-      case Invokevirtual(cls, name) =>
+      case Invokevirtual(cls, name, _) =>
         val cls2 = StackTrace.rewrite(cls.s)
         val name2 = StackTrace.rewrite(name.s, true)
         t"invoke·virtual $cls2 ⌗ $name2"
 
-      case Invokespecial(cls, name) =>
+      case Invokespecial(cls, name, _) =>
         val cls2 = StackTrace.rewrite(cls.s)
         val name2 = StackTrace.rewrite(name.s, true)
         t"invoke·special $cls2 . $name2"
 
-      case Invokestatic(cls, name) =>
+      case Invokestatic(cls, name, _) =>
         val cls2 = StackTrace.rewrite(cls.s)
         val name2 = StackTrace.rewrite(name.s, true)
         t"invoke·static $cls2 . $name2"
 
-      case Invokeinterface(cls, name, _) =>
+      case Invokeinterface(cls, name, _, _) =>
         val cls2 = StackTrace.rewrite(cls.s)
         val name2 = StackTrace.rewrite(name.s, true)
         t"invoke·interface $cls2 ⌗ $name2"
 
-      case Invokedynamic(name) =>
+      case Invokedynamic(name, _) =>
         val name2 = StackTrace.rewrite(name.s, true)
         t"invoke·dynamic $name2"
 
@@ -770,15 +841,15 @@ object Bytecode:
     case Dreturn
     case Areturn
     case Return
-    case Getstatic(index: Short)
-    case Putstatic(index: Short)
-    case Getfield(index: Short)
-    case Putfield(index: Short)
-    case Invokevirtual(owner: Text, method: Text)
-    case Invokespecial(owner: Text, method: Text)
-    case Invokestatic(owner: Text, method: Text)
-    case Invokeinterface(owner: Text, method: Text, count: Byte)
-    case Invokedynamic(method: Text)
+    case Getstatic(owner: Text, field: Text, descriptor: Text)
+    case Putstatic(owner: Text, field: Text, descriptor: Text)
+    case Getfield(owner: Text, field: Text, descriptor: Text)
+    case Putfield(owner: Text, field: Text, descriptor: Text)
+    case Invokevirtual(owner: Text, method: Text, descriptor: Text)
+    case Invokespecial(owner: Text, method: Text, descriptor: Text)
+    case Invokestatic(owner: Text, method: Text, descriptor: Text)
+    case Invokeinterface(owner: Text, method: Text, descriptor: Text, count: Byte)
+    case Invokedynamic(method: Text, descriptor: Text)
     case New(index: Short)
     case Newarray(atype: Byte)
     case Anewarray(index: Short)
@@ -1100,7 +1171,12 @@ object Bytecode:
         case Nop                      => stack
         case New(_)                   => L(t"class") :: stack
         case Dup                      => stack.head :: stack.head :: stack.tail
-        case Invokespecial(_, _)      => L(t"unknown") :: stack.tail // FIXME
+
+        case Invokespecial(_, _, descriptor) =>
+          val parsed = Descriptor.parse(descriptor)
+          parsed.result.lay(stack.drop(parsed.args.size + 1)): result =>
+            result :: stack.drop(parsed.args.size + 1)
+
         case Astore(_)                => stack.tail
         case Astore1                  => stack.tail
         case Astore2                  => stack.tail
@@ -1114,11 +1190,29 @@ object Bytecode:
         case Areturn                  => L(t"?") :: Nil
         case Iload1                   => I :: stack
         case Checkcast(_)             => L(t"?") :: stack.tail
-        case Invokedynamic(_)         => L(t"?") :: stack.tail // FIXME
-        case Getstatic(_)             => L(t"?") :: stack
-        case Invokevirtual(_, _)      => L(t"?") :: stack.tail
-        case Invokestatic(_, _)       => L(t"?") :: stack.tail
-        case Invokeinterface(_, _, _) => L(t"?") :: stack.tail
+
+        case Invokedynamic(_, descriptor) =>
+          val parsed = Descriptor.parse(descriptor)
+          parsed.result.lay(stack.drop(parsed.args.size)): result =>
+            result :: stack.drop(parsed.args.size)
+
+        case Getstatic(_, _, descriptor) => Frame.fromFieldDescriptor(descriptor) :: stack
+
+        case Invokevirtual(_, _, descriptor) =>
+          val parsed = Descriptor.parse(descriptor)
+          parsed.result.lay(stack.drop(parsed.args.size + 1)): result =>
+            result :: stack.drop(parsed.args.size + 1)
+
+        case Invokestatic(_, _, descriptor) =>
+          val parsed = Descriptor.parse(descriptor)
+          parsed.result.lay(stack.drop(parsed.args.size)): result =>
+            result :: stack.drop(parsed.args.size)
+
+        case Invokeinterface(_, _, descriptor, _) =>
+          val parsed = Descriptor.parse(descriptor)
+          parsed.result.lay(stack.drop(parsed.args.size + 1)): result =>
+            result :: stack.drop(parsed.args.size + 1)
+
         case Ifnonnull(_)             => stack.tail
         case Ifeq(_)                  => stack.tail
         case Instanceof(_)            => L(t"?") :: stack.tail

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -198,6 +198,80 @@ object Bytecode:
       case newPrimArray: jlci.NewPrimitiveArrayInstruction =>
         Newarray(typeKindToFrame(newPrimArray.typeKind.nn))
 
+      case load: jlci.LoadInstruction =>
+        val slot = load.slot
+        source.opcode.nn.bytecode.absolve match
+          case 21 => Iload(slot)
+          case 22 => Lload(slot)
+          case 23 => Fload(slot)
+          case 24 => Dload(slot)
+          case 25 => Aload(slot)
+          case 26 => Iload0
+          case 27 => Iload1
+          case 28 => Iload2
+          case 29 => Iload3
+          case 30 => Lload0
+          case 31 => Lload1
+          case 32 => Lload2
+          case 33 => Lload3
+          case 34 => Fload0
+          case 35 => Fload1
+          case 36 => Fload2
+          case 37 => Fload3
+          case 38 => Dload0
+          case 39 => Dload1
+          case 40 => Dload2
+          case 41 => Dload3
+          case 42 => Aload0
+          case 43 => Aload1
+          case 44 => Aload2
+          case 45 => Aload3
+
+      case store: jlci.StoreInstruction =>
+        val slot = store.slot
+        source.opcode.nn.bytecode.absolve match
+          case 54 => Istore(slot)
+          case 55 => Lstore(slot)
+          case 56 => Fstore(slot)
+          case 57 => Dstore(slot)
+          case 58 => Astore(slot)
+          case 59 => Istore0
+          case 60 => Istore1
+          case 61 => Istore2
+          case 62 => Istore3
+          case 63 => Lstore0
+          case 64 => Lstore1
+          case 65 => Lstore2
+          case 66 => Lstore3
+          case 67 => Fstore0
+          case 68 => Fstore1
+          case 69 => Fstore2
+          case 70 => Fstore3
+          case 71 => Dstore0
+          case 72 => Dstore1
+          case 73 => Dstore2
+          case 74 => Dstore3
+          case 75 => Astore0
+          case 76 => Astore1
+          case 77 => Astore2
+          case 78 => Astore3
+
+      case inc: jlci.IncrementInstruction =>
+        Iinc(inc.slot, inc.constant)
+
+      case arg: jlci.ConstantInstruction.ArgumentConstantInstruction =>
+        val intValue = arg.constantValue.nn.toString.toInt
+        source.opcode.nn.bytecode.absolve match
+          case 16 => Bipush(intValue.toByte)
+          case 17 => Sipush(intValue.toShort)
+
+      case ldc: jlci.ConstantInstruction.LoadConstantInstruction =>
+        val text = ldc.constantValue.nn.toString.tt
+        source.opcode.nn.bytecode.absolve match
+          case 18 => Ldc(text)
+          case 19 => LdcW(text)
+          case 20 => Ldc2W(text)
+
       case other =>
         source.opcode.nn.bytecode match
           case 0   => Nop
@@ -216,36 +290,6 @@ object Bytecode:
           case 13  => Fconst2
           case 14  => Dconst0
           case 15  => Dconst1
-          case 16  => Bipush(0)
-          case 17  => Sipush(0)
-          case 18  => Ldc(0)
-          case 19  => LdcW(0)
-          case 20  => Ldc2W(0)
-          case 21  => Iload(0)
-          case 22  => Lload(0)
-          case 23  => Fload(0)
-          case 24  => Dload(0)
-          case 25  => Aload(0)
-          case 26  => Iload0
-          case 27  => Iload1
-          case 28  => Iload2
-          case 29  => Iload3
-          case 30  => Lload0
-          case 31  => Lload1
-          case 32  => Lload2
-          case 33  => Lload3
-          case 34  => Fload0
-          case 35  => Fload1
-          case 36  => Fload2
-          case 37  => Fload3
-          case 38  => Dload0
-          case 39  => Dload1
-          case 40  => Dload2
-          case 41  => Dload3
-          case 42  => Aload0
-          case 43  => Aload1
-          case 44  => Aload2
-          case 45  => Aload3
           case 46  => Iaload
           case 47  => Laload
           case 48  => Faload
@@ -254,31 +298,6 @@ object Bytecode:
           case 51  => Baload
           case 52  => Caload
           case 53  => Saload
-          case 54  => Istore(0)
-          case 55  => Lstore(0)
-          case 56  => Fstore(0)
-          case 57  => Dstore(0)
-          case 58  => Astore(0)
-          case 59  => Istore0
-          case 60  => Istore1
-          case 61  => Istore2
-          case 62  => Istore3
-          case 63  => Lstore0
-          case 64  => Lstore1
-          case 65  => Lstore2
-          case 66  => Lstore3
-          case 67  => Fstore0
-          case 68  => Fstore1
-          case 69  => Fstore2
-          case 70  => Fstore3
-          case 71  => Dstore0
-          case 72  => Dstore1
-          case 73  => Dstore2
-          case 74  => Dstore3
-          case 75  => Astore0
-          case 76  => Astore1
-          case 77  => Astore2
-          case 78  => Astore3
           case 79  => Iastore
           case 80  => Lastore
           case 81  => Fastore
@@ -332,7 +351,6 @@ object Bytecode:
           case 129 => Lor
           case 130 => Ixor
           case 131 => Lxor
-          case 132 => Iinc(0, 0)
           case 133 => I2l
           case 134 => I2f
           case 135 => I2d
@@ -414,16 +432,16 @@ object Bytecode:
       case Fconst2              => t"f·const₂"
       case Dconst0              => t"d·const₀"
       case Dconst1              => t"d·const₁"
-      case Bipush(_)            => t"b·i·push"
-      case Sipush(_)            => t"s·i·push"
-      case Ldc(_)               => t"ldc"
-      case LdcW(_)              => t"ldcʷ"
-      case Ldc2W(_)             => t"ldc²ʷ"
-      case Iload(_)             => t"i·load"
-      case Lload(_)             => t"l·load"
-      case Fload(_)             => t"f·load"
-      case Dload(_)             => t"d·load"
-      case Aload(_)             => t"a·load"
+      case Bipush(value)        => t"b·i·push $value"
+      case Sipush(value)        => t"s·i·push $value"
+      case Ldc(value)           => t"ldc $value"
+      case LdcW(value)          => t"ldcʷ $value"
+      case Ldc2W(value)         => t"ldc²ʷ $value"
+      case Iload(slot)          => t"i·load $slot"
+      case Lload(slot)          => t"l·load $slot"
+      case Fload(slot)          => t"f·load $slot"
+      case Dload(slot)          => t"d·load $slot"
+      case Aload(slot)          => t"a·load $slot"
       case Iload0               => t"i·load₀"
       case Iload1               => t"i·load₁"
       case Iload2               => t"i·load₂"
@@ -452,11 +470,11 @@ object Bytecode:
       case Baload               => t"bᴬ·load"
       case Caload               => t"cᴬ·load"
       case Saload               => t"sᴬ·load"
-      case Istore(_)            => t"i·store"
-      case Lstore(_)            => t"l·store"
-      case Fstore(_)            => t"f·store"
-      case Dstore(_)            => t"d·store"
-      case Astore(_)            => t"a·store"
+      case Istore(slot)         => t"i·store $slot"
+      case Lstore(slot)         => t"l·store $slot"
+      case Fstore(slot)         => t"f·store $slot"
+      case Dstore(slot)         => t"d·store $slot"
+      case Astore(slot)         => t"a·store $slot"
       case Istore0              => t"i·store₀"
       case Istore1              => t"i·store₁"
       case Istore2              => t"i·store₂"
@@ -530,7 +548,7 @@ object Bytecode:
       case Lor                  => t"l·or"
       case Ixor                 => t"i·xor"
       case Lxor                 => t"l·xor"
-      case Iinc(_, _)           => t"i·inc"
+      case Iinc(slot, const)    => t"i·inc $slot $const"
       case I2l                  => t"i→l"
       case I2f                  => t"i→"
       case I2d                  => t"i→d"
@@ -567,7 +585,7 @@ object Bytecode:
       case IfAcmpne(_)          => t"if·a·cmp·ne"
       case Goto(_)              => t"goto"
       case Jsr(_)               => t"jsr"
-      case Ret(_)               => t"ret"
+      case Ret(slot)            => t"ret $slot"
       case Tableswitch()        => t"table·switch"
       case Lookupswitch()       => t"lookup·switch"
       case Ireturn              => t"i·return"
@@ -709,16 +727,16 @@ object Bytecode:
     case Fconst2
     case Dconst0
     case Dconst1
-    case Bipush(byte: Byte)
-    case Sipush(short: Short)
-    case Ldc(index: Byte)
-    case LdcW(index: Short)
-    case Ldc2W(index: Short)
-    case Iload(index: Byte)
-    case Lload(index: Byte)
-    case Fload(index: Byte)
-    case Dload(index: Byte)
-    case Aload(index: Byte)
+    case Bipush(value: Byte)
+    case Sipush(value: Short)
+    case Ldc(value: Text)
+    case LdcW(value: Text)
+    case Ldc2W(value: Text)
+    case Iload(slot: Int)
+    case Lload(slot: Int)
+    case Fload(slot: Int)
+    case Dload(slot: Int)
+    case Aload(slot: Int)
     case Iload0
     case Iload1
     case Iload2
@@ -747,11 +765,11 @@ object Bytecode:
     case Baload
     case Caload
     case Saload
-    case Istore(variable: Byte)
-    case Lstore(variable: Byte)
-    case Fstore(variable: Byte)
-    case Dstore(variable: Byte)
-    case Astore(variable: Byte)
+    case Istore(slot: Int)
+    case Lstore(slot: Int)
+    case Fstore(slot: Int)
+    case Dstore(slot: Int)
+    case Astore(slot: Int)
     case Istore0
     case Istore1
     case Istore2
@@ -825,7 +843,7 @@ object Bytecode:
     case Lor
     case Ixor
     case Lxor
-    case Iinc(index: Byte, const: Byte)
+    case Iinc(slot: Int, const: Int)
     case I2l
     case I2f
     case I2d
@@ -862,7 +880,7 @@ object Bytecode:
     case IfAcmpne(offset: Short)
     case Goto(offset: Short)
     case Jsr(offset: Short)
-    case Ret(index: Byte)
+    case Ret(slot: Int)
     case Tableswitch()
     case Lookupswitch()
     case Ireturn

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -1414,3 +1414,32 @@ case class Bytecode
       instruction.copy(line = instruction.line.let(_ + codepoint.line - 1))
 
     copy(sourceFile = codepoint.source.cut(t"/").last, instructions = instructions2)
+
+  def effectivelyStaticCalls: Set[Int] =
+    import Bytecode.Opcode.*
+    val byOffset = instructions.iterator.map(i => i.offset -> i).toMap
+    val priorStacks: Map[Int, List[Bytecode.Frame]] =
+      var prev: Optional[List[Bytecode.Frame]] = Nil
+      val builder = Map.newBuilder[Int, List[Bytecode.Frame]]
+
+      instructions.foreach: instr =>
+        prev.let(builder += instr.offset -> _)
+        prev = instr.stack
+
+      builder.result()
+
+    instructions.iterator.flatMap: instr =>
+      val (owner, descriptor) = instr.opcode match
+        case Invokevirtual(owner, _, descriptor)        => (owner, descriptor)
+        case Invokeinterface(owner, _, descriptor, _)   => (owner, descriptor)
+        case _                                          => (t"", t"")
+
+      if owner == t"" then None else
+        priorStacks.get(instr.offset).flatMap: pre =>
+          val argCount = Bytecode.Descriptor.parse(descriptor).args.size
+          if pre.size <= argCount then None
+          else pre.drop(argCount).head match
+            case Bytecode.Frame.L(name) if name == owner => Some(instr.offset)
+            case _                                       => None
+
+    . toSet

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -148,7 +148,8 @@ object Bytecode:
       case jlc.TypeKind.REFERENCE => Frame.L(t"?")
       case jlc.TypeKind.VOID      => panic(m"void TypeKind has no Frame representation")
 
-    def apply(source: jlc.Instruction): Opcode = source match
+    def apply(source: jlc.Instruction, labels: Map[jlc.Label, Int] = Map.empty)
+    :   Opcode = source match
       case invocation: jlci.InvokeInstruction =>
         val classname = invocation.owner.nn.name.nn.stringValue.nn.replace("/", ".").nn.tt
         val method = invocation.name.nn.stringValue.nn.tt
@@ -272,6 +273,42 @@ object Bytecode:
           case 19 => LdcW(text)
           case 20 => Ldc2W(text)
 
+      case tswitch: jlci.TableSwitchInstruction =>
+        val default = labels.getOrElse(tswitch.defaultTarget.nn, 0)
+        val targets = tswitch.cases.nn.asScala.toList.map: c =>
+          labels.getOrElse(c.nn.target.nn, 0)
+        Tableswitch(default, tswitch.lowValue, tswitch.highValue, targets)
+
+      case lswitch: jlci.LookupSwitchInstruction =>
+        val default = labels.getOrElse(lswitch.defaultTarget.nn, 0)
+        val cases = lswitch.cases.nn.asScala.toList.map: c =>
+          (c.nn.caseValue, labels.getOrElse(c.nn.target.nn, 0))
+        Lookupswitch(default, cases)
+
+      case branch: jlci.BranchInstruction =>
+        val target = labels.getOrElse(branch.target.nn, 0)
+        source.opcode.nn.bytecode.absolve match
+          case 153 => Ifeq(target)
+          case 154 => Ifne(target)
+          case 155 => Iflt(target)
+          case 156 => Ifge(target)
+          case 157 => Ifgt(target)
+          case 158 => Ifle(target)
+          case 159 => IfIcmpeq(target)
+          case 160 => IfIcmpne(target)
+          case 161 => IfIcmplt(target)
+          case 162 => IfIcmpge(target)
+          case 163 => IfIcmpgt(target)
+          case 164 => IfIcmple(target)
+          case 165 => IfAcmpeq(target)
+          case 166 => IfAcmpne(target)
+          case 167 => Goto(target)
+          case 168 => Jsr(target)
+          case 198 => Ifnull(target)
+          case 199 => Ifnonnull(target)
+          case 200 => GotoW(target)
+          case 201 => JsrW(target)
+
       case other =>
         source.opcode.nn.bytecode match
           case 0   => Nop
@@ -371,25 +408,7 @@ object Bytecode:
           case 150 => Fcmpg
           case 151 => Dcmpl
           case 152 => Dcmpg
-          case 153 => Ifeq(0)
-          case 154 => Ifne(0)
-          case 155 => Iflt(0)
-          case 156 => Ifge(0)
-          case 157 => Ifgt(0)
-          case 158 => Ifle(0)
-          case 159 => IfIcmpeq(0)
-          case 160 => IfIcmpne(0)
-          case 161 => IfIcmplt(0)
-          case 162 => IfIcmpge(0)
-          case 163 => IfIcmpgt(0)
-          case 164 => IfIcmple(0)
-          case 165 => IfAcmpeq(0)
-          case 166 => IfAcmpne(0)
-          case 167 => Goto(0)
-          case 168 => Jsr(0)
           case 169 => Ret(0)
-          case 170 => Tableswitch()
-          case 171 => Lookupswitch()
           case 172 => Ireturn
           case 173 => Lreturn
           case 174 => Freturn
@@ -401,10 +420,6 @@ object Bytecode:
           case 194 => Monitorenter
           case 195 => Monitorexit
           case 196 => Wide()
-          case 198 => Ifnull(0)
-          case 199 => Ifnonnull(0)
-          case 200 => GotoW(0)
-          case 201 => JsrW(0)
 
           case opcode =>
             panic(m"unrecognized opcode $opcode")
@@ -569,25 +584,30 @@ object Bytecode:
       case Fcmpg                => t"f·cmpg"
       case Dcmpl                => t"d·cmpl"
       case Dcmpg                => t"d·cmpg"
-      case Ifeq(_)              => t"if·eq"
-      case Ifne(_)              => t"if·ne"
-      case Iflt(_)              => t"if·lt"
-      case Ifge(_)              => t"if·ge"
-      case Ifgt(_)              => t"if·gt"
-      case Ifle(_)              => t"if·le"
-      case IfIcmpeq(_)          => t"if·i·cmp·eq"
-      case IfIcmpne(_)          => t"if·i·cmp·ne"
-      case IfIcmplt(_)          => t"if·i·cmp·lt"
-      case IfIcmpge(_)          => t"if·i·cmp·ge"
-      case IfIcmpgt(_)          => t"if·i·cmp·gt"
-      case IfIcmple(_)          => t"if·i·cmp·le"
-      case IfAcmpeq(_)          => t"if·a·cmp·eq"
-      case IfAcmpne(_)          => t"if·a·cmp·ne"
-      case Goto(_)              => t"goto"
-      case Jsr(_)               => t"jsr"
+      case Ifeq(target)         => t"if·eq →$target"
+      case Ifne(target)         => t"if·ne →$target"
+      case Iflt(target)         => t"if·lt →$target"
+      case Ifge(target)         => t"if·ge →$target"
+      case Ifgt(target)         => t"if·gt →$target"
+      case Ifle(target)         => t"if·le →$target"
+      case IfIcmpeq(target)     => t"if·i·cmp·eq →$target"
+      case IfIcmpne(target)     => t"if·i·cmp·ne →$target"
+      case IfIcmplt(target)     => t"if·i·cmp·lt →$target"
+      case IfIcmpge(target)     => t"if·i·cmp·ge →$target"
+      case IfIcmpgt(target)     => t"if·i·cmp·gt →$target"
+      case IfIcmple(target)     => t"if·i·cmp·le →$target"
+      case IfAcmpeq(target)     => t"if·a·cmp·eq →$target"
+      case IfAcmpne(target)     => t"if·a·cmp·ne →$target"
+      case Goto(target)         => t"goto →$target"
+      case Jsr(target)          => t"jsr →$target"
       case Ret(slot)            => t"ret $slot"
-      case Tableswitch()        => t"table·switch"
-      case Lookupswitch()       => t"lookup·switch"
+
+      case Tableswitch(default, low, high, targets) =>
+        t"table·switch [$low..$high] →${targets.map(_.show).join(t",")} default →$default"
+
+      case Lookupswitch(default, cases) =>
+        val rendered = cases.map((v, t) => t"$v→$t").join(t",")
+        t"lookup·switch $rendered default →$default"
       case Ireturn              => t"i·return"
       case Lreturn              => t"l·return"
       case Freturn              => t"f·return"
@@ -627,10 +647,10 @@ object Bytecode:
 
       case Multianewarray(cls, dims) =>
         t"multi·a·new·array ${StackTrace.rewrite(cls.s)} $dims"
-      case Ifnull(_)            => t"if·null"
-      case Ifnonnull(_)         => t"if·!null"
-      case GotoW(_)             => t"gotoʷ"
-      case JsrW(_)              => t"jsrʷ"
+      case Ifnull(target)       => t"if·null →$target"
+      case Ifnonnull(target)    => t"if·!null →$target"
+      case GotoW(target)        => t"gotoʷ →$target"
+      case JsrW(target)         => t"jsrʷ →$target"
       case Breakpoint           => t"breakpoint"
       case OpCb                 => t"-CB-"
       case OpCc                 => t"-CC-"
@@ -864,25 +884,25 @@ object Bytecode:
     case Fcmpg
     case Dcmpl
     case Dcmpg
-    case Ifeq(offset: Short)
-    case Ifne(offset: Short)
-    case Iflt(offset: Short)
-    case Ifge(offset: Short)
-    case Ifgt(offset: Short)
-    case Ifle(offset: Short)
-    case IfIcmpeq(offset: Short)
-    case IfIcmpne(offset: Short)
-    case IfIcmplt(offset: Short)
-    case IfIcmpge(offset: Short)
-    case IfIcmpgt(offset: Short)
-    case IfIcmple(offset: Short)
-    case IfAcmpeq(offset: Short)
-    case IfAcmpne(offset: Short)
-    case Goto(offset: Short)
-    case Jsr(offset: Short)
+    case Ifeq(target: Int)
+    case Ifne(target: Int)
+    case Iflt(target: Int)
+    case Ifge(target: Int)
+    case Ifgt(target: Int)
+    case Ifle(target: Int)
+    case IfIcmpeq(target: Int)
+    case IfIcmpne(target: Int)
+    case IfIcmplt(target: Int)
+    case IfIcmpge(target: Int)
+    case IfIcmpgt(target: Int)
+    case IfIcmple(target: Int)
+    case IfAcmpeq(target: Int)
+    case IfAcmpne(target: Int)
+    case Goto(target: Int)
+    case Jsr(target: Int)
     case Ret(slot: Int)
-    case Tableswitch()
-    case Lookupswitch()
+    case Tableswitch(default: Int, low: Int, high: Int, targets: List[Int])
+    case Lookupswitch(default: Int, cases: List[(Int, Int)])
     case Ireturn
     case Lreturn
     case Freturn
@@ -909,10 +929,10 @@ object Bytecode:
     case Monitorexit
     case Wide()
     case Multianewarray(arrayClass: Text, dimensions: Int)
-    case Ifnull(branch: Short)
-    case Ifnonnull(branch: Short)
-    case GotoW(branch: Int)
-    case JsrW(branch: Int)
+    case Ifnull(target: Int)
+    case Ifnonnull(target: Int)
+    case GotoW(target: Int)
+    case JsrW(target: Int)
     case Breakpoint
     case OpCb
     case OpCc

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -33,6 +33,7 @@
 package mandible
 
 import java.lang.classfile as jlc
+import java.lang.classfile.attribute as jlca
 import java.lang.classfile.instruction as jlci
 
 import scala.reflect.*
@@ -106,6 +107,33 @@ object Bytecode:
           panic(m"unexpected character '${other.toString.tt}' in descriptor")
 
     def fromFieldDescriptor(descriptor: Text): Frame = parseOne(descriptor, 0)._1
+
+    def fromVerificationType(vti: jlca.StackMapFrameInfo.VerificationTypeInfo): Frame =
+      vti match
+        case s: jlca.StackMapFrameInfo.SimpleVerificationTypeInfo =>
+          s match
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.INTEGER => I
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.FLOAT   => F
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.DOUBLE  => D
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.LONG    => J
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.NULL    => L(t"null")
+
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.UNINITIALIZED_THIS =>
+              L(t"this")
+
+            case jlca.StackMapFrameInfo.SimpleVerificationTypeInfo.TOP =>
+              L(t"top")
+
+        case obj: jlca.StackMapFrameInfo.ObjectVerificationTypeInfo =>
+          val raw = obj.className.nn.name.nn.stringValue.nn
+          if raw.startsWith("[") then parseOne(raw.tt, 0)._1
+          else L(raw.replace('/', '.').nn.tt)
+
+        case _: jlca.StackMapFrameInfo.UninitializedVerificationTypeInfo =>
+          L(t"uninit")
+
+        case other =>
+          L(t"unknown")
 
   enum Frame:
     case Z, B, C, S, I, J, F, D

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -1235,56 +1235,145 @@ object Bytecode:
 
     def transform(stack: List[Frame]): List[Frame] =
       import Frame.*
+
+      def invokeWithReceiver(descriptor: Text): List[Frame] =
+        val parsed = Descriptor.parse(descriptor)
+        val popped = stack.drop(parsed.args.size + 1)
+        parsed.result.lay(popped)(_ :: popped)
+
+      def invokeStaticOrDynamic(descriptor: Text): List[Frame] =
+        val parsed = Descriptor.parse(descriptor)
+        val popped = stack.drop(parsed.args.size)
+        parsed.result.lay(popped)(_ :: popped)
+
       this match
-        case Nop                      => stack
-        case New(_)                   => L(t"class") :: stack
-        case Dup                      => stack.head :: stack.head :: stack.tail
+        case Nop => stack
+        case AconstNull => L(t"null") :: stack
+        case IconstM1 | Iconst0 | Iconst1 | Iconst2 | Iconst3 | Iconst4 | Iconst5 => I :: stack
+        case Lconst0 | Lconst1 => J :: stack
+        case Fconst0 | Fconst1 | Fconst2 => F :: stack
+        case Dconst0 | Dconst1 => D :: stack
+        case Bipush(_) | Sipush(_) => I :: stack
+        case Ldc(_) | LdcW(_) => L(t"?") :: stack
+        case Ldc2W(_) => J :: stack
 
-        case Invokespecial(_, _, descriptor) =>
-          val parsed = Descriptor.parse(descriptor)
-          parsed.result.lay(stack.drop(parsed.args.size + 1)): result =>
-            result :: stack.drop(parsed.args.size + 1)
+        case Iload(_) | Iload0 | Iload1 | Iload2 | Iload3 => I :: stack
+        case Lload(_) | Lload0 | Lload1 | Lload2 | Lload3 => J :: stack
+        case Fload(_) | Fload0 | Fload1 | Fload2 | Fload3 => F :: stack
+        case Dload(_) | Dload0 | Dload1 | Dload2 | Dload3 => D :: stack
+        case Aload(_) | Aload0 | Aload1 | Aload2 | Aload3 => L(t"?") :: stack
 
-        case Astore(_)                => stack.tail
-        case Astore1                  => stack.tail
-        case Astore2                  => stack.tail
-        case Astore3                  => stack.tail
-        case Aload(_)                 => L(t"?") :: stack
-        case Aload0                   => L(t"?") :: stack
-        case Aload1                   => L(t"?") :: stack
-        case Aload2                   => L(t"?") :: stack
-        case Aload3                   => L(t"?") :: stack
-        case Athrow                   => L(t"?") :: Nil
-        case Areturn                  => L(t"?") :: Nil
-        case Iload1                   => I :: stack
-        case Checkcast(_)             => L(t"?") :: stack.tail
+        case Iaload => I :: stack.drop(2)
+        case Laload => J :: stack.drop(2)
+        case Faload => F :: stack.drop(2)
+        case Daload => D :: stack.drop(2)
+        case Aaload => L(t"?") :: stack.drop(2)
+        case Baload | Caload | Saload => I :: stack.drop(2)
 
-        case Invokedynamic(_, descriptor) =>
-          val parsed = Descriptor.parse(descriptor)
-          parsed.result.lay(stack.drop(parsed.args.size)): result =>
-            result :: stack.drop(parsed.args.size)
+        case Istore(_) | Lstore(_) | Fstore(_) | Dstore(_) | Astore(_) => stack.drop(1)
+        case Istore0 | Istore1 | Istore2 | Istore3 => stack.drop(1)
+        case Lstore0 | Lstore1 | Lstore2 | Lstore3 => stack.drop(1)
+        case Fstore0 | Fstore1 | Fstore2 | Fstore3 => stack.drop(1)
+        case Dstore0 | Dstore1 | Dstore2 | Dstore3 => stack.drop(1)
+        case Astore0 | Astore1 | Astore2 | Astore3 => stack.drop(1)
+
+        case Iastore | Lastore | Fastore | Dastore | Aastore => stack.drop(3)
+        case Bastore | Castore | Sastore => stack.drop(3)
+
+        case Pop => stack.drop(1)
+        case Pop2 => stack.drop(2)
+        case Dup => stack.head :: stack
+
+        case DupX1 => stack match
+          case a :: b :: rest => a :: b :: a :: rest
+          case _ => stack
+
+        case DupX2 => stack match
+          case a :: b :: c :: rest => a :: b :: c :: a :: rest
+          case _ => stack
+
+        case Dup2 => stack match
+          case a :: b :: rest => a :: b :: a :: b :: rest
+          case _ => stack
+
+        case Dup2X1 => stack match
+          case a :: b :: c :: rest => a :: b :: c :: a :: b :: rest
+          case _ => stack
+
+        case Dup2X2 => stack match
+          case a :: b :: c :: d :: rest => a :: b :: c :: d :: a :: b :: rest
+          case _ => stack
+
+        case Swap => stack match
+          case a :: b :: rest => b :: a :: rest
+          case _ => stack
+
+        case Iadd | Isub | Imul | Idiv | Irem | Iand | Ior | Ixor => I :: stack.drop(2)
+        case Ishl | Ishr | Iushr => I :: stack.drop(2)
+        case Ladd | Lsub | Lmul | Ldiv | Lrem | Land | Lor | Lxor => J :: stack.drop(2)
+        case Lshl | Lshr | Lushr => J :: stack.drop(2)
+        case Fadd | Fsub | Fmul | Fdiv | Frem => F :: stack.drop(2)
+        case Dadd | Dsub | Dmul | Ddiv | Drem => D :: stack.drop(2)
+
+        case Ineg | Lneg | Fneg | Dneg => stack
+        case Iinc(_, _) => stack
+
+        case I2l => J :: stack.drop(1)
+        case I2f => F :: stack.drop(1)
+        case I2d => D :: stack.drop(1)
+        case L2i => I :: stack.drop(1)
+        case L2f => F :: stack.drop(1)
+        case L2d => D :: stack.drop(1)
+        case F2i => I :: stack.drop(1)
+        case F2l => J :: stack.drop(1)
+        case F2d => D :: stack.drop(1)
+        case D2i => I :: stack.drop(1)
+        case D2l => J :: stack.drop(1)
+        case D2f => F :: stack.drop(1)
+        case I2b | I2c | I2s => stack
+
+        case Lcmp | Fcmpl | Fcmpg | Dcmpl | Dcmpg => I :: stack.drop(2)
+
+        case Ifeq(_) | Ifne(_) | Iflt(_) | Ifge(_) | Ifgt(_) | Ifle(_) => stack.drop(1)
+
+        case IfIcmpeq(_) | IfIcmpne(_) | IfIcmplt(_)
+          | IfIcmpge(_) | IfIcmpgt(_) | IfIcmple(_) => stack.drop(2)
+
+        case IfAcmpeq(_) | IfAcmpne(_) => stack.drop(2)
+        case Ifnull(_) | Ifnonnull(_) => stack.drop(1)
+        case Goto(_) | GotoW(_) | Ret(_) => stack
+        case Jsr(_) | JsrW(_) => L(t"retaddr") :: stack
+        case Tableswitch(_, _, _, _) | Lookupswitch(_, _) => stack.drop(1)
+
+        case Ireturn | Lreturn | Freturn | Dreturn | Areturn => Nil
+        case Return => Nil
+        case Athrow => stack.take(1)
 
         case Getstatic(_, _, descriptor) => Frame.fromFieldDescriptor(descriptor) :: stack
+        case Putstatic(_, _, _) => stack.drop(1)
 
-        case Invokevirtual(_, _, descriptor) =>
-          val parsed = Descriptor.parse(descriptor)
-          parsed.result.lay(stack.drop(parsed.args.size + 1)): result =>
-            result :: stack.drop(parsed.args.size + 1)
+        case Getfield(_, _, descriptor) =>
+          Frame.fromFieldDescriptor(descriptor) :: stack.drop(1)
 
-        case Invokestatic(_, _, descriptor) =>
-          val parsed = Descriptor.parse(descriptor)
-          parsed.result.lay(stack.drop(parsed.args.size)): result =>
-            result :: stack.drop(parsed.args.size)
+        case Putfield(_, _, _) => stack.drop(2)
 
-        case Invokeinterface(_, _, descriptor, _) =>
-          val parsed = Descriptor.parse(descriptor)
-          parsed.result.lay(stack.drop(parsed.args.size + 1)): result =>
-            result :: stack.drop(parsed.args.size + 1)
+        case Invokestatic(_, _, descriptor) => invokeStaticOrDynamic(descriptor)
+        case Invokevirtual(_, _, descriptor) => invokeWithReceiver(descriptor)
+        case Invokespecial(_, _, descriptor) => invokeWithReceiver(descriptor)
+        case Invokeinterface(_, _, descriptor, _) => invokeWithReceiver(descriptor)
+        case Invokedynamic(_, descriptor) => invokeStaticOrDynamic(descriptor)
 
-        case Ifnonnull(_)             => stack.tail
-        case Ifeq(_)                  => stack.tail
-        case Instanceof(_)            => L(t"?") :: stack.tail
-        case opcode                   => unsafely(throw Exception("Unhandled "+opcode))
+        case New(cls) => L(cls) :: stack
+        case Newarray(elem) => Array(elem) :: stack.drop(1)
+        case Anewarray(cls) => Array(L(cls)) :: stack.drop(1)
+        case Multianewarray(cls, dims) => Array(L(cls)) :: stack.drop(dims)
+        case Arraylength => I :: stack.drop(1)
+        case Checkcast(cls) => L(cls) :: stack.drop(1)
+        case Instanceof(_) => I :: stack.drop(1)
+        case Monitorenter | Monitorexit => stack.drop(1)
+
+        case Wide() | Breakpoint | Impdep1 | Impdep2 => stack
+        case _: Opcode => stack
 
 case class Bytecode(sourceFile: Optional[Text], instructions: List[Bytecode.Instruction]):
   def embed(codepoint: Codepoint): Bytecode =

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -163,6 +163,20 @@ object Bytecode:
   case class Instruction
     ( opcode: Opcode, line: Optional[Int], stack: Optional[List[Frame]], offset: Int )
 
+  case class Linearized(depth: Int, source: Text, instruction: Instruction)
+
+  object Linearized:
+    given teletypeable: (palette: BytecodePalette) => List[Linearized] is Teletypeable = lines =>
+      lines.map: line =>
+        val indent: Text = Text("  ".repeat(line.depth).nn)
+        val src =
+          if line.source == t"" then e""
+          else e"${Fg(palette.bytecode)}(${line.source})  "
+
+        e"$indent$src${line.instruction.opcode.teletype}"
+
+      . join(e"\n")
+
   object Opcode:
     private def typeKindToFrame(kind: jlc.TypeKind): Frame = kind match
       case jlc.TypeKind.BOOLEAN   => Frame.Z
@@ -1414,6 +1428,44 @@ case class Bytecode
       instruction.copy(line = instruction.line.let(_ + codepoint.line - 1))
 
     copy(sourceFile = codepoint.source.cut(t"/").last, instructions = instructions2)
+
+  def linearize
+    ( resolver:        (Text, Text, Text) => Optional[Bytecode],
+      maxDepth:        Int = 3,
+      maxInstructions: Int = 1000 )
+  :   List[Bytecode.Linearized] =
+
+    import Bytecode.Opcode.*
+    val staticCalls = effectivelyStaticCalls
+    val results = scala.collection.mutable.ListBuffer.empty[Bytecode.Linearized]
+    var budget = maxInstructions
+
+    def expand(bc: Bytecode, depth: Int, source: Text): Unit =
+      val callsite = bc.effectivelyStaticCalls
+
+      bc.instructions.iterator.takeWhile(_ => budget > 0).foreach: instr =>
+        budget -= 1
+
+        val target: Optional[(Text, Text, Text)] = instr.opcode match
+          case Invokestatic(o, n, d)                                          => (o, n, d)
+          case Invokevirtual(o, n, d)    if callsite.contains(instr.offset)   => (o, n, d)
+          case Invokeinterface(o, n, d, _) if callsite.contains(instr.offset) => (o, n, d)
+          case _                                                              => Unset
+
+        target.let: (owner, name, descriptor) =>
+          if depth >= maxDepth then results += Bytecode.Linearized(depth, source, instr)
+          else resolver(owner, name, descriptor) match
+            case bytecode: Bytecode =>
+              results += Bytecode.Linearized(depth, source, instr)
+              expand(bytecode, depth + 1, t"$owner.$name")
+
+            case _ =>
+              results += Bytecode.Linearized(depth, source, instr)
+
+        . or(results += Bytecode.Linearized(depth, source, instr))
+
+    expand(this, 0, t"")
+    results.toList
 
   def effectivelyStaticCalls: Set[Int] =
     import Bytecode.Opcode.*

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -87,6 +87,18 @@ class Classfile(data: Data):
 
         builder.result()
 
+      val stackMaps: Map[jlc.Label, List[Bytecode.Frame]] =
+        val attr =
+          code.attributes.nn.iterator.nn.asScala.collectFirst:
+            case smt: jlca.StackMapTableAttribute => smt
+
+        attr.fold(Map.empty): smt =>
+          smt.entries.nn.asScala.iterator.map: entry =>
+            val frames =
+              entry.stack.nn.asScala.toList.map(Bytecode.Frame.fromVerificationType).reverse
+            entry.target.nn -> frames
+          . toMap
+
       def recur
         ( todo:  List[jlc.CodeElement],
           line:  Optional[Int],
@@ -118,7 +130,10 @@ class Classfile(data: Data):
                 recur(todo, line, done, stack, count)
 
               case other: jlci.LabelTarget =>
-                recur(todo, line, done, stack, count)
+                val resetStack: Optional[List[Bytecode.Frame]] =
+                  stackMaps.get(other.label.nn).fold(stack)(identity)
+
+                recur(todo, line, done, resetStack, count)
 
               case other =>
                 panic(m"did not handle ${other.toString.tt}")

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -71,6 +71,19 @@ class Classfile(data: Data):
     def name: Text = model.methodName.nn.toString.tt
 
     def bytecode: Optional[Bytecode] = Optional(model.code().nn.get()).let: code =>
+      val elements = code.elementList.nn.asScala.to(List)
+
+      val labels: Map[jlc.Label, Int] =
+        val builder = Map.newBuilder[jlc.Label, Int]
+        var offset = 0
+
+        elements.foreach:
+          case instr: jlc.Instruction       => offset += instr.sizeInBytes
+          case target: jlci.LabelTarget     => builder += target.label.nn -> offset
+          case _                            => ()
+
+        builder.result()
+
       def recur
         ( todo:  List[jlc.CodeElement],
           line:  Optional[Int],
@@ -85,7 +98,7 @@ class Classfile(data: Data):
           case next :: todo =>
             next match
               case instruction: jlc.Instruction =>
-                val opcode = Bytecode.Opcode(instruction)
+                val opcode = Bytecode.Opcode(instruction, labels)
                 val stack2 = stack.let(opcode.transform(_))
 
                 recur
@@ -108,7 +121,7 @@ class Classfile(data: Data):
                 panic(m"did not handle ${other.toString.tt}")
 
 
-      val instructions = recur(code.elementList.nn.asScala.to(List), Unset, Nil, Nil, 0)
+      val instructions = recur(elements, Unset, Nil, Nil, 0)
 
       Bytecode(sourceFile, instructions)
 

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -70,7 +70,10 @@ class Classfile(data: Data):
   class Method(model: jlc.MethodModel):
     def name: Text = model.methodName.nn.toString.tt
 
-    def bytecode: Optional[Bytecode] = Optional(model.code().nn.get()).let: code =>
+    def bytecode: Optional[Bytecode] = Optional(model.code().nn.get()).let: codeModel =>
+      val code: jlca.CodeAttribute = codeModel match
+        case attr: jlca.CodeAttribute => attr
+        case _                        => panic(m"code attribute not present")
       val elements = code.elementList.nn.asScala.to(List)
 
       val labels: Map[jlc.Label, Int] =
@@ -123,7 +126,7 @@ class Classfile(data: Data):
 
       val instructions = recur(elements, Unset, Nil, Nil, 0)
 
-      Bytecode(sourceFile, instructions)
+      Bytecode(sourceFile, instructions, code.maxStack, code.maxLocals)
 
   private lazy val model: jlc.ClassModel = jlc.ClassFile.of().nn.parse(unsafely(data.mutable)).nn
   lazy val methods: List[Method] = model.methods.nn.asScala.to(List).map(Method(_))

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -38,7 +38,35 @@ import classloaders.threadContext
 
 object Tests extends Suite(m"Mandible tests"):
   def run(): Unit =
-    test(m"Compile something"):
+    test(m"Locate a known method on a classfile"):
       val rewrite =
         Classfile[StackTrace].let(_.methods.find(_.name == t"rewrite").getOrElse(Unset)).vouch
     . assert()
+
+    test(m"Disassemble a known method's bytecode"):
+      val bytecode =
+        Classfile[StackTrace]
+        . let(_.methods.find(_.name == t"rewrite").getOrElse(Unset))
+        . let(_.bytecode)
+        . vouch
+      bytecode.instructions.size
+    . assert(_ > 0)
+
+    test(m"Bytecode carries declared maxStack and maxLocals"):
+      val bytecode =
+        Classfile[StackTrace]
+        . let(_.methods.find(_.name == t"rewrite").getOrElse(Unset))
+        . let(_.bytecode)
+        . vouch
+      (bytecode.maxStack, bytecode.maxLocals)
+    . assert((s, l) => s >= 0 && l >= 0)
+
+    test(m"Method descriptor parser handles primitives and references"):
+      Bytecode.Descriptor.parse(t"(Ljava/lang/String;I)V")
+    . assert: parsed =>
+        parsed.args.size == 2 && parsed.result.absent
+
+    test(m"Method descriptor parser handles array types and return"):
+      Bytecode.Descriptor.parse(t"([[Ljava/lang/Object;J)Z")
+    . assert: parsed =>
+        parsed.args.size == 2 && parsed.result == Bytecode.Frame.Z

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -70,3 +70,42 @@ object Tests extends Suite(m"Mandible tests"):
       Bytecode.Descriptor.parse(t"([[Ljava/lang/Object;J)Z")
     . assert: parsed =>
         parsed.args.size == 2 && parsed.result == Bytecode.Frame.Z
+
+    test(m"Detect virtual call as effectively static when receiver is a singleton"):
+      // Construct: GETSTATIC Foo$.MODULE$:LFoo$;  followed by  INVOKEVIRTUAL Foo$.doIt()V
+      val moduleFrame = Bytecode.Frame.L(t"Foo$$")
+      val getstatic =
+        Bytecode.Instruction
+          ( Bytecode.Opcode.Getstatic(t"Foo$$", t"MODULE$$", t"LFoo$$;"),
+            Unset,
+            moduleFrame :: Nil,
+            0 )
+
+      val invoke =
+        Bytecode.Instruction
+          ( Bytecode.Opcode.Invokevirtual(t"Foo$$", t"doIt", t"()V"),
+            Unset,
+            Nil,
+            3 )
+
+      Bytecode(Unset, List(getstatic, invoke), 1, 0).effectivelyStaticCalls
+    . assert(_ == Set(3))
+
+    test(m"A virtual call on an opaque receiver is not flagged as static"):
+      val opaqueFrame = Bytecode.Frame.L(t"?")
+      val getstatic =
+        Bytecode.Instruction
+          ( Bytecode.Opcode.Getstatic(t"Bar", t"thing", t"Ljava/lang/Object;"),
+            Unset,
+            opaqueFrame :: Nil,
+            0 )
+
+      val invoke =
+        Bytecode.Instruction
+          ( Bytecode.Opcode.Invokevirtual(t"Foo$$", t"doIt", t"()V"),
+            Unset,
+            Nil,
+            3 )
+
+      Bytecode(Unset, List(getstatic, invoke), 1, 0).effectivelyStaticCalls
+    . assert(_.isEmpty)

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -109,3 +109,41 @@ object Tests extends Suite(m"Mandible tests"):
 
       Bytecode(Unset, List(getstatic, invoke), 1, 0).effectivelyStaticCalls
     . assert(_.isEmpty)
+
+    test(m"Linearizer inlines a resolvable static-dispatchable call"):
+      val moduleFrame = Bytecode.Frame.L(t"Foo$$")
+      val getstatic =
+        Bytecode.Instruction
+          ( Bytecode.Opcode.Getstatic(t"Foo$$", t"MODULE$$", t"LFoo$$;"),
+            Unset,
+            moduleFrame :: Nil,
+            0 )
+
+      val invoke =
+        Bytecode.Instruction
+          ( Bytecode.Opcode.Invokevirtual(t"Foo$$", t"doIt", t"()V"),
+            Unset,
+            Nil,
+            3 )
+
+      val caller = Bytecode(Unset, List(getstatic, invoke), 1, 0)
+
+      val calleeBody =
+        Bytecode.Instruction(Bytecode.Opcode.Iconst1, Unset, Bytecode.Frame.I :: Nil, 0)
+        :: Bytecode.Instruction(Bytecode.Opcode.Ireturn, Unset, Nil, 1)
+        :: Nil
+      val callee = Bytecode(Unset, calleeBody, 1, 0)
+
+      val resolver: (Text, Text, Text) => Optional[Bytecode] =
+        (o, n, d) => if o == t"Foo$$" && n == t"doIt" then callee else Unset
+
+      caller.linearize(resolver, maxDepth = 2).map(_.depth)
+    . assert(_ == List(0, 0, 1, 1))
+
+    test(m"Linearizer respects maxInstructions budget"):
+      val noop =
+        Bytecode.Instruction(Bytecode.Opcode.Nop, Unset, Nil, 0)
+      val caller = Bytecode(Unset, List.fill(50)(noop), 0, 0)
+
+      caller.linearize((_, _, _) => Unset, maxInstructions = 7).size
+    . assert(_ == 7)


### PR DESCRIPTION
Mandible — the bytecode-visibility library — now produces correct
operand-stack snapshots at every instruction of a method, rather than
truncating at the first non-trivial opcode. The opcode parser reads
real operands (field references, method descriptors, branch targets,
local-variable slots, switch tables) from the JDK Classfile API rather
than dropping them as zeros; the per-instruction `transform` covers
the full opcode set; and the `StackMapTable` is consulted to reset the
stack at branch joins. Built on that, Mandible now flags
`invokevirtual` calls that are effectively static (Scala
singleton-object dispatch) and exposes a `linearize` API that splices
in the callee bytecode at every such call, recursively, under explicit
depth and instruction-count limits.

## Stack snapshots are now complete

`Bytecode.Opcode.transform` previously covered ~21 of ~200 opcodes
and threw on the rest, so `Bytecode.instructions` only carried a
populated `stack: Optional[List[Frame]]` for trivial methods. It now
covers every standard JVM opcode and uses parsed method descriptors
to pop receiver+args and push the return frame on the four `invoke*`
forms and `invokedynamic`.

## Real operand data on every opcode

Field, type-check, new/array, load/store/iinc, constants, branches
and switches now carry the resolved data from the typed
\`java.lang.classfile.instruction.*Instruction\` subclasses, instead of
the literal \`0\` previously emitted by the integer-based parser:

- \`Getstatic\` / \`Putstatic\` / \`Getfield\` / \`Putfield\` carry
  \`(owner, field, descriptor)\`.
- \`Invoke*\` instructions carry the method descriptor.
- \`New\`, \`Anewarray\`, \`Checkcast\`, \`Instanceof\`, \`Multianewarray\`
  carry their resolved class names.
- Branch and switch instructions carry absolute byte-offset targets,
  resolved against a label-position map built in a pre-pass over
  \`code.elementList\`.

## Stack reset at branch targets

\`Method.bytecode\` reads the classfile's \`StackMapTableAttribute\` and
seeds the running stack with the verifier-checked frame at each
labelled join point, so the tracked stack stays correct across
branches, loops and exception handlers.

## \`maxStack\` / \`maxLocals\` on \`Bytecode\`

\`\`\`scala
val bc: Bytecode = classfile.methods.find(_.name == t"foo")
                 . let(_.bytecode).vouch
bc.maxStack    // declared peak operand-stack depth
bc.maxLocals   // declared local-variable slot count
\`\`\`

## Singleton-call detection

\`\`\`scala
bc.effectivelyStaticCalls: Set[Int]
\`\`\`

returns the byte offsets of \`invokevirtual\` / \`invokeinterface\` calls
whose receiver is provably a Scala singleton object — i.e. the Frame
at the receiver position is \`L(Foo$)\` and the invoke target's owner
is \`Foo$\`. Object classes are \`final\` in Scala 3, so dispatch is
genuinely resolvable.

## Linearization

\`\`\`scala
val resolver: (Text, Text, Text) => Optional[Bytecode] = ...
val flat: List[Bytecode.Linearized] =
  bc.linearize(resolver, maxDepth = 3, maxInstructions = 1000)
\`\`\`

Each \`Linearized(depth, source, instruction)\` carries the inlining
depth and an \`owner.method\` source label; a provided \`Teletypeable\`
indents nested calls under their call sites. Calls the resolver
can't satisfy or that exceed the budget are kept verbatim. This is a
best-effort visualisation, not verifier-clean inlined bytecode —
local-slot remapping, branch offset rewriting and exception-handler
relocation are deliberately not attempted.