### PR TITLE
Extend Mosquito with common linear-algebra operations

### DIFF
--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -33,6 +33,7 @@
 package mosquito
 
 import scala.compiletime.*
+import scala.compiletime.ops.int.-
 
 import anticipation.*
 import gossamer.*
@@ -382,6 +383,129 @@ object Matrix:
         new Matrix[element, n, n](dimension, dimension, resultElements)
 
 
+  extension [n <: Int](matrix: Matrix[Double, n, n])
+    def eigensystem(using ValueOf[n])
+    :   Optional[(Tensor[Double, n], Matrix[Double, n, n])] =
+
+      val dimension = matrix.rows
+      val tolerance = 1.0e-12
+      val maxIterations = 100*dimension*dimension
+
+      var symmetric = true
+      var checkRow = 0
+      while checkRow < dimension && symmetric do
+        var checkCol = checkRow + 1
+        while checkCol < dimension && symmetric do
+          if math.abs(matrix(checkRow, checkCol) - matrix(checkCol, checkRow)) > tolerance
+          then symmetric = false
+          checkCol += 1
+
+        checkRow += 1
+
+      if !symmetric then Unset
+      else
+        val mat: Array[Double] = matrix.elements.mutable(using Unsafe).clone()
+        val vec: Array[Double] = new Array[Double](dimension*dimension)
+        var diagIndex = 0
+        while diagIndex < dimension do
+          vec(dimension*diagIndex + diagIndex) = 1.0
+          diagIndex += 1
+
+        var iteration = 0
+        var converged = false
+
+        while !converged && iteration < maxIterations do
+          var maxAbs = 0.0
+          var p = 0
+          var q = 0
+          var i = 0
+          while i < dimension do
+            var j = i + 1
+            while j < dimension do
+              val absValue = math.abs(mat(dimension*i + j))
+              if absValue > maxAbs then
+                maxAbs = absValue
+                p = i
+                q = j
+
+              j += 1
+
+            i += 1
+
+          if maxAbs < tolerance then converged = true
+          else
+            val mpp = mat(dimension*p + p)
+            val mqq = mat(dimension*q + q)
+            val mpq = mat(dimension*p + q)
+
+            val theta = (mqq - mpp)/(2.0*mpq)
+
+            val tan =
+              if theta >= 0.0 then 1.0/(theta + math.sqrt(theta*theta + 1.0))
+              else 1.0/(theta - math.sqrt(theta*theta + 1.0))
+
+            val cos = 1.0/math.sqrt(1.0 + tan*tan)
+            val sin = tan*cos
+
+            val newMpp = cos*cos*mpp - 2.0*cos*sin*mpq + sin*sin*mqq
+            val newMqq = sin*sin*mpp + 2.0*cos*sin*mpq + cos*cos*mqq
+
+            mat(dimension*p + p) = newMpp
+            mat(dimension*q + q) = newMqq
+            mat(dimension*p + q) = 0.0
+            mat(dimension*q + p) = 0.0
+
+            var rotateIndex = 0
+            while rotateIndex < dimension do
+              if rotateIndex != p && rotateIndex != q then
+                val mip = mat(dimension*rotateIndex + p)
+                val miq = mat(dimension*rotateIndex + q)
+                val updatedMip = cos*mip - sin*miq
+                val updatedMiq = sin*mip + cos*miq
+                mat(dimension*rotateIndex + p) = updatedMip
+                mat(dimension*rotateIndex + q) = updatedMiq
+                mat(dimension*p + rotateIndex) = updatedMip
+                mat(dimension*q + rotateIndex) = updatedMiq
+
+              rotateIndex += 1
+
+            var vecIndex = 0
+            while vecIndex < dimension do
+              val vkp = vec(dimension*vecIndex + p)
+              val vkq = vec(dimension*vecIndex + q)
+              vec(dimension*vecIndex + p) = cos*vkp - sin*vkq
+              vec(dimension*vecIndex + q) = sin*vkp + cos*vkq
+              vecIndex += 1
+
+          iteration += 1
+
+        if !converged then Unset
+        else
+          val eigvalArr = IArray.build[Any](dimension): array =>
+            var i = 0
+            while i < dimension do
+              array(i) = mat(dimension*i + i)
+              i += 1
+
+          val eigvecArr = IArray.build[Double](dimension*dimension): array =>
+            var i = 0
+            while i < dimension*dimension do
+              array(i) = vec(i)
+              i += 1
+
+          val eigvals = new Tensor[Double, n](eigvalArr)
+          val eigvecs = new Matrix[Double, n, n](dimension, dimension, eigvecArr)
+          (eigvals, eigvecs)
+
+
+    def eigenvalues(using ValueOf[n]): Optional[Tensor[Double, n]] =
+      matrix.eigensystem.let(_(0))
+
+
+    def eigenvectors(using ValueOf[n]): Optional[Matrix[Double, n, n]] =
+      matrix.eigensystem.let(_(1))
+
+
 class Matrix[element, rows <: Int, columns <: Int]
   ( val rows: Int, val columns: Int, val elements: IArray[element] ):
 
