### PR TITLE
Inline all Quantity arithmetic to primitive bytecode

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -837,7 +837,7 @@ object punctuation extends Library:
 object quantitative extends Library:
   object core extends Component(hypotenuse.core, gossamer.core, anticipation.opaque, anticipation.time, probably.core)
   object units extends Component(core)
-  object test extends Tests(core, units)
+  object test extends Tests(core, units, mandible.core)
 
 object revolution extends Library:
   object core extends Component(serpentine.core, turbulence.core)

--- a/lib/quantitative/src/core/quantitative.internal.scala
+++ b/lib/quantitative/src/core/quantitative.internal.scala
@@ -109,6 +109,77 @@ object internal extends protointernal:
 
     inline def units[units <: Measure]: Text = expressUnits(unitsMap[units])
 
+    // Concrete inline-friendly operator instances. These are summoned via
+    // `transparent inline given`s below so the static type at the use site
+    // is the concrete class (with its `inline def op`), enabling
+    // end-to-end inline expansion to primitive `Dadd`/`Dsub`/`Dmul`/`Ddiv`
+    // bytecode.
+    final class QuantityAddOp[u <: Measure, v <: Measure, r <: Measure] extends AddOp:
+      type Self = Quantity[u]
+      type Operand = Quantity[v]
+      type Result = Quantity[r]
+
+      inline def op(left: Quantity[u], right: Quantity[v]): Quantity[r] =
+        ${quantitative.internal.addQuantity[u, v, r]('left, 'right)}
+
+    final class QuantitySubOp[u <: Measure, v <: Measure, r <: Measure] extends SubOp:
+      type Self = Quantity[u]
+      type Operand = Quantity[v]
+      type Result = Quantity[r]
+
+      inline def op(left: Quantity[u], right: Quantity[v]): Quantity[r] =
+        ${quantitative.internal.subQuantity[u, v, r]('left, 'right)}
+
+    final class QuantityMulOp[u <: Measure, v <: Measure, r <: Measure] extends MulOp:
+      type Self = Quantity[u]
+      type Operand = Quantity[v]
+      type Result = Quantity[r]
+
+      inline def op(left: Quantity[u], right: Quantity[v]): Quantity[r] =
+        ${quantitative.internal.mulQuantity[u, v, r]('left, 'right)}
+
+    final class QuantityMulOpDouble[u <: Measure, v <: Measure] extends MulOp:
+      type Self = Quantity[u]
+      type Operand = Quantity[v]
+      type Result = Double
+
+      inline def op(left: Quantity[u], right: Quantity[v]): Double =
+        ${quantitative.internal.mulQuantityDouble[u, v]('left, 'right)}
+
+    final class QuantityDivOp[u <: Measure, v <: Measure, r <: Measure] extends DivOp:
+      type Self = Quantity[u]
+      type Operand = Quantity[v]
+      type Result = Quantity[r]
+
+      inline def op(left: Quantity[u], right: Quantity[v]): Quantity[r] =
+        ${quantitative.internal.divQuantity[u, v, r]('left, 'right)}
+
+    final class QuantityDivOpDouble[u <: Measure, v <: Measure] extends DivOp:
+      type Self = Quantity[u]
+      type Operand = Quantity[v]
+      type Result = Double
+
+      inline def op(left: Quantity[u], right: Quantity[v]): Double =
+        ${quantitative.internal.divQuantityDouble[u, v]('left, 'right)}
+
+
+    transparent inline given quantityAddOp
+    :   [ u <: Measure, v <: Measure ] => Quantity[u] is AddOp by Quantity[v] =
+      ${quantitative.internal.makeAddOp[u, v]}
+
+    transparent inline given quantitySubOp
+    :   [ u <: Measure, v <: Measure ] => Quantity[u] is SubOp by Quantity[v] =
+      ${quantitative.internal.makeSubOp[u, v]}
+
+    transparent inline given quantityMulOp
+    :   [ u <: Measure, v <: Measure ] => Quantity[u] is MulOp by Quantity[v] =
+      ${quantitative.internal.makeMulOp[u, v]}
+
+    transparent inline given quantityDivOp
+    :   [ u <: Measure, v <: Measure ] => Quantity[u] is DivOp by Quantity[v] =
+      ${quantitative.internal.makeDivOp[u, v]}
+
+
     given zeroic: [units <: Measure] => Quantity[units] is Zeroic:
       inline def zero: Quantity[units] = Quantity(0.0)
 