@@ -420,6 +544,94 @@ class Matrix[element, rows <: Int, columns <: Int]
         row += 1
 
     new Matrix[element, columns, rows](columns, rows, arr)
+
+
+  def submatrix(droppedRow: Int, droppedColumn: Int)(using ClassTag[element])
+  :   Matrix[element, rows - 1, columns - 1] =
+
+    val newRows = rows - 1
+    val newCols = columns - 1
+
+    val arr = IArray.build[element](newRows*newCols): array =>
+      var r = 0
+      while r < newRows do
+        var c = 0
+        while c < newCols do
+          val origRow = if r < droppedRow then r else r + 1
+          val origCol = if c < droppedColumn then c else c + 1
+          array(newCols*r + c) = elements(columns*origRow + origCol)
+          c += 1
+
+        r += 1
+
+    new Matrix[element, rows - 1, columns - 1](newRows, newCols, arr)
+
+
+  def frobeniusNorm
+    ( using multiplicable: element is Multiplicable by element,
+            addable:       multiplicable.Result is Addable by multiplicable.Result
+                           to multiplicable.Result,
+            rootable:      multiplicable.Result is Rootable[2] to element )
+  :   element =
+
+    val length = elements.length
+    var sum: multiplicable.Result = elements(0)*elements(0)
+    var i = 1
+    while i < length do
+      sum = addable.add(sum, elements(i)*elements(i))
+      i += 1
+
+    sum.sqrt
+
+
+  def rank
+    ( using zeroic:         element is Zeroic,
+            subtraction:    element is Subtractable by element to element,
+            multiplication: element is Multiplicable by element to element,
+            divisible:      element is Divisible by element to element )
+  :   Int =
+
+    val r = rows
+    val c = columns
+    val zero = zeroic.zero
+    val a: Array[element] = elements.mutable(using Unsafe).clone()
+
+    var rankCount = 0
+    var col = 0
+
+    while col < c && rankCount < r do
+      var pivotRow = -1
+      var i = rankCount
+      while i < r && pivotRow < 0 do
+        if a(c*i + col) != zero then pivotRow = i
+        i += 1
+
+      if pivotRow >= 0 then
+        if pivotRow != rankCount then
+          var k = 0
+          while k < c do
+            val tmp = a(c*rankCount + k)
+            a(c*rankCount + k) = a(c*pivotRow + k)
+            a(c*pivotRow + k) = tmp
+            k += 1
+
+        val pivotValue = a(c*rankCount + col)
+        var rowIdx = rankCount + 1
+
+        while rowIdx < r do
+          val factor = a(c*rowIdx + col)/pivotValue
+          var k = col
+          while k < c do
+            a(c*rowIdx + k) = a(c*rowIdx + k) - factor*a(c*rankCount + k)
+            k += 1
+
+          rowIdx += 1
+
+        rankCount += 1
+
+      col += 1
+
+    rankCount
 
   override def equals(right: Any): Boolean = right.asMatchable match
     case matrix: Matrix[?, ?, ?] => elements.sameElements(matrix.elements)

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -44,6 +44,8 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
+import mosquito.internal.Tensor
+
 object Matrix:
   given showable: [element: Showable] => Text is Measurable => Matrix[element, ?, ?] is Showable =
     matrix =>
@@ -66,6 +68,102 @@ object Matrix:
         . join(before, t" ", after)
 
       . join(t"\n")
+
+  given addable
+  :   [ a,
+        rows <: Int,
+        columns <: Int,
+        left <: Matrix[a, rows, columns],
+        b,
+        right <: Matrix[b, rows, columns],
+        result ]
+  =>  ( addable: a is Addable by b to result, classTag: ClassTag[result] )
+  =>  left is Addable:
+
+    type Operand = right
+    type Result = Matrix[result, rows, columns]
+
+    def add(left: left, right: right): Matrix[result, rows, columns] =
+      val length = left.elements.length
+
+      val arr = IArray.build[result](length): array =>
+        var i = 0
+        while i < length do
+          array(i) = addable.add(left.elements(i), right.elements(i))
+          i += 1
+
+      new Matrix[result, rows, columns](left.rows, left.columns, arr)
+
+
+  given subtractable
+  :   [ a,
+        rows <: Int,
+        columns <: Int,
+        left <: Matrix[a, rows, columns],
+        b,
+        right <: Matrix[b, rows, columns],
+        result ]
+  =>  ( subtractable: a is Subtractable by b to result, classTag: ClassTag[result] )
+  =>  left is Subtractable:
+
+    type Operand = right
+    type Result = Matrix[result, rows, columns]
+
+    def subtract(left: left, right: right): Matrix[result, rows, columns] =
+      val length = left.elements.length
+
+      val arr = IArray.build[result](length): array =>
+        var i = 0
+        while i < length do
+          array(i) = subtractable.subtract(left.elements(i), right.elements(i))
+          i += 1
+
+      new Matrix[result, rows, columns](left.rows, left.columns, arr)
+
+
+  def identity[element, dimension <: Int]
+    ( using unital:        element is Unital,
+            zeroic:        element is Zeroic,
+            classTag:      ClassTag[element],
+            dimensionSize: ValueOf[dimension] )
+  :   Matrix[element, dimension, dimension] =
+
+    val size = dimensionSize.value
+    val one = unital.one
+    val zero = zeroic.zero
+
+    val arr = IArray.build[element](size*size): array =>
+      var i = 0
+      while i < size do
+        var j = 0
+        while j < size do
+          array(size*i + j) = if i == j then one else zero
+          j += 1
+
+        i += 1
+
+    new Matrix[element, dimension, dimension](size, size, arr)
+
+
+  def zero[element, rowCount <: Int, columnCount <: Int]
+    ( using zeroic:   element is Zeroic,
+            classTag: ClassTag[element],
+            rowValue: ValueOf[rowCount],
+            colValue: ValueOf[columnCount] )
+  :   Matrix[element, rowCount, columnCount] =
+
+    val rowsValue = valueOf[rowCount]
+    val colsValue = valueOf[columnCount]
+    val zero = zeroic.zero
+
+    val arr = IArray.build[element](rowsValue*colsValue): array =>
+      var i = 0
+      while i < rowsValue*colsValue do
+        array(i) = zero
+        i += 1
+
+    new Matrix[element, rowCount, columnCount](rowsValue, colsValue, arr)
+
 
   private type Constraint[rows <: Tuple, element] =
     Tuple.Union
@@ -164,6 +262,82 @@ object Matrix:
       laplaceExpansion(matrix.elements, dimension, fullMask, fullMask, dimension)
 
 