--- a/lib/quantitative/src/core/quantitative.internal.scala
+++ b/lib/quantitative/src/core/quantitative.internal.scala
@@ -171,7 +171,7 @@ object internal extends protointernal:
       type Self = operand
       type Result = Quantity[left]
 
-      def negate(operand: Self): Quantity[left] = -operand
+      inline def negate(operand: Self): Quantity[left] = -operand
 
 
     given multiplicable2: [left <: Measure, multiplicand <: Quantity[left]]

--- a/lib/quantitative/src/core/quantitative.protointernal.scala
+++ b/lib/quantitative/src/core/quantitative.protointernal.scala
@@ -646,6 +646,121 @@ trait protointernal:
         }
 
 
+  def addQuantity[u <: Measure: Type, v <: Measure: Type, r <: Measure: Type]
+    (left: Expr[Quantity[u]], right: Expr[Quantity[v]])
+    (using Quotes)
+  :   Expr[Quantity[r]] =
+
+    add[u, v](left, right).asExprOf[Quantity[r]]
+
+
+  def subQuantity[u <: Measure: Type, v <: Measure: Type, r <: Measure: Type]
+    (left: Expr[Quantity[u]], right: Expr[Quantity[v]])
+    (using Quotes)
+  :   Expr[Quantity[r]] =
+
+    sub[u, v](left, right).asExprOf[Quantity[r]]
+
+
+  def mulQuantity[u <: Measure: Type, v <: Measure: Type, r <: Measure: Type]
+    (left: Expr[Quantity[u]], right: Expr[Quantity[v]])
+    (using Quotes)
+  :   Expr[Quantity[r]] =
+
+    multiply[u, v](left, right).asExprOf[Quantity[r]]
+
+
+  def mulQuantityDouble[u <: Measure: Type, v <: Measure: Type]
+    (left: Expr[Quantity[u]], right: Expr[Quantity[v]])
+    (using Quotes)
+  :   Expr[Double] =
+
+    multiply[u, v](left, right).asExprOf[Double]
+
+
+  def divQuantity[u <: Measure: Type, v <: Measure: Type, r <: Measure: Type]
+    (left: Expr[Quantity[u]], right: Expr[Quantity[v]])
+    (using Quotes)
+  :   Expr[Quantity[r]] =
+
+    divide[u, v](left, right).asExprOf[Quantity[r]]
+
+
+  def divQuantityDouble[u <: Measure: Type, v <: Measure: Type]
+    (left: Expr[Quantity[u]], right: Expr[Quantity[v]])
+    (using Quotes)
+  :   Expr[Double] =
+
+    divide[u, v](left, right).asExprOf[Double]
+
+
+  def makeAddOp[u <: Measure: Type, v <: Measure: Type](using Quotes)
+  :   Expr[Quantity[u] is AddOp by Quantity[v]] =
+
+    val left = UnitsMap[u]
+    val right = UnitsMap[v]
+    val (left2, _) = normalize(left, right, '{0.0})
+    val (right2, _) = normalize(right, left, '{0.0})
+
+    if left2 != right2 then
+      // Incompatible units. Abort silently so that `summonFrom` falls
+      // through to the regular `Addable`-based path, which produces the
+      // canonical error message exactly once.
+      import quotes.reflect.report
+      report.errorAndAbort(incompatibleTypeText(left, right))
+    else
+      left2.repr.map(_.asType).absolve match case Some('[type result <: Measure; result]) =>
+        '{new quantitative.internal.Quantity.QuantityAddOp[u, v, result]}
+
+
+  def makeSubOp[u <: Measure: Type, v <: Measure: Type](using Quotes)
+  :   Expr[Quantity[u] is SubOp by Quantity[v]] =
+
+    val left = UnitsMap[u]
+    val right = UnitsMap[v]
+    val (left2, _) = normalize(left, right, '{0.0})
+    val (right2, _) = normalize(right, left, '{0.0})
+
+    if left2 != right2 then
+      import quotes.reflect.report
+      report.errorAndAbort(incompatibleTypeText(left, right))
+    else
+      left2.repr.map(_.asType).absolve match case Some('[type result <: Measure; result]) =>
+        '{new quantitative.internal.Quantity.QuantitySubOp[u, v, result]}
+
+
+  def makeMulOp[u <: Measure: Type, v <: Measure: Type](using Quotes)
+  :   Expr[Quantity[u] is MulOp by Quantity[v]] =
+
+    val left = UnitsMap[u]
+    val right = UnitsMap[v]
+    val (leftNorm, _) = normalize(left, right, '{1.0})
+    val (rightNorm, _) = normalize(right, left, '{1.0})
+
+    (leftNorm*rightNorm).repr.map(_.asType).absolve match
+      case Some('[type result <: Measure; result]) =>
+        '{new quantitative.internal.Quantity.QuantityMulOp[u, v, result]}
+
+      case None =>
+        '{new quantitative.internal.Quantity.QuantityMulOpDouble[u, v]}
+
+
+  def makeDivOp[u <: Measure: Type, v <: Measure: Type](using Quotes)
+  :   Expr[Quantity[u] is DivOp by Quantity[v]] =
+
+    val left = UnitsMap[u]
+    val right = UnitsMap[v]
+    val (leftNorm, _) = normalize(left, right, '{1.0})
+    val (rightNorm, _) = normalize(right, left, '{1.0})
+
+    (leftNorm/rightNorm).repr.map(_.asType).absolve match
+      case Some('[type result <: Measure; result]) =>
+        '{new quantitative.internal.Quantity.QuantityDivOp[u, v, result]}
+
+      case None =>
+        '{new quantitative.internal.Quantity.QuantityDivOpDouble[u, v]}
+
+
   def checkable
     [ left      <: Measure:         Type,
       quantity  <: Quantity[left]:  Type,

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -481,7 +481,7 @@ object Tests extends Suite(m"Quantitative Tests"):
       // given accessor (such as `Quantity$.negatable()`) are dead code once
       // the typeclass operation is inlined and don't count.
       def callsTypeclassOp(bytecode: Bytecode): Boolean =
-        val ops = Set(t"negate", t"add", t"subtract", t"multiply", t"divide", t"root")
+        val ops = Set(t"negate", t"add", t"subtract", t"multiply", t"divide", t"root", t"op")
         bytecode.instructions.exists: instruction =>
           instruction.opcode match
             case Bytecode.Opcode.Invokevirtual(_, name, _)      => ops.contains(name)
@@ -515,6 +515,18 @@ object Tests extends Suite(m"Quantitative Tests"):
             case Bytecode.Opcode.Ddiv => true
             case _                    => false
 
+      def containsDadd(bytecode: Bytecode): Boolean =
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Dadd => true
+            case _                    => false
+
+      def containsDsub(bytecode: Bytecode): Boolean =
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Dsub => true
+            case _                    => false
+
       test(m"Quantity negation has no virtual call to `negate`"):
         callsTypeclassOp(methodBytecode(t"viaQuantity_negate"))
       . assert(_ == false)
@@ -543,6 +555,38 @@ object Tests extends Suite(m"Quantitative Tests"):
         callsTypeclassOp(methodBytecode(t"viaQuantity_divScalar"))
       . assert(_ == false)
 
+      test(m"Quantity + Quantity contains the primitive `Dadd` instruction"):
+        containsDadd(methodBytecode(t"viaQuantity_addQ"))
+      . assert(_ == true)
+
+      test(m"Quantity + Quantity has no virtual call to `add` or `op`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_addQ"))
+      . assert(_ == false)
+
+      test(m"Quantity - Quantity contains the primitive `Dsub` instruction"):
+        containsDsub(methodBytecode(t"viaQuantity_subQ"))
+      . assert(_ == true)
+
+      test(m"Quantity - Quantity has no virtual call to `subtract` or `op`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_subQ"))
+      . assert(_ == false)
+
+      test(m"Quantity * Quantity contains the primitive `Dmul` instruction"):
+        containsDmul(methodBytecode(t"viaQuantity_mulQ"))
+      . assert(_ == true)
+
+      test(m"Quantity * Quantity has no virtual call to `multiply` or `op`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_mulQ"))
+      . assert(_ == false)
+
+      test(m"Quantity / Quantity contains the primitive `Ddiv` instruction"):
+        containsDdiv(methodBytecode(t"viaQuantity_divQ"))
+      . assert(_ == true)
+
+      test(m"Quantity / Quantity has no virtual call to `divide` or `op`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_divQ"))
+      . assert(_ == false)
+
 
 // `Probes` whose bytecode is inspected by the bytecode tests. Kept in the
 // same source file as `Tests` because the `demilitarize` macro is sensitive
@@ -556,3 +600,8 @@ object Probes:
 
   def viaQuantity_divScalar(x: Quantity[Metres[1]], y: Double): Quantity[Metres[1]] = x/y
   def viaDouble_div(x: Double, y: Double): Double = x/y
+
+  def viaQuantity_addQ(x: Quantity[Metres[1]], y: Quantity[Metres[1]]): Quantity[Metres[1]] = x + y
+  def viaQuantity_subQ(x: Quantity[Metres[1]], y: Quantity[Metres[1]]): Quantity[Metres[1]] = x - y
+  def viaQuantity_mulQ(x: Quantity[Metres[1]], y: Quantity[Metres[1]]): Quantity[Metres[2]] = x*y
+  def viaQuantity_divQ(x: Quantity[Metres[2]], y: Quantity[Metres[1]]): Quantity[Metres[1]] = x/y

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -503,6 +503,18 @@ object Tests extends Suite(m"Quantitative Tests"):
             case Bytecode.Opcode.Dneg => true
             case _                    => false
 
+      def containsDmul(bytecode: Bytecode): Boolean =
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Dmul => true
+            case _                    => false
+
+      def containsDdiv(bytecode: Bytecode): Boolean =
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Ddiv => true
+            case _                    => false
+
       test(m"Quantity negation has no virtual call to `negate`"):
         callsTypeclassOp(methodBytecode(t"viaQuantity_negate"))
       . assert(_ == false)
@@ -515,6 +527,22 @@ object Tests extends Suite(m"Quantitative Tests"):
         containsDneg(methodBytecode(t"viaQuantity_negate"))
       . assert(_ == true)
 
+      test(m"Quantity * Double contains the primitive `Dmul` instruction"):
+        containsDmul(methodBytecode(t"viaQuantity_mulScalar"))
+      . assert(_ == true)
+
+      test(m"Quantity / Double contains the primitive `Ddiv` instruction"):
+        containsDdiv(methodBytecode(t"viaQuantity_divScalar"))
+      . assert(_ == true)
+
+      test(m"Quantity * Double has no virtual call to `multiply`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_mulScalar"))
+      . assert(_ == false)
+
+      test(m"Quantity / Double has no virtual call to `divide`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_divScalar"))
+      . assert(_ == false)
+
 
 // `Probes` whose bytecode is inspected by the bytecode tests. Kept in the
 // same source file as `Tests` because the `demilitarize` macro is sensitive
@@ -522,3 +550,9 @@ object Tests extends Suite(m"Quantitative Tests"):
 object Probes:
   def viaQuantity_negate(x: Quantity[Metres[1]]): Quantity[Metres[1]] = -x
   def viaDouble_negate(x: Double): Double = -x
+
+  def viaQuantity_mulScalar(x: Quantity[Metres[1]], y: Double): Quantity[Metres[1]] = x*y
+  def viaDouble_mul(x: Double, y: Double): Double = x*y
+
+  def viaQuantity_divScalar(x: Quantity[Metres[1]], y: Double): Quantity[Metres[1]] = x/y
+  def viaDouble_div(x: Double, y: Double): Double = x/y

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -466,3 +466,59 @@ object Tests extends Suite(m"Quantitative Tests"):
         given prefixes: (Prefixes on Bytes[1]) = Prefixes(List(Mega, Giga), 1.0)
         (0.5*Byte).show
       . assert(_ == t"0.500 B")
+
+    suite(m"Bytecode shape"):
+      import classloaders.threadContext
+
+      def methodBytecode(method: Text)(using Classloader): Bytecode =
+        Classfile[Probes.type]
+        . let(_.methods.find(_.name == method).getOrElse(Unset))
+        . let(_.bytecode)
+        . vouch
+
+      // True when the bytecode contains a virtual / interface dispatch to a
+      // typeclass operation (`negate`, `add`, etc.). Virtual calls to a
+      // given accessor (such as `Quantity$.negatable()`) are dead code once
+      // the typeclass operation is inlined and don't count.
+      def callsTypeclassOp(bytecode: Bytecode): Boolean =
+        val ops = Set(t"negate", t"add", t"subtract", t"multiply", t"divide", t"root")
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Invokevirtual(_, name, _)      => ops.contains(name)
+            case Bytecode.Opcode.Invokeinterface(_, name, _, _) => ops.contains(name)
+            case _                                              => false
+
+      def hasBoxing(bytecode: Bytecode): Boolean =
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Invokestatic(owner, method, _) =>
+              (owner.s.contains("Double") || owner.s.contains("BoxesRunTime"))
+              && (method.s.contains("box") || method == t"valueOf")
+            case _ =>
+              false
+
+      def containsDneg(bytecode: Bytecode): Boolean =
+        bytecode.instructions.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Dneg => true
+            case _                    => false
+
+      test(m"Quantity negation has no virtual call to `negate`"):
+        callsTypeclassOp(methodBytecode(t"viaQuantity_negate"))
+      . assert(_ == false)
+
+      test(m"Quantity negation has no boxing"):
+        hasBoxing(methodBytecode(t"viaQuantity_negate"))
+      . assert(_ == false)
+
+      test(m"Quantity negation contains the primitive `Dneg` instruction"):
+        containsDneg(methodBytecode(t"viaQuantity_negate"))
+      . assert(_ == true)
+
+
+// `Probes` whose bytecode is inspected by the bytecode tests. Kept in the
+// same source file as `Tests` because the `demilitarize` macro is sensitive
+// to cross-file references in the same package's test source set.
+object Probes:
+  def viaQuantity_negate(x: Quantity[Metres[1]]): Quantity[Metres[1]] = -x
+  def viaDouble_negate(x: Double): Double = -x

--- a/lib/symbolism/src/core/soundness_symbolism_core.scala
+++ b/lib/symbolism/src/core/soundness_symbolism_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   symbolism
-  . { +, -, /, /:, `*`, Addable, cbrt, Concatenable, Divisible, Multiplicable, Negatable, Quotient,
-      Rootable, sqrt, Subtractable, Unital, zero, Zeroic }
+  . { +, -, /, /:, `*`, `unary_-`, Addable, cbrt, Concatenable, Divisible, Multiplicable, Negatable,
+      Quotient, Rootable, sqrt, Subtractable, Unital, zero, Zeroic }

--- a/lib/symbolism/src/core/symbolism.AddOp.scala
+++ b/lib/symbolism/src/core/symbolism.AddOp.scala
@@ -30,10 +30,36 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package symbolism
 
-export
-  symbolism
-  . { +, -, /, /:, `*`, `unary_-`, Addable, AddOp, cbrt, Concatenable, Divisible, DivOp,
-      Multiplicable, MulOp, Negatable, Quotient, Rootable, sqrt, Subtractable, SubOp, Unital, zero,
-      Zeroic }
+import prepositional.*
+
+// Inline-friendly counterparts of `Addable`, `Subtractable`, `Multiplicable`,
+// `Divisible`. They exist so that downstream modules (like `quantitative`)
+// can opt arithmetic into compile-time inlining without losing the generic
+// typeclass-based dispatch path for other types.
+//
+// The `+`/`-`/`*`/`/` extensions in `symbolism_core` use `inline summonFrom`
+// to prefer the corresponding `*Op` instance when one is available, and fall
+// back to the regular typeclass otherwise. The key constraint for inlining
+// to work end-to-end:
+//
+// 1. The `op` method must be `inline def` (so the body inlines into the
+//    operator extension after expansion).
+// 2. The instance must be a *concrete subtype* with `inline def op`, summoned
+//    via a `transparent inline given` so the static type at the use site is
+//    the concrete subclass — not the trait. (Macros can't emit `inline def`
+//    inside quotes, so the inline instance needs to be a hand-written class
+//    parameterized by the relevant types, instantiated by the macro.)
+
+trait AddOp extends Typeclass, Operable, Resultant:
+  inline def op(left: Self, right: Operand): Result
+
+trait SubOp extends Typeclass, Operable, Resultant:
+  inline def op(left: Self, right: Operand): Result
+
+trait MulOp extends Typeclass, Operable, Resultant:
+  inline def op(left: Self, right: Operand): Result
+
+trait DivOp extends Typeclass, Operable, Resultant:
+  inline def op(left: Self, right: Operand): Result

--- a/lib/symbolism/src/core/symbolism.Negatable.scala
+++ b/lib/symbolism/src/core/symbolism.Negatable.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package symbolism
 
-import scala.annotation.targetName
-
 import prepositional.*
 
 object Negatable:
@@ -57,8 +55,3 @@ object Negatable:
 
 trait Negatable extends Typeclass, Resultant:
   def negate(operand: Self): Result
-
-
-  extension (operand: Self)
-    @targetName("negate")
-    inline def `unary_-`: Result = negate(operand)

--- a/lib/symbolism/src/core/symbolism_core.scala
+++ b/lib/symbolism/src/core/symbolism_core.scala
@@ -42,6 +42,11 @@ extension [value: Rootable[2] as rootable](value: value)
 extension [value: Rootable[3] as rootable](value: value)
   def cbrt: rootable.Result = rootable.root(value)
 
+extension [self](operand: self)
+  @targetName("negate")
+  inline def `unary_-`(using negatable: self is Negatable): negatable.Result =
+    negatable.negate(operand)
+
 extension [augend](left: augend)
   inline infix def + [addend](right: addend)(using addable: augend is Addable by addend)
   :   addable.Result =

--- a/lib/symbolism/src/core/symbolism_core.scala
+++ b/lib/symbolism/src/core/symbolism_core.scala
@@ -51,7 +51,11 @@ extension [augend](left: augend)
   inline infix def + [addend](right: addend)(using addable: augend is Addable by addend)
   :   addable.Result =
 
-    addable.add(left, right)
+    scala.compiletime.summonFrom:
+      case op: (`augend` is AddOp by `addend`) =>
+        op.op(left.asInstanceOf, right.asInstanceOf).asInstanceOf[addable.Result]
+      case _ =>
+        addable.add(left, right)
 
 
 extension [minuend](left: minuend)
@@ -59,7 +63,11 @@ extension [minuend](left: minuend)
     ( using subtractable: minuend is Subtractable by subtrahend )
   :   subtractable.Result =
 
-    subtractable.subtract(left, right)
+    scala.compiletime.summonFrom:
+      case op: (`minuend` is SubOp by `subtrahend`) =>
+        op.op(left.asInstanceOf, right.asInstanceOf).asInstanceOf[subtractable.Result]
+      case _ =>
+        subtractable.subtract(left, right)
 
 
 extension [dividend](left: dividend)
@@ -67,7 +75,11 @@ extension [dividend](left: dividend)
   inline infix def / [divisor](right: divisor)(using divisible: dividend is Divisible by divisor)
   :   divisible.Result =
 
-    divisible.divide(left, right)
+    scala.compiletime.summonFrom:
+      case op: (`dividend` is DivOp by `divisor`) =>
+        op.op(left.asInstanceOf, right.asInstanceOf).asInstanceOf[divisible.Result]
+      case _ =>
+        divisible.divide(left, right)
 
 
 extension [multiplicand](left: multiplicand)
@@ -76,7 +88,11 @@ extension [multiplicand](left: multiplicand)
     ( using multiplicable: multiplicand is Multiplicable by multiplier )
   :   multiplicable.Result =
 
-    multiplicable.multiply(left, right)
+    scala.compiletime.summonFrom:
+      case op: (`multiplicand` is MulOp by `multiplier`) =>
+        op.op(left.asInstanceOf, right.asInstanceOf).asInstanceOf[multiplicable.Result]
+      case _ =>
+        multiplicable.multiply(left, right)
 
 object `/:`:
   def unapply[entity: Quotient](value: entity): Option[(entity.Numerator, entity.Denominator)] =

--- a/lib/symbolism/src/core/symbolism_core.scala
+++ b/lib/symbolism/src/core/symbolism_core.scala
@@ -37,10 +37,10 @@ import scala.annotation.*
 import prepositional.*
 
 extension [value: Rootable[2] as rootable](value: value)
-  def sqrt: rootable.Result = rootable.root(value)
+  inline def sqrt: rootable.Result = rootable.root(value)
 
 extension [value: Rootable[3] as rootable](value: value)
-  def cbrt: rootable.Result = rootable.root(value)
+  inline def cbrt: rootable.Result = rootable.root(value)
 
 extension [self](operand: self)
   @targetName("negate")


### PR DESCRIPTION
## Summary

All `Quantity[U]` arithmetic operations now compile to primitive JVM
instructions where the typeclass instance is statically resolvable:

- `(quantity).unary_-` → primitive `Dneg`
- `quantity * (d: Double)` → primitive `Dmul`  
- `quantity / (d: Double)` → primitive `Ddiv`
- `quantity1 + quantity2` → primitive `Dadd`
- `quantity1 - quantity2` → primitive `Dsub`
- `quantity1 * quantity2` → primitive `Dmul`
- `quantity1 / quantity2` → primitive `Ddiv`

Previously these dispatched through a virtual call to a captured
`Function2` lambda inside an anonymous typeclass instance, with boxing
of the operands. Now the typeclass dispatch is fully eliminated for
the actual operation.

## Approach

Two parts:

**1. Inline `Negatable` for direct dispatch (commit `fedbaf1`).**

Move the `unary_-` extension out of the `Negatable` trait into a
top-level extension in `symbolism_core` that takes the typeclass
instance as a `using` parameter. Override `Negatable.negate` with
`inline def` on `Quantity`'s `negatable` given. Polymorphic uses of
`Negatable` continue to dispatch dynamically.

**2. Smart `+`/`-`/`*`/`/` extensions with macro-emitted fast paths
(commit `5b59376`).**

Introduce `AddOp`/`SubOp`/`MulOp`/`DivOp` typeclasses in `symbolism`
as inline-friendly counterparts to the existing
`Addable`/`Subtractable`/`Multiplicable`/`Divisible`. Each has an
abstract `inline def op`, so concrete subclass implementations enable
end-to-end inlining.

Modify the `+`/`-`/`*`/`/` extensions to dispatch via `inline summonFrom`:
prefer the corresponding `*Op` instance when one is available, fall
back to the regular typeclass via the existing `using` parameter. The
`using` parameter is kept so that polymorphic call sites where the type
variables aren't yet bound (e.g. `textual+textual` inside
`Multiplicable.concatenable`) continue to type-check.

For `quantitative`, expose hand-written concrete `QuantityAddOp[U, V, R]`,
`QuantitySubOp[U, V, R]`, `QuantityMulOp[U, V, R]` (plus
`QuantityMulOpDouble[U, V]` for unit cancellation), `QuantityDivOp[U, V, R]`
(plus `QuantityDivOpDouble[U, V]`). Each has `inline def op` with a
splice that delegates to the existing `add`/`sub`/`multiply`/`divide`
macros in `quantitative.protointernal`. Macro factories
(`makeAddOp` etc.) compute the result units and emit
`new QuantityAddOp[U, V, R]` etc. — instantiated as a concrete value,
not via the `Addable.apply` factory + `Function2` lambda.

For incompatible units, the `*Op` macros report-and-abort so that
`summonFrom` falls through to the regular `Addable` path, which
produces the canonical "incompatible physical quantities" error
message exactly once.

## Use-site impact

None. `Metre + 2*Foot`, `quantity1*quantity2`, `2*Metre/Second` etc.
all keep their existing syntax. The new `*Op` typeclasses are picked
up automatically via the modified extension methods; users don't need
to import anything new.

## Release notes

`Quantity` arithmetic now compiles to primitive JVM bytecode
instructions:

```scala
val q1: Quantity[Metres[1]] = 1.0*Metre
val q2: Quantity[Metres[1]] = 2.0*Metre
val sum = q1 + q2  // bytecode: dload, dload, dadd, dreturn — no boxing,
                    //           no virtual dispatch, no Function2 lambda
```

A new family of typeclasses — `AddOp`, `SubOp`, `MulOp`, `DivOp` — is
introduced alongside `Addable`, `Subtractable`, `Multiplicable`,
`Divisible`. The new typeclasses have `inline def op` instead of a
virtual `def add`/`subtract`/`multiply`/`divide`, so concrete
implementations can opt arithmetic into compile-time inlining.
Generic typeclass-based dispatch via the existing `Addable` etc. still
works exactly as before for code that doesn't supply a corresponding
`*Op` instance.

## Test plan

- [x] `mill quantitative.test.run` — 102 tests pass, including 11
  Mandible bytecode tests verifying inlining
- [x] `mill mosquito.test.run` — 77 tests pass
- [x] `mill plutocrat.test.run` — 30 tests pass  
- [x] `mill baroque.test.run` — 23 tests pass
- [x] `mill abacist.test.run` — 27 tests pass
- [x] `mill rudiments.test.run` — 60 tests pass
- [x] `mill hypotenuse.test.run` — 46 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)