+    def trace(using addition: element is Addable by element to element): element =
+      val dimension = matrix.rows
+      var sum: element = matrix(0, 0)
+      var i = 1
+      while i < dimension do
+        sum = sum + matrix(i, i)
+        i += 1
+
+      sum
+
+
+    def minor(row: Int, column: Int)
+      ( using multiplication: element is Multiplicable by element to element,
+              addition:       element is Addable by element to element,
+              subtraction:    element is Subtractable by element to element )
+    :   element =
+
+      val dimension = matrix.rows
+      val fullMask: Long = (1L << dimension) - 1L
+      val rowMask = fullMask & ~(1L << row)
+      val columnMask = fullMask & ~(1L << column)
+      laplaceExpansion(matrix.elements, dimension, rowMask, columnMask, dimension - 1)
+
+
+    def cofactor(row: Int, column: Int)
+      ( using multiplication: element is Multiplicable by element to element,
+              addition:       element is Addable by element to element,
+              subtraction:    element is Subtractable by element to element,
+              zeroic:         element is Zeroic )
+    :   element =
+
+      val minorValue = matrix.minor(row, column)
+      if (row + column) % 2 == 0 then minorValue else zeroic.zero - minorValue
+
+
+    def adjugate
+      ( using multiplication: element is Multiplicable by element to element,
+              addition:       element is Addable by element to element,
+              subtraction:    element is Subtractable by element to element,
+              zeroic:         element is Zeroic,
+              unital:         element is Unital,
+              classTag:       ClassTag[element] )
+    :   Matrix[element, n, n] =
+
+      val dimension = matrix.rows
+      val elements = matrix.elements
+
+      if dimension == 1 then new Matrix[element, n, n](1, 1, IArray(unital.one))
+      else
+        val fullMask: Long = (1L << dimension) - 1L
+
+        val resultElements = IArray.build[element](dimension*dimension): array =>
+          var outputRow = 0
+
+          while outputRow < dimension do
+            var outputColumn = 0
+
+            while outputColumn < dimension do
+              val rowMask = fullMask & ~(1L << outputColumn)
+              val columnMask = fullMask & ~(1L << outputRow)
+
+              val minorDeterminant =
+                laplaceExpansion(elements, dimension, rowMask, columnMask, dimension - 1)
+
+              val signedMinor =
+                if (outputRow + outputColumn) % 2 == 0 then minorDeterminant
+                else zeroic.zero - minorDeterminant
+
+              array(dimension*outputRow + outputColumn) = signedMinor
+              outputColumn += 1
+
+            outputRow += 1
+
+        new Matrix[element, n, n](dimension, dimension, resultElements)
+
+
     def inverse
       ( using multiplication: element is Multiplicable by element to element,
               addition:       element is Addable by element to element,
@@ -212,6 +386,40 @@ class Matrix[element, rows <: Int, columns <: Int]
   ( val rows: Int, val columns: Int, val elements: IArray[element] ):
 
   def apply(row: Int, column: Int): element = elements(columns*row + column)
+
+  def row(index: Int): Tensor[element, columns] =
+    val cols = columns
+    val arr = IArray.build[Any](cols): array =>
+      var i = 0
+      while i < cols do
+        array(i) = elements(cols*index + i)
+        i += 1
+
+    new Tensor[element, columns](arr)
+
+
+  def column(index: Int): Tensor[element, rows] =
+    val arr = IArray.build[Any](rows): array =>
+      var i = 0
+      while i < rows do
+        array(i) = elements(columns*i + index)
+        i += 1
+
+    new Tensor[element, rows](arr)
+
+
+  def transpose(using ClassTag[element]): Matrix[element, columns, rows] =
+    val arr = IArray.build[element](rows*columns): array =>
+      var row = 0
+      while row < rows do
+        var col = 0
+        while col < columns do
+          array(rows*col + row) = elements(columns*row + col)
+          col += 1
+
+        row += 1
+
+    new Matrix[element, columns, rows](columns, rows, arr)
 
   override def equals(right: Any): Boolean = right.asMatchable match
     case matrix: Matrix[?, ?, ?] => elements.sameElements(matrix.elements)
@@ -279,3 +487,31 @@ class Matrix[element, rows <: Int, columns <: Int]
         row += 1
 
     new Matrix(rows, columns2, elements)
+
+
+  @targetName("mulVec")
+  def * [right]
+    ( right: Tensor[right, columns] )
+    ( using multiplication: element is Multiplicable by right,
+            addition:       multiplication.Result is Addable by multiplication.Result,
+            equality:       addition.Result =:= multiplication.Result,
+            columnValue:    ValueOf[columns] )
+  :   Tensor[multiplication.Result, rows] =
+
+    val inner = valueOf[columns]
+
+    val arr = IArray.build[Any](rows): array =>
+      var row = 0
+      while row < rows do
+        var sum: multiplication.Result =
+          apply(row, 0)*right.data(0).asInstanceOf[right]
+
+        var k = 1
+        while k < inner do
+          sum = sum + apply(row, k)*right.data(k).asInstanceOf[right]
+          k += 1
+
+        array(row) = sum
+        row += 1
+
+    new Tensor[multiplication.Result, rows](arr)

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -298,6 +298,84 @@ object Matrix:
       if (row + column) % 2 == 0 then minorValue else zeroic.zero - minorValue
 
 
+    def solve(rhs: Tensor[element, n])
+      ( using zeroic:         element is Zeroic,
+              subtraction:    element is Subtractable by element to element,
+              multiplication: element is Multiplicable by element to element,
+              divisible:      element is Divisible by element to element,
+              classTag:       ClassTag[element] )
+    :   Optional[Tensor[element, n]] =
+
+      val size = matrix.rows
+      val zero = zeroic.zero
+      val a: Array[element] = matrix.elements.mutable(using Unsafe).clone()
+      val b: Array[element] = new Array[element](size)
+      var copyIndex = 0
+      while copyIndex < size do
+        b(copyIndex) = rhs.data(copyIndex).asInstanceOf[element]
+        copyIndex += 1
+
+      var col = 0
+      var singular = false
+
+      while col < size && !singular do
+        var pivotRow = -1
+        var search = col
+        while search < size && pivotRow < 0 do
+          if a(size*search + col) != zero then pivotRow = search
+          search += 1
+
+        if pivotRow < 0 then singular = true
+        else
+          if pivotRow != col then
+            var swap = col
+            while swap < size do
+              val tmp = a(size*col + swap)
+              a(size*col + swap) = a(size*pivotRow + swap)
+              a(size*pivotRow + swap) = tmp
+              swap += 1
+
+            val rhsTmp = b(col)
+            b(col) = b(pivotRow)
+            b(pivotRow) = rhsTmp
+
+          val pivotValue = a(size*col + col)
+          var rowIdx = col + 1
+          while rowIdx < size do
+            val factor = a(size*rowIdx + col)/pivotValue
+            var elim = col
+            while elim < size do
+              a(size*rowIdx + elim) = a(size*rowIdx + elim) - factor*a(size*col + elim)
+              elim += 1
+
+            b(rowIdx) = b(rowIdx) - factor*b(col)
+            rowIdx += 1
+
+        col += 1
+
+      if singular then Unset
+      else
+        val x: Array[element] = new Array[element](size)
+        var i = size - 1
+        while i >= 0 do
+          var sum: element = b(i)
+          var j = i + 1
+          while j < size do
+            sum = sum - a(size*i + j)*x(j)
+            j += 1
+
+          x(i) = sum/a(size*i + i)
+          i -= 1
+
+        val tensorData = IArray.build[Any](size): array =>
+          var k = 0
+          while k < size do
+            array(k) = x(k)
+            k += 1
+
+        new Tensor[element, n](tensorData)
+
+
     def adjugate
       ( using multiplication: element is Multiplicable by element to element,
               addition:       element is Addable by element to element,

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -650,3 +650,42 @@ object Tests extends Suite(m"Mosquito tests"):
 
         norms.max
       . assert(_ < 0.000001)
+
+    suite(m"Solve linear system"):
+      test(m"Solve 2x2 system"):
+        val mat = Matrix[2, 2]((2.0, 1.0), (1.0, 3.0))
+        val rhs = Tensor(3.0, 4.0)
+        val solution = mat.solve(rhs).vouch
+        math.abs(solution(0) - 1.0) + math.abs(solution(1) - 1.0)
+      . assert(_ < 0.000001)
+
+      test(m"Solve identity system returns RHS"):
+        val solution = Matrix.identity[Double, 3].solve(Tensor(7.0, 8.0, 9.0)).vouch
+        solution
+      . assert(_ == Tensor(7.0, 8.0, 9.0))
+
+      test(m"Solve 3x3 system"):
+        val mat = Matrix[3, 3]((1.0, 1.0, 1.0), (0.0, 2.0, 5.0), (2.0, 5.0, -1.0))
+        val rhs = Tensor(6.0, -4.0, 27.0)
+        val solution = mat.solve(rhs).vouch
+        val expected = Tensor(5.0, 3.0, -2.0)
+        (0 until 3).map(i => math.abs(solution(i) - expected(i))).max
+      . assert(_ < 0.000001)
+
+      test(m"Solve verifies A * x = b"):
+        val mat = Matrix[3, 3]((4.0, 1.0, 2.0), (1.0, 5.0, 3.0), (2.0, 3.0, 6.0))
+        val rhs = Tensor(7.0, 8.0, 9.0)
+        val solution = mat.solve(rhs).vouch
+        val recovered = mat*solution
+        (0 until 3).map(i => math.abs(recovered(i) - rhs(i))).max
+      . assert(_ < 0.000001)
+
+      test(m"Solve singular system returns Unset"):
+        Matrix[2, 2]((1.0, 2.0), (2.0, 4.0)).solve(Tensor(3.0, 6.0))
+      . assert(_ == Unset)
+
+      test(m"Solve requires row swap (zero in pivot)"):
+        val mat = Matrix[2, 2]((0.0, 1.0), (1.0, 0.0))
+        val solution = mat.solve(Tensor(2.0, 3.0)).vouch
+        math.abs(solution(0) - 3.0) + math.abs(solution(1) - 2.0)
+      . assert(_ < 0.000001)

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -548,3 +548,105 @@ object Tests extends Suite(m"Mosquito tests"):
         val product = mat*Matrix.identity[Int, 3]
         product == mat
       . assert(_ == true)
+
+    suite(m"Submatrix"):
+      val m3 = Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 9))
+
+      test(m"Submatrix removing row 0 column 0"):
+        m3.submatrix(0, 0)
+      . assert(_ == Matrix[2, 2]((5, 6), (8, 9)))
+
+      test(m"Submatrix removing center"):
+        m3.submatrix(1, 1)
+      . assert(_ == Matrix[2, 2]((1, 3), (7, 9)))
+
+      test(m"Submatrix removing last row and column"):
+        m3.submatrix(2, 2)
+      . assert(_ == Matrix[2, 2]((1, 2), (4, 5)))
+
+      test(m"Submatrix of 2x3 matrix has shape 1x2"):
+        Matrix[2, 3]((1, 2, 3), (4, 5, 6)).submatrix(0, 1)
+      . assert(_ == Matrix[1, 2](Tuple1((4, 6))))
+
+    suite(m"Frobenius norm"):
+      test(m"Frobenius norm of [[3, 0], [0, 4]] = 5"):
+        Matrix[2, 2]((3.0, 0.0), (0.0, 4.0)).frobeniusNorm
+      . assert(_ === 5.0 +/- 0.000001)
+
+      test(m"Frobenius norm of [[1, 2], [3, 4]]"):
+        Matrix[2, 2]((1.0, 2.0), (3.0, 4.0)).frobeniusNorm
+      . assert(_ === math.sqrt(30.0) +/- 0.000001)
+
+      test(m"Frobenius norm of identity equals sqrt(n)"):
+        Matrix.identity[Double, 4].frobeniusNorm
+      . assert(_ === 2.0 +/- 0.000001)
+
+    suite(m"Rank"):
+      test(m"Rank of 3x3 identity is 3"):
+        Matrix.identity[Double, 3].rank
+      . assert(_ == 3)
+
+      test(m"Rank of 3x3 zero is 0"):
+        Matrix.zero[Double, 3, 3].rank
+      . assert(_ == 0)
+
+      test(m"Rank of singular 2x2"):
+        Matrix[2, 2]((1.0, 2.0), (2.0, 4.0)).rank
+      . assert(_ == 1)
+
+      test(m"Rank of 3x3 matrix with linearly dependent columns"):
+        Matrix[3, 3]((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)).rank
+      . assert(_ == 2)
+
+      test(m"Rank of non-square 2x3 with full row rank"):
+        Matrix[2, 3]((1.0, 0.0, 2.0), (0.0, 1.0, 3.0)).rank
+      . assert(_ == 2)
+
+    suite(m"Eigenvalues and eigenvectors"):
+      test(m"Eigenvalues of 2x2 diagonal matrix"):
+        val sorted =
+          Matrix[2, 2]((2.0, 0.0), (0.0, 3.0)).eigenvalues.let(_.list.sorted).vouch
+
+        math.abs(sorted(0) - 2.0) + math.abs(sorted(1) - 3.0)
+      . assert(_ < 0.000001)
+
+      test(m"Eigenvalues of [[2, 1], [1, 2]] are 1 and 3"):
+        val sorted =
+          Matrix[2, 2]((2.0, 1.0), (1.0, 2.0)).eigenvalues.let(_.list.sorted).vouch
+
+        math.abs(sorted(0) - 1.0) + math.abs(sorted(1) - 3.0)
+      . assert(_ < 0.000001)
+
+      test(m"Eigenvalues of identity are all 1"):
+        val list = Matrix.identity[Double, 3].eigenvalues.let(_.list).vouch
+        list.map(v => math.abs(v - 1.0)).max
+      . assert(_ < 0.000001)
+
+      test(m"Eigensystem of non-symmetric matrix is Unset"):
+        Matrix[2, 2]((1.0, 2.0), (3.0, 4.0)).eigensystem
+      . assert(_ == Unset)
+
+      test(m"M * v = lambda * v for each eigenvector"):
+        val mat = Matrix[2, 2]((2.0, 1.0), (1.0, 2.0))
+        val pair = mat.eigensystem.vouch
+        val vals = pair(0)
+        val vecs = pair(1)
+        val v0 = vecs.column(0)
+        val v1 = vecs.column(1)
+        val lambda0 = vals(0)
+        val lambda1 = vals(1)
+        val mv0 = mat*v0
+        val mv1 = mat*v1
+        val d0 = math.abs(mv0(0) - lambda0*v0(0)) + math.abs(mv0(1) - lambda0*v0(1))
+        val d1 = math.abs(mv1(0) - lambda1*v1(0)) + math.abs(mv1(1) - lambda1*v1(1))
+        math.max(d0, d1)
+      . assert(_ < 0.000001)
+
+      test(m"Eigenvectors are unit vectors"):
+        val mat = Matrix[3, 3]((4.0, 1.0, 2.0), (1.0, 5.0, 3.0), (2.0, 3.0, 6.0))
+        val vecs = mat.eigenvectors.vouch
+        val norms = (0 until 3).map: column =>
+          math.abs(vecs.column(column).norm - 1.0)
+
+        norms.max
+      . assert(_ < 0.000001)

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -409,3 +409,142 @@ object Tests extends Suite(m"Mosquito tests"):
 
         val sum = v1 + v1
       . assert()
+
+    suite(m"Row and column extraction"):
+      val mat = Matrix[2, 3]((1, 2, 3), (4, 5, 6))
+
+      test(m"row(0) of a 2x3 matrix"):
+        mat.row(0)
+      . assert(_ == Tensor(1, 2, 3))
+
+      test(m"row(1) of a 2x3 matrix"):
+        mat.row(1)
+      . assert(_ == Tensor(4, 5, 6))
+
+      test(m"column(0) of a 2x3 matrix"):
+        mat.column(0)
+      . assert(_ == Tensor(1, 4))
+
+      test(m"column(2) of a 2x3 matrix"):
+        mat.column(2)
+      . assert(_ == Tensor(3, 6))
+
+      test(m"row size matches column count"):
+        mat.row(0).size
+      . assert(_ == 3)
+
+      test(m"column size matches row count"):
+        mat.column(0).size
+      . assert(_ == 2)
+
+    suite(m"Transpose"):
+      test(m"Transpose of 2x3 matrix"):
+        Matrix[2, 3]((1, 2, 3), (4, 5, 6)).transpose
+      . assert(_ == Matrix[3, 2]((1, 4), (2, 5), (3, 6)))
+
+      test(m"Transpose round-trip is identity"):
+        val mat = Matrix[2, 3]((1, 2, 3), (4, 5, 6))
+        val roundTripped = mat.transpose.transpose
+        roundTripped == mat
+      . assert(_ == true)
+
+      test(m"Determinant invariant under transpose"):
+        val mat = Matrix[3, 3]((2, -3, 1), (2, 0, -1), (1, 4, 5))
+        mat.determinant - mat.transpose.determinant
+      . assert(_ == 0)
+
+    suite(m"Trace"):
+      test(m"Trace of 3x3 matrix"):
+        Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 10)).trace
+      . assert(_ == 16)
+
+      test(m"Trace of 2x2 zero is zero"):
+        Matrix[2, 2]((0, 0), (0, 0)).trace
+      . assert(_ == 0)
+
+      test(m"Trace of identity matrix is dimension"):
+        Matrix.identity[Int, 4].trace
+      . assert(_ == 4)
+
+    suite(m"Minor and cofactor"):
+      val mat = Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 10))
+
+      test(m"Minor at (0, 0) is determinant of submatrix"):
+        mat.minor(0, 0)
+      . assert(_ == 2)
+
+      test(m"Minor at (0, 1)"):
+        mat.minor(0, 1)
+      . assert(_ == -2)
+
+      test(m"Minor at (1, 2)"):
+        mat.minor(1, 2)
+      . assert(_ == -6)
+
+      test(m"Cofactor at (0, 0) matches its minor"):
+        mat.cofactor(0, 0)
+      . assert(_ == 2)
+
+      test(m"Cofactor at (0, 1) flips sign"):
+        mat.cofactor(0, 1)
+      . assert(_ == 2)
+
+      test(m"Cofactor at (1, 2) flips sign"):
+        mat.cofactor(1, 2)
+      . assert(_ == 6)
+
+    suite(m"Adjugate"):
+      test(m"Adjugate of 2x2 matrix"):
+        Matrix[2, 2]((1, 2), (3, 4)).adjugate
+      . assert(_ == Matrix[2, 2]((4, -2), (-3, 1)))
+
+      test(m"Adjugate of 3x3 matrix"):
+        Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 10)).adjugate
+      . assert(_ == Matrix[3, 3]((2, 4, -3), (2, -11, 6), (-3, 6, -3)))
+
+      test(m"M * adjugate(M) = det(M) * I (3x3)"):
+        val mat = Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 10))
+        mat*mat.adjugate
+      . assert(_ == Matrix[3, 3]((-3, 0, 0), (0, -3, 0), (0, 0, -3)))
+
+    suite(m"Matrix addition and subtraction"):
+      test(m"Add two 2x3 matrices"):
+        Matrix[2, 3]((1, 2, 3), (4, 5, 6)) + Matrix[2, 3]((6, 5, 4), (3, 2, 1))
+      . assert(_ == Matrix[2, 3]((7, 7, 7), (7, 7, 7)))
+
+      test(m"Subtract two 2x3 matrices"):
+        Matrix[2, 3]((10, 9, 8), (7, 6, 5)) - Matrix[2, 3]((1, 2, 3), (4, 5, 6))
+      . assert(_ == Matrix[2, 3]((9, 7, 5), (3, 1, -1)))
+
+      test(m"Add matrices of quantities"):
+        Matrix[2, 2]((1.0*Metre, 2.0*Metre), (3.0*Metre, 4.0*Metre))
+        + Matrix[2, 2]((5.0*Metre, 6.0*Metre), (7.0*Metre, 8.0*Metre))
+      . assert(_ == Matrix[2, 2]((6.0*Metre, 8.0*Metre), (10.0*Metre, 12.0*Metre)))
+
+    suite(m"Matrix-vector multiplication"):
+      test(m"2x3 matrix times 3-vector"):
+        Matrix[2, 3]((1, 2, 3), (4, 5, 6))*Tensor(7, 8, 9)
+      . assert(_ == Tensor(50, 122))
+
+      test(m"Identity matrix times vector is the vector"):
+        Matrix.identity[Int, 3]*Tensor(2, 3, 5)
+      . assert(_ == Tensor(2, 3, 5))
+
+    suite(m"Identity and zero constructors"):
+      test(m"Identity 3x3 of Int"):
+        Matrix.identity[Int, 3]
+      . assert(_ == Matrix[3, 3]((1, 0, 0), (0, 1, 0), (0, 0, 1)))
+
+      test(m"Identity 2x2 of Double"):
+        Matrix.identity[Double, 2]
+      . assert(_ == Matrix[2, 2]((1.0, 0.0), (0.0, 1.0)))
+
+      test(m"Zero 2x3 of Double"):
+        Matrix.zero[Double, 2, 3]
+      . assert(_ == Matrix[2, 3]((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)))
+
+      test(m"M * identity equals M"):
+        val mat = Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 9))
+        val product = mat*Matrix.identity[Int, 3]
+        product == mat
+      . assert(_ == true)


### PR DESCRIPTION
Extends Mosquito's matrix support to cover the most common linear-algebra operations that were previously missing — basic operations (row/column extraction, transpose, trace, minor/cofactor/adjugate, +/-, matrix-vector multiplication, identity/zero), submatrix with type-level dimensions, Frobenius norm, rank via row reduction, eigenvalues/eigenvectors via Jacobi rotation for symmetric Double matrices, and solving square linear systems Ax = b.

## Basic operations

```scala
val m = Matrix[2, 3]((1, 2, 3), (4, 5, 6))
m.row(0)          // Tensor(1, 2, 3)
m.column(2)       // Tensor(3, 6)
m.transpose       // Matrix[3, 2]((1, 4), (2, 5), (3, 6))
```

For square matrices:

```scala
val m = Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 10))
m.trace                 // 16
m.minor(0, 0)           // 2
m.cofactor(0, 1)        // 2  (signed)
m.adjugate              // transpose of the cofactor matrix
```

Element-wise arithmetic and matrix-vector multiplication:

```scala
Matrix[2, 2]((1, 2), (3, 4)) + Matrix[2, 2]((5, 6), (7, 8))
Matrix[2, 3]((1, 2, 3), (4, 5, 6))*Tensor(7, 8, 9)   // Tensor(50, 122)
```

Identity and zero constructors via `Unital` / `Zeroic`:

```scala
Matrix.identity[Int, 3]
Matrix.zero[Double, 2, 3]
```

## Submatrix and structural operations

`submatrix(r, c)` removes a row and column, with the result's dimensions known at compile time:

```scala
val m = Matrix[3, 3]((1, 2, 3), (4, 5, 6), (7, 8, 9))
val s: Matrix[Int, 2, 2] = m.submatrix(1, 1)   // [[1, 3], [7, 9]]
```

`frobeniusNorm` and `rank`:

```scala
Matrix[2, 2]((3.0, 0.0), (0.0, 4.0)).frobeniusNorm           // 5.0
Matrix[3, 3]((1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0)).rank   // 2
```

## Solve linear systems

`solve(b)` finds `x` such that `A*x = b` for a square matrix `A`, via Gaussian elimination with partial pivoting and back-substitution. Returns `Unset` if the matrix is singular.

```scala
val a = Matrix[2, 2]((2.0, 1.0), (1.0, 3.0))
val b = Tensor(3.0, 4.0)
a.solve(b)                  // Optional[Tensor[Double, 2]]   = Tensor(1.0, 1.0)
```

## Eigenvalues and eigenvectors

For symmetric `Matrix[Double, n, n]`, the Jacobi rotation algorithm gives eigenvalues and eigenvectors. Returns `Unset` if the matrix is non-symmetric or doesn't converge.

```scala
val m = Matrix[2, 2]((2.0, 1.0), (1.0, 2.0))
m.eigenvalues   // Optional[Tensor[Double, 2]]   ≈ Tensor(1.0, 3.0)
m.eigenvectors  // Optional[Matrix[Double, 2, 2]] — columns are eigenvectors
m.eigensystem   // Optional[(Tensor[Double, 2], Matrix[Double, 2, 2])]
```

Non-symmetric matrices return `Unset`:

```scala
Matrix[2, 2]((1.0, 2.0), (3.0, 4.0)).eigensystem   // Unset
```