### PR TITLE
Add Punctuation benchmark suite

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -834,6 +834,7 @@ object punctuation extends Library:
   object html extends Component(core)
   object ansi extends Component(core, harlequin.core)
   object test extends Tests(core, html, ansi, jacinta.core, telekinesis.core, sedentary.core, quantitative.units)
+  object bench extends Benchmarks(core, quantitative.units)
 
 object quantitative extends Library:
   object core extends Component(hypotenuse.core, gossamer.core, anticipation.opaque, anticipation.time, probably.core)

--- a/lib/punctuation/res/bench/punctuation/emphasis-stress.md
+++ b/lib/punctuation/res/bench/punctuation/emphasis-stress.md
@@ -1,0 +1,136 @@
+# Emphasis stress
+
+A fixture of pure inline density, designed to isolate inline-parser cost from
+block-parser cost. Almost no block structure: just paragraphs packed with
+emphasis runs, links, code spans, autolinks, escapes, and entities. The
+delimiter-stack algorithm and the rule-of-3 length pairing are exercised
+heavily.
+
+[a]: https://example.com/a "title a"
+[b]: https://example.org/b 'title b'
+[c]: https://example.net/c (paren title c)
+[deep]: https://example.com/deep
+
+Paragraph one: *single em* and **double strong** and ***triple ems*** and
+****quad runs**** and *****five***** and ******six****** in a row, with `code`
+and [a link](https://example.com) and ![an image](/i.png "alt") and an
+autolink <https://example.org> and a [reference][a] and a [collapsed][] and a
+shortcut [c] reference. Backslash escapes \* \_ \[ \] \\ and entities &amp;
+&#42; &#x2A; &copy; appear too.
+
+Paragraph two — the gnarly cases for the rule of 3:
+*foo***bar
+**foo***bar
+***foo*bar**
+**foo*bar***
+*foo *bar* baz*
+**foo **bar** baz**
+***foo ***bar*** baz***
+*a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*
+
+Paragraph three — alternating asterisk and underscore (different delimiters
+do not pair with each other):
+*a_b_c*
+_a*b*c_
+**a__b__c**
+__a**b**c__
+***a___b___c***
+
+Paragraph four — Unicode flanking (left/right flanking rules with punctuation
+and whitespace boundaries):
+".*foo*."
+"(*foo*)"
+"a*b*c"
+"a *b* c"
+"a* b *c"
+"_foo_."
+"(_foo_)"
+"a_b_c"
+"a _b_ c"
+
+Paragraph five — long runs and adjacent runs:
+**********foo**********
+__________foo__________
+*****foo*****bar*****baz*****
+*foo**bar***baz****qux*****quux*
+
+Paragraph six — links and images mixed with emphasis:
+[*italic link*](https://x)
+[**bold link**](https://x)
+[***both link***](https://x)
+*[italic around link](https://x)*
+**[bold around link](https://x)**
+*outer **inner [link](https://x) inner** outer*
+![*italic image*](/i.png)
+*[image](/i.png) and ![embedded](/e.png)*
+
+Paragraph seven — code spans inside emphasis (code spans take precedence):
+*foo `code` bar*
+**foo `code` bar**
+*`code` foo*
+*foo `co*de` bar*
+*foo \`code\` bar*
+
+Paragraph eight — references inside emphasis:
+*[a]*
+**[b]**
+***[c]***
+*[a][a] [b][] [c]*
+**[deep][]**
+
+Paragraph nine — backslash escapes inside delimiter runs:
+*foo\*bar*
+**foo\**bar**
+*foo\_bar*
+*foo\\bar*
+\*not emphasis\*
+\**not strong\**
+\*\*emphasis around escapes\*\*
+
+Paragraph ten — autolinks and HTML inlines mixed with emphasis:
+*<https://example.com>*
+**<mail@example.com>**
+*<span>html</span>*
+**<em>nested em</em>**
+*foo <span>span</span> bar*
+
+Paragraph eleven — adjacent emphasis runs must not merge:
+*foo* *bar* *baz*
+**foo** **bar** **baz**
+*foo***bar***baz*
+**foo*bar*baz**
+
+Paragraph twelve — pathological-ish nested cases (still well-formed):
+*a *b *c *d *e *f *g *h *i *j* k* l* m* n* o* p* q* r*
+**a **b **c **d **e **f **g** h** i** j** k** l** m** n**
+
+Paragraph thirteen — link reference resolution stress:
+[a][a] [a][b] [a][c] [b][a] [b][b] [b][c] [c][a] [c][b] [c][c]
+[a] [b] [c] [deep] [a][] [b][] [c][] [deep][]
+![a][a] ![b][b] ![c][c] ![deep][deep]
+[**bold ref**][a] [*italic ref*][b] [`code ref`][c]
+
+Paragraph fourteen — entities packed densely:
+&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;
+&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;
+&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;
+&copy;&reg;&trade;&hellip;&mdash;&ndash;
+&lt;&gt;&quot;&apos;&nbsp;
+
+Paragraph fifteen — code spans of varied lengths:
+`a` ``b`` ```c``` ````d```` `e``f``g`
+`with backtick \` inside`
+`` `interior` ``
+``` ``two backticks`` ```
+`spaces   preserved`
+`  trim leading and trailing  `
+
+Paragraph sixteen — final mixed paragraph hitting everything:
+The *quick* **brown** ***fox*** [jumps](https://x) over the [lazy][a] dog with
+`inline code` and an ![image](/i.png) and an autolink <https://example.org>
+plus an entity &amp; and a backslash escape \* and a hard break\
+on the next line and a soft
+break wrapping here, all in one *italic **strong** italic* and one **strong
+*italic* strong** and one ***strong-italic [link](https://x) strong-italic***.
+
+[collapsed]: https://example.com/collapsed

--- a/lib/punctuation/res/bench/punctuation/medium.md
+++ b/lib/punctuation/res/bench/punctuation/medium.md
@@ -1,0 +1,437 @@
+All Quantitative terms and types are defined in the `quantitative` package,
+```scala
+import quantitative.*
+```
+and exported to the `soundness` package:
+```scala
+import soundness.*
+```
+
+### `Quantity` types
+
+Physical quantities can be represented by different `Quantity` types, with an appropriate parameter that encodes
+the value's units. We can create a quantity by multiplying an existing `Double` (or any numeric type) by some
+unit value, such as `Metre` or `Joule`, which are just `Quantity` values equal to `1.0` of the appropriate unit.
+For example:
+```amok
+syntax  scala
+##
+val distance = 58.3*Metre
+```
+
+The types of these values will be inferred. The value `distance` will get the type `Quantity[Metres[1]]`, since
+its value is a number of metres (raised to the power `1`).
+
+In general, types representing units are written in the plural (for example, `Metres`, `Feet`, `Candelas`), with
+a bias for distinction when the singular name is often used in the plural; for example, the type is `Kelvins`
+even though "Kelvins" and "Kelvin" are both commonly used for plural values. Unit instances are always named in
+the singular.
+
+We can compute an `area` value by squaring the distance,
+```amok
+syntax  scala
+##
+val area = distance*distance
+```
+which should have units of square metres (`m²`). Quantitative represents this as the type, `Quantity[Metres[2]]`; the
+`2` singleton literal value represents the metres being squared. Likewise, a volume would have the parameter
+`Metres[3]`.
+
+### Representation and displaying
+
+Each quantity, regardless of its units, is represented in the JVM as a `Double` using an opaque type
+alias.
+
+The precise types, representing units, are known statically, but are erased by runtime. Hence, all
+dimensionality checking takes place at compiletime, after which, operations on `Quantity`s will be
+operations on `Double`s, and will achieve similar performance.
+
+The raw `Double` value of a `Quantity` can always be obtained with `Quantity#value`
+
+Due to this representation, the `toString` method on `Quantity`s is the same as `Double`s `toString`,
+so the `toString` representations will show just the raw numerical value, without any units. In
+general, `toString` should not be used. A `gossamer.Show` instance is provided to produce
+human-readable `Text` values, so calling `show` on a `Quantity` will produce much better output.
+
+### Derived units
+
+We can also define:
+```amok
+syntax  scala
+##
+val energy = Joule*28000
+```
+
+The type of the `energy` value _could_ have been defined as `Quantity[Joule[1]]`, but 1 J is equivalent to 1
+kg⋅m²⋅s¯², and it's more useful for the type to reflect a product of thes more basic units (even though we
+can still use the `Joule` value to construct it).
+
+Metres, seconds and kilograms are all SI base units. Kilograms are a little different, since _nominally_, a
+kilogram is one thousand grams (while a gram is _not_ an SI base unit), and this has a small implication on
+the way we construct such units.
+
+Quantitative provides general syntax for metric naming conventions, allowing prefixes such as `Nano` or `Mega`
+to be applied to existing unit values to specify the appropriate scale to the value. Hence, a kilogram value
+is written, `Kilo(Gram)`. But since the SI base unit is the kilogram, this and any other multiple of `Gram`,
+such as `Micro(Gram)`, will use the type `Kilogram`, or more precisely, `Kilogram[1]`.
+
+Therefore, the type of `energy` is `Quantity[Grams[1] & Metres[2] & Second[-2]]`, using a combination of three
+base units raised to different powers. They are combined into an intersection type with the `&` type operator,
+which provides the useful property that the order of the intersection is unimportant;
+`Second[-2] & Metres[2] & Grams[1]` is an _identical_ type, much as kg m²s¯² and s¯²m²kg are identical
+units.
+
+Just as we could construct an area by multiplying two lengths, we can compute a new value with appropriate units
+by combining, say, `area` and `energy`,
+```amok
+syntax  scala
+##
+val volume = distance*distance*distance
+val energyDensity = energy/volume
+```
+and its type will be inferred with the parameter `Kilogram[1] & Metres[-1] & Second[-2]`.
+
+If we had instead calculated `energy/area`, whose units do not include metres, the type parameter would be just
+`Kilogram[1] & Second[-2]`; the redundant `Metres[0]` would be automatically removed from the conjunction.
+
+We can go further. For example, the ["SUVAT" equations of motion](https://en.wikipedia.org/wiki/Equations_of_motion)
+can be safely implemented as methods, and
+their dimensionality will be checked at compiletime. For example, the equation,
+```mathml
+<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>s</mi><mo>=</mo><mi>u</mi><mi>t</mi><mo>+</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><mi>a</mi><msup><mi>t</mi><mn>2</mn></msup></math>
+```
+calculating a distance (`s`) from an initial velocity (`u`), acceleration (`a`) and time (`t`) can be
+implemented using Quantitative `Quantity`s with,
+```amok
+syntax  scala
+##
+type Velocity = Quantity[Metres[1] & Seconds[-1]]
+type Time = Quantity[Seconds[1]]
+type Acceleration = Quantity[Metres[1] & Seconds[-2]]
+type Distance = Quantity[Metres[1]]
+
+def s(u: Velocity, t: Time, a: Acceleration): Distance =
+  u*t + 0.5*a*t*t
+```
+or more verbosely,
+```amok
+syntax  scala
+##
+def distance
+    (velocity0: Quantity[Metres[1] & Seconds[-1]],
+     time: Quantity[Seconds[1]],
+     acceleration: Quantity[Metres[1] & Seconds[-2]])
+        :   Quantity[Metres[1]] =
+
+  velocity0*time + 0.5*acceleration*time*time
+```
+
+While the method arguments have more complex types, the expression, `u*t + 0.5*a*t*t`, is checked for
+dimensional consistency. If we had written `t + 0.5*a*t*t` or `u*t + 0.5*a*a*t` instead, these would
+have produced errors at compiletime.
+
+### Combining mixed units
+
+Kilograms, metres and seconds are units of in the mass, length and time dimensions, which are never
+interchangeable. Yet we sometimes need to work with different units of the same dimension, such as
+feet, metres, yards and miles as different (but interchangeable) units of length; or kilograms and
+pounds, as units of mass.
+
+Each type representing units, such as `Metres` or `Kilograms`, must be a subtype of the `Units` type,
+which is parameterized with its power (with a singleton literal integer) and a _dimension_, i.e. another type
+representing the nature of the measurement. For `Metres` the dimension is `Length`; for `Kilograms` it is
+`Mass`; `Candela`'s is `Luminosity`.
+
+`Metres[PowerType]` is a subtype of `Units[PowerType, Length]`, where `PowerType` must be a singleton
+integer type. More specifically, `Metres[1]` would be a subtype of `Units[1, Length]`.
+
+Note that there are no special dimensions for compound units, like energy, since the time, length and mass
+components of the units of an energy quantity will be associated with the `Second`, `Metres` and `Kilogram`
+types respectively.
+
+Encoding the dimension in the type makes it possible to freely mix different units of the same dimension.
+
+It is possible to create new length or mass units, such as `Inch` or `Pound`, which share the `Length` or `Mass`
+dimensions. This allows them to be considered equivalent in some calculations, if a conversion coefficient is
+available.
+
+Quantitative defines a variety of imperial measurements, and will automatically convert units of the same
+dimension to the same units in multiplications and divisions. For example,
+```amok
+syntax  scala
+##
+val width = 0.3*Metre
+val height = 5*Inch
+val area2 = width*height
+```
+will infer the type `Quantity[Metres[2]]` for `area`.
+
+However, the conversion of one of the units from inches to metres was necessary only to avoid a mixture of
+`Inches` and `Metres` in the resultant type, but the expression, `height*height` would produce a value with the
+units, `Inches[2]`, performing no unnecessary conversions.
+
+### Conversions
+
+#### Addition & subtraction
+
+Addition and subtraction are possible between quantities which share the same dimension.
+
+We can safely add an inch and a metre,
+```amok
+syntax  scala
+##
+val length = 1*Inch + 1*Metre
+```
+but we can't subtract a second from a litre:
+```amok
+syntax  scala
+error  Lit..ond
+  caption  This will not compile because litres and seconds are incompatible
+##
+val nonsense = Litre - Second
+
+```
+
+For the addition and subtraction of values with mixed units, the question arises of which units the result
+should take. Quantitative will use the _principal unit_ for the dimension, which is determined by the presence
+of a unique contextual `PrincipalUnit` instance, parameterized on `Dimension` and `Units` types.
+
+In general, if the units for the same dimension don't match between the operands, then the principal unit
+will be used for both. This may mean that adding a foot to a mile produces a result measured in metres,
+but a new `PrincipalUnit[Length, Miles[1]]()` contextual value could always be provided in-scope,
+which will take precedence over the `PrincipalUnit[Length, Metres[1]]` in scope.
+
+Some additional contextual values may be required, though. See [below](#conversion-ratios) for more
+information on conversions.
+
+#### Inequality Comparisons
+
+Likewise, we can compare units in like or mixed values with the four standard inequality operators
+(`<`, `>`, `<=`, `>=`). These will return `true` or `false` if the operands have the same dimension,
+even if they have different units, for example,
+```amok
+syntax  scala
+highlight  8..Metre  This returns true.
+##
+8*Foot < 4*Metre
+
+```
+while incompatible units will result in a compile error.
+
+#### Equality
+
+Equality between different `Quantity` values should be treated with care, since all such values are
+represented as `Double`s at runtime, and the JVM's standard equality will not take units into
+account. So, by default, `3*Foot == 3*Metre` will yield `true`, since `3.0 == 3.0`!
+
+This is highly undesirable, but luckily there's a solution:
+```amok
+syntax  scala
+##
+import language.strictEquality
+```
+
+This turns on Scala's strict-equality feature, which forbids comparisons between any two types unless
+a corresponding `CanEqual[LeftOperandType, RightOperandType]` exists in scope for the appropriate
+operand types. Quantitative provides just such an instance for `Quantity` instances with the same units.
+
+The runtime equality check, however, is performed in exactly the same way: by comparing two `Double`s.
+That is absolutely fine if we know the units are identical, but it does not allow equality comparisons
+between `Quantity`s of the same dimension and different units.
+
+For this, there are two possibilities:
+- convert one of the `Quantity`s to the units of the other
+- test `left <= right && left >= right`, which will only be true if `left` equals `right`
+
+#### Conversion ratios
+
+In order to automatically convert between two units, Quantitative needs to know the ratio between them.
+This is provided with a contextual `Ratio` value for the appropriate pair of units: one with the
+power `1` and the other with the power `-1`. The rate of conversion should be specified as a singleton
+literal `Double` as the second parameter. The `given` may be `erased`, if using Scala's erased definitions.
+
+For example,
+```amok
+syntax     scala
+highlight  erased  We can make the value erased.
+##
+erased given Ratio[Kilograms[1] & Tons[-1], 1016.0469088] = ###
+
+```
+which specifies that there are about 1016 kilograms in a ton, and will be used if Quantitative ever needs
+to convert between kilograms and tons.
+
+By making the conversion rate a _type_ (a singleton literal, specifically), its value is available at
+compiletime, even while the `given` is `erased`. This has the further advantage that any calculations on
+`Quantity`s which need to use the conversion ratio in a calculation involving other constants will use
+constant folding to automatically perform arithmetic operations on constants at compiletime, saving the
+performance cost of doing these at runtime.
+
+### Explicit Conversions
+
+To convert a quantity to different units, we can use the `in` method, passing it an _unapplied_ units type
+constructor, such as `Hour` or `Furlong`. The significance of the type being "unapplied" is that a units type
+constructor is typically _applied_ to an integer singleton type, such as `Metres[2]` representing square
+metres. Each dimension in a quantity must have the same units, no matter what its power, so it doesn't make
+sense to specify that power when converting.
+
+So, `(10*Metre).in[Yards]`, would create a value representing approximately 10.94 yards, while,
+`(3*Foot * 1*Metre * 0.4*Centi(Metre)).in[Inches]`, would calculate a volume in cubic inches.
+
+If a quantity includes units in multiple dimensions, these can be converted in steps, for example,
+```amok
+syntax  scala
+highlight  Mi..es  First convert into miles per second...
+highlight  Ho..rs  ...and then convert the seconds into hours.
+##
+val distance2 = 100*Metre
+val time = 9.8*Second
+val speed = distance2/time
+val mph = speed.in[Miles].in[Hours]
+
+```
+
+### SI definitions
+
+There are seven SI base dimensions, with corresponding units, which are defined by Quantitative:
+ - `Length` with units type, `Metres`, and unit value, `Metre`
+ - `Mass` with units, `Kilograms`, and unit value, `Kilogram`
+ - `Time` with units, `Seconds`, and unit value, `Second`
+ - `Current` with units, `Amperes`, and unit value, `Ampere`
+ - `Luminosity` with units, `Candelas`, and unit value, `Candela`
+ - `AmountOfSubstance` with units, `Moles`, and unit value, `Mole`
+ - `Temperature` with units, `Kelvins`, and unit value, `Kelvin`
+
+As well as these, the following SI derived unit values are defined in terms of the base units:
+ - `Hertz`, for measuring frequency, as one per second
+ - `Newton`, for measuring force, as one metre-kilogram per square second
+ - `Pascal`, for measuring pressure, as one Newton per square metre
+ - `Joule`, for measuring energy, as one Newton-metre
+ - `Watt`, for measuring power, as one Joule per second
+ - `Coulomb`, for measuring electric charge, as one second-Ampere
+ - `Volt`, for measuring electric potential, as one Watt per Ampere
+ - `Farad`, for measuring electrical capacitance, as one Coulomb per Volt
+ - `Ohm`, for measuring electrical resistance, as one Volt per Ampere
+ - `Siemens`, for measuring electrical conductance, as one Ampere per Volt
+ - `Weber`, for measuring magnetic flux, as one Volt-second
+ - `Tesla`, for measuring magnetic flux density, as one Weber per square metre
+ - `Henry`, for measuring electrical inductance, as one Weber per Ampere
+ - `Lux`, for measuring illuminance, as one Candela per square metre
+ - `Becquerel`, for measuring radioactivity, as one per second
+ - `Gray`, for measuring ionizing radiation dose, as one Joule per kilogram
+ - `Sievert`, for measuring stochastic health risk of ionizing radiation, as one Joule per kilogram
+ - `Katal`, for measuring catalytic activity, as one mole per second
+
+## Defining your own units
+
+Quantitative provides implementations of a variety of useful (and some less useful) units from the
+metric system, CGS and imperial. It's also very easy to define your own units.
+
+Imagine we wanted to implement the FLOPS unit, for measuring the floating-point performance of a
+CPU: floating-point instructions per second.
+
+Trivially, we could create a value,
+```amok
+syntax  scala
+##
+val SimpleFlop = 1.0/Second
+```
+and use it in equations such as, `1000000*SimpleFlop * Minute` to yield an absolute number representing
+the number of floating-point instructions that could (theoretically) be calculated in one minute by
+a one-megaFLOP CPU.
+
+But this definition is just a value, not a unit. We can tweak the definition slightly to,
+```amok
+syntax  scala
+##
+val Flop = MetricUnit(1.0/Second)
+```
+and it becomes possible to use metric prefixes on the value. So we could rewrite the above expression
+as, `Mega(Flop) * Minute`.
+
+### Introducing new dimensions
+
+The result is just a `Double`, though, which is a little unsatisfactory, since it represents
+something more specific: a number of instructions. To do better, we need to introduce a new
+`Dimension`, distinct from length, mass and other dimensions, and representing a CPU's
+performance,
+```amok
+syntax  scala
+##
+trait CpuPerformance extends Dimension
+```
+and create a `Flops` type corresponding to this dimension:
+```amok
+syntax  scala
+##
+import rudiments.*
+trait Flops[PowerType <: Nat]
+extends Units[PowerType, CpuPerformance]
+
+val Flop: MetricUnit[Flops[1]] = MetricUnit(1)
+```
+
+The type parameter, `PowerType`, is a necessary part of this definition, and must be constrained on
+the `Nat` type defined in [Rudiments](https://github.com/propensive/rudiments/), which is just an
+alias for `Int & Singleton`. If you are using Scala's erased definitions, both `CpuPerformance` and
+`Flops` may be made `sealed trait`s to reduce the bytecode size slightly.
+
+With these definitions, we can now write `Mega(Flop) * Minute` to get a result with the dimensions
+"FLOPS-seconds", represented by the type, `Quantity[Flops[1] & Seconds[1]]`.
+
+If we want to show the FLOPS value as `Text`, a symbolic name is required. This can be specified
+with a contextual instance of `UnitName[Flops[1]]`,
+```amok
+syntax  scala
+##
+given UnitName[Flops[1]] = () => t"FLOPS"
+```
+which will allow `show` to be called on a quantity involving FLOPs.
+
+### Describing physical quantities
+
+English provides many names for physical quantities, including the familiar base dimensions of
+_length_, _mass_, _time_ and so on, as well as combinations of these, such as _velocity_,
+_acceleration_ and _electrical resistance_.
+
+Definitions of names for many of these physical quantities are already defined, and will appear in
+error messages when a mismatch occurs.
+```amok
+syntax  scala
+error   M..)  
+  caption
+      the left operand represents velocity, but the right operand represents acceleration
+##
+Metre/Second + Metre/(Second*Second)
+
+```
+It is also possible to define your own, for example, here is the definition for "force":
+```amok
+syntax  scala
+##
+erased given DimensionName[Units[1, Mass] & Units[1, Length] & Units[-2, Time], "force"] = erasedValue
+```
+
+The singleton type `"force"` is the provided name for any units corresponding to the dimensions,
+mass×length×time¯².
+
+### Substituting simplified units
+
+While the SI base units can be used to describe the units of most physical quantities, there often
+exist simpler forms of their units. For example, the Joule, `J`, is equal to `kg⋅m²⋅s¯²`, and is
+much easier to write.
+
+By default, Quantitative will use the latter form, but it is possible to define alternative
+representations of units where these exist, and Quantitative will use these whenever a quantity is
+displayed. A contextual value can be defined, such as the following,
+```amok
+syntax     scala
+##
+import gossamer.t
+
+given SubstituteUnits[Kilograms[1] & Metres[2] & Seconds[-2]](t"J")
+```
+and then a value such as, `2.8*Kilo(Joule)` will be rendered as `2800 J` instead of `2800 kg⋅m²⋅s¯²`.
+
+Note that this only applies if the quantity's units exactly match the type parameter of
+`SubstituteUnits`, and units such as Joule-seconds would still be displayed as `kg⋅m²⋅s¯¹`.

--- a/lib/punctuation/res/bench/punctuation/small.md
+++ b/lib/punctuation/res/bench/punctuation/small.md
@@ -1,0 +1,18 @@
+### Decoupled Integration
+
+Soundness is a vast ecosystem of small libraries, for many diverse applications. For specific needs, individual libraries can be selected à la carte, without introducing a complex graph of dependencies. Care has been taken to decouple libraries which aren't directly related, without compromising their integration. Soundness's typeclass-based approach has made it possible to avoid unnecessary dependencies through the careful specification of small interfaces.
+
+But Soundness also provides six bundles of libraries targetting different domains. These are web for web applications; data for data processing; sci for scientific applications; cli for command-line applications; test for testing; and, tool for tooling development. The base bundle provides a common set of fundamental libraries, and all includes everything.
+### Compositionality
+
+Monads are the foundation of functional programming, but they don't compose. Lifting every value into a monadic wrapper type is a burden that's familiar, but can never compose as easily as expressions.
+
+Soundness APIs are _direct-style_ APIs. They are designed to compose. And they're ready for a whole new level of safety with Scala's advanced _capture checking_ functionality.
+### Declarative Programming
+
+Declarative code is easier to reason about because it's independent of control flow. Its essential structure arises from scopes and contexts, and in Scala 3 it's possible with _contextual_ values. Declare a new given instance or import an existing one, and it's valid for the entire scope. And you decide whether that's just a method body, or your entire project—on a continuuum between local and global. There's less repetition, and your code is more maintainable.
+### Next Generation Scala
+
+Soundness was developed natively for Scala 3, and exploits its extensive new features to the limit. Its sound typesystem and powerful metaprogramming capabilities make it uniquely able to accommodate APIs that take full advantage of precise types without compromising your code's legibility.
+
+Soundness is evolved from the experience of Scala 2, but not held back by its legacy. No interface has been compromised in its expressiveness for compatibility with Scala 2. Adopting Soundness means a full-throated endorsement of the future of Scala.

--- a/lib/punctuation/res/bench/punctuation/stress-mix.md
+++ b/lib/punctuation/res/bench/punctuation/stress-mix.md
@@ -1,0 +1,1643 @@
+# Stress mix
+
+A synthetic Markdown document exercising every CommonMark feature in roughly
+representative proportions. The body of this file is a base section of ~4 KB,
+repeated several times below with minor variations so the parser does not
+benefit from caching effects on identical input.
+
+[upstream]: https://example.com/upstream "Upstream reference"
+[mirror]: https://example.org/mirror
+[license]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0"
+[ref-image]: /images/diagram.png "A diagram"
+
+## Section 1: prose with mixed inline content
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com "Example") and an
+![inline image](/img/example.png "Caption"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license] reference.
+
+Autolinks like <https://commonmark.org> and emails like <mail@example.com> are
+also exercised. So is escaping: \*not emphasis\* and \[not a link\] and \\.
+Hard line breaks come from a backslash\
+or two trailing spaces.  
+Soft breaks just wrap
+to the next line.
+
+Some HTML inlines: <span>raw</span> and <kbd>Ctrl</kbd>+<kbd>C</kbd>. An entity
+reference like &amp; or &#42; or &#x2A; should decode.
+
+## Section 2: headings of every level
+
+# H1 ATX
+## H2 ATX
+### H3 ATX
+#### H4 ATX
+##### H5 ATX
+###### H6 ATX
+
+Setext H1
+=========
+
+Setext H2
+---------
+
+## Section 3: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with a continuation paragraph.
+
+* another item with
+
+  > a nested blockquote inside.
+
+* third item with
+
+  ```scala
+  val x = 42
+  println(x)
+  ```
+
+Ordered list with nesting:
+
+1. First level
+   1. Second level
+      - mixed bullet at third level
+      - another bullet
+   2. Second level item two
+2. First level item two
+   1. Nested again
+3. First level item three with `inline code` and *emphasis*.
+
+Loose ordered list:
+
+1) item one with paragraph
+
+   continuing here.
+
+2) item two
+3) item three
+
+## Section 4: block quotes
+
+> A simple block quote.
+> It spans two lines.
+
+> Outer block quote.
+>
+> > Inner block quote.
+> > > Triple-nested block quote with **strong** content.
+>
+> Back to outer level with a [link][upstream].
+
+## Section 5: code blocks
+
+Fenced code block with info string:
+
+```scala
+def parse(text: Text): Markdown of Layout =
+  // walk the cursor line by line
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Fenced code block with no info:
+
+```
+plain   text   with   spaces
+preserved exactly as written
+```
+
+Indented code block:
+
+    indented line one
+    indented line two
+    val x = "with quotes \" and backslashes \\"
+
+Tilde fenced block:
+
+~~~rust
+fn main() {
+    println!("Hello, world!");
+}
+~~~
+
+## Section 6: thematic breaks
+
+Above:
+
+---
+
+Star form:
+
+***
+
+Underscore form:
+
+___
+
+## Section 7: emphasis edge cases
+
+Triple emphasis: ***foo bar baz***
+Mixed: *foo **bar** baz*
+Underscore mid-word: foo_bar_baz (not emphasis)
+Asterisk mid-word: foo*bar*baz (is emphasis)
+Adjacent runs: ****foo****
+Within strong: **foo *bar* baz**
+Nested deeply: *a *b *c* d* e*
+
+## Section 8: more references
+
+See also [upstream link][upstream] and the [mirror][] for backups, and consult
+the [license] before redistribution. The diagram is shown ![below][ref-image].
+
+> Quoted reference: pull from [upstream] daily.
+
+End of section.
+
+---
+
+# Section repeat 2
+
+[upstream]: https://example.com/upstream "Upstream reference"
+[mirror]: https://example.org/mirror
+
+## Section 1 (repeat 2): prose with mixed inline content
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/2 "Example two") and an
+![inline image](/img/example2.png "Caption two"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference.
+
+Autolinks like <https://example.org/2> are also exercised. Backslash escapes
+\*here\* and \[there\] and \\.
+
+Hard break\
+and another  
+soft break wrapping
+to the next line.
+
+## Section 2 (repeat 2): tight nested lists
+
+- root one
+  - child one
+    - grand-child one
+    - grand-child two with `code`
+  - child two with [link](https://example.com)
+- root two with **bold**
+- root three
+  - inner
+
+## Section 3 (repeat 2): block quotes and code
+
+> Outer.
+> > Middle.
+> > > Inner with *emphasis* and a [link](https://x).
+
+```scala
+final class Cursor[data]:
+  inline def advance(): Unit = pos += 1
+  inline def more: Boolean = pos < writeEnd || moreSlow()
+```
+
+    plain indented block
+    second line
+    third line
+
+## Section 4 (repeat 2): emphasis edge cases
+
+*a*b*c*d*e*
+**a**b**c**d**
+***a*b*c***
+*foo _bar_ baz*
+_foo *bar* baz_
+**foo *bar baz***
+
+End of repeat.
+
+---
+
+# Section repeat 3
+
+[upstream]: https://example.net/upstream
+[mirror]: https://example.net/mirror
+
+Long paragraph one with *italic*, **bold**, ***both***, `code`,
+[a link](https://example.com/three), an ![image](/img/three.png),
+[ref][upstream], [mirror][], and a final shortcut [upstream]. The paragraph
+continues for several lines to give the inline parser a real workout, with
+plenty of soft line breaks and the occasional hard break  
+right here. Backslash escapes \* \_ \[ \] \( \) \\ \` \! all show.
+
+> Quote with [inline](https://x) and **bold** and `code`.
+>
+> > Nested quote with *emphasis*.
+>
+> Back to outer.
+
+## Subsection
+
+1. Numbered with **strong**
+2. Another with [link](https://x)
+3. Third with `code`
+
+- Bulleted with *italic*
+- Another with [reference][upstream]
+- Third with autolink <https://example.org>
+
+```python
+def fib(n):
+    if n < 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+```
+
+    indented again
+    second line again
+
+End of section repeat 3.
+
+---
+
+# Section repeat 4
+
+A dense paragraph: *a* *b* *c* **d** **e** **f** ***g*** ***h*** `i` `j` `k`
+[a](https://x) [b](https://y) [c](https://z) ![d](/d.png) ![e](/e.png) <https://f>
+\* \_ \[ \] \( \) \\ \` \! &amp; &copy; &#x2A; <span>x</span>.
+
+> Quote line one.
+> Quote line two with `inline` and *em* and **strong**.
+>
+> > Inner quote.
+
+- list one
+  - nested
+    - deep
+      - very deep with *emphasis* and `code` and [link](https://x)
+- list two
+- list three with very long paragraph content that wraps across multiple lines
+  to exercise paragraph continuation handling within list items, including
+  some `inline code` and [links](https://example.org) along the way.
+
+```haskell
+factorial :: Integer -> Integer
+factorial 0 = 1
+factorial n = n * factorial (n - 1)
+```
+
+End of section repeat 4.
+
+---
+
+# Section repeat 5
+
+Triple-nested blockquote with mixed content:
+
+> outer
+> > middle with *emphasis*
+> > > inner with [link](https://x) and `code` and **bold**
+> > > and a continuation line.
+> > middle continuation.
+> outer continuation.
+
+Loose ordered list with code:
+
+1. Step one.
+
+   Continuation paragraph.
+
+   ```scala
+   def step1(): Unit = ()
+   ```
+
+2. Step two.
+
+   > A blockquote inside.
+
+3. Step three.
+
+Reference resolution stress:
+
+[a]: /url-a
+[b]: /url-b "title b"
+[c]: /url-c (paren title c)
+
+See [a], [b][], [c][a], and ![image][b].
+
+## Final emphasis stress
+
+*foo*bar*baz*
+**foo**bar**baz**
+***foo***bar***baz***
+_foo_bar_baz_ (no emphasis since underscore mid-word)
+__foo__bar__baz__
+*a **b** c*
+**a *b* c**
+***a **b** c***
+*a *b *c *d* e* f* g*
+
+End of stress-mix.md.
+
+---
+
+# Section repeat 6
+
+[upstream]: https://example.com/r6
+[mirror]: https://example.org/r6
+
+A section to add bulk and ensure the file crosses 50 KB. The body deliberately
+mixes features so the parser cannot exploit a narrow distribution: *italic*,
+**bold**, ***both***, `code`, [link](https://x), [ref][upstream],
+![image](/i.png), <https://example.org>, and HTML <span>inline</span>.
+
+> Quoted bulk content with **strong**, *emphasis*, `code`, and a [link][upstream]
+> and a hard break\
+> here.
+
+- bulk list item one with *emphasis*
+- bulk list item two with `code`
+- bulk list item three with [link](https://x)
+  - nested with **bold**
+  - nested with ![image](/i.png)
+- bulk list item four
+
+```scala
+object Bench:
+  def run(): Unit =
+    println("running")
+```
+
+    indented bulk
+    second line
+    third line
+
+# Section repeat 7
+
+[upstream]: https://example.com/r7
+
+Another bulk section with full feature mix.
+
+1. Ordered bulk one with *italic*
+2. Ordered bulk two with **bold**
+3. Ordered bulk three with `code`
+4. Ordered bulk four with [link](https://x)
+5. Ordered bulk five with [ref][upstream]
+
+> Bulk quote one.
+> Bulk quote two with `inline`.
+>
+> > Nested bulk quote.
+
+```rust
+fn bulk() -> i32 {
+    42
+}
+```
+
+End of bulk content.
+
+# Section repeat 8
+
+Ten paragraphs of mixed inline content follow.
+
+Paragraph 1: *a* **b** ***c*** `d` [e](https://e) ![f](/f.png) <https://g>.
+Paragraph 2: *foo* and **bar** and ***baz*** with `code` and [link](https://x).
+Paragraph 3: backslash escapes \* \_ \[ \] \\ and entities &amp; &#42;.
+Paragraph 4: HTML inlines <em>e</em> <strong>s</strong> <code>c</code>.
+Paragraph 5: hard break\
+on next line and soft  
+break here.
+Paragraph 6: long mixed prose with *italic*, **bold**, `code`, and a
+[link with title](https://example.com "title"), all on one paragraph.
+Paragraph 7: emphasis edge ***foo*bar*baz***.
+Paragraph 8: emphasis edge *foo **bar** baz*.
+Paragraph 9: emphasis edge **foo *bar* baz**.
+Paragraph 10: final paragraph with [ref-link][upstream].
+
+[upstream]: https://example.com/r8
+
+End of stress-mix.md.
+
+---
+
+# Section repeat 9
+
+[upstream]: https://example.com/r9
+[mirror]: https://example.org/r9
+[license-r9]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r9"
+
+## Subsection 9.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/9 "Example 9") and an
+![inline image](/img/example9.png "Caption 9"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r9] reference.
+
+Autolinks like <https://commonmark.org/9> and emails like <mail9@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 9</span> <kbd>Ctrl</kbd>+<kbd>9</kbd>.
+
+## Subsection 9.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/9)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x9 = 9
+  println(x9)
+  ```
+
+Nested ordered list:
+
+1. First level 9
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep9)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 9.3: block quotes
+
+> A simple block quote 9.
+> It spans two lines.
+
+> Outer block quote 9.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 9.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse9(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (9)
+    indented line two
+    val y9 = "with quotes \" and backslashes \\"
+
+## Subsection 9.5: emphasis edge cases
+
+Triple emphasis: ***foo 9 bar baz***
+Mixed: *foo **bar 9** baz*
+Adjacent: ****foo 9****
+Nested: *a *b *c 9* d* e*
+
+## Subsection 9.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r9].
+
+End of section repeat 9.
+
+---
+
+# Section repeat 10
+
+[upstream]: https://example.com/r10
+[mirror]: https://example.org/r10
+[license-r10]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r10"
+
+## Subsection 10.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/10 "Example 10") and an
+![inline image](/img/example10.png "Caption 10"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r10] reference.
+
+Autolinks like <https://commonmark.org/10> and emails like <mail10@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 10</span> <kbd>Ctrl</kbd>+<kbd>10</kbd>.
+
+## Subsection 10.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/10)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x10 = 10
+  println(x10)
+  ```
+
+Nested ordered list:
+
+1. First level 10
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep10)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 10.3: block quotes
+
+> A simple block quote 10.
+> It spans two lines.
+
+> Outer block quote 10.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 10.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse10(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (10)
+    indented line two
+    val y10 = "with quotes \" and backslashes \\"
+
+## Subsection 10.5: emphasis edge cases
+
+Triple emphasis: ***foo 10 bar baz***
+Mixed: *foo **bar 10** baz*
+Adjacent: ****foo 10****
+Nested: *a *b *c 10* d* e*
+
+## Subsection 10.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r10].
+
+End of section repeat 10.
+
+---
+
+# Section repeat 11
+
+[upstream]: https://example.com/r11
+[mirror]: https://example.org/r11
+[license-r11]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r11"
+
+## Subsection 11.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/11 "Example 11") and an
+![inline image](/img/example11.png "Caption 11"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r11] reference.
+
+Autolinks like <https://commonmark.org/11> and emails like <mail11@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 11</span> <kbd>Ctrl</kbd>+<kbd>11</kbd>.
+
+## Subsection 11.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/11)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x11 = 11
+  println(x11)
+  ```
+
+Nested ordered list:
+
+1. First level 11
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep11)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 11.3: block quotes
+
+> A simple block quote 11.
+> It spans two lines.
+
+> Outer block quote 11.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 11.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse11(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (11)
+    indented line two
+    val y11 = "with quotes \" and backslashes \\"
+
+## Subsection 11.5: emphasis edge cases
+
+Triple emphasis: ***foo 11 bar baz***
+Mixed: *foo **bar 11** baz*
+Adjacent: ****foo 11****
+Nested: *a *b *c 11* d* e*
+
+## Subsection 11.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r11].
+
+End of section repeat 11.
+
+---
+
+# Section repeat 12
+
+[upstream]: https://example.com/r12
+[mirror]: https://example.org/r12
+[license-r12]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r12"
+
+## Subsection 12.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/12 "Example 12") and an
+![inline image](/img/example12.png "Caption 12"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r12] reference.
+
+Autolinks like <https://commonmark.org/12> and emails like <mail12@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 12</span> <kbd>Ctrl</kbd>+<kbd>12</kbd>.
+
+## Subsection 12.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/12)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x12 = 12
+  println(x12)
+  ```
+
+Nested ordered list:
+
+1. First level 12
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep12)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 12.3: block quotes
+
+> A simple block quote 12.
+> It spans two lines.
+
+> Outer block quote 12.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 12.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse12(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (12)
+    indented line two
+    val y12 = "with quotes \" and backslashes \\"
+
+## Subsection 12.5: emphasis edge cases
+
+Triple emphasis: ***foo 12 bar baz***
+Mixed: *foo **bar 12** baz*
+Adjacent: ****foo 12****
+Nested: *a *b *c 12* d* e*
+
+## Subsection 12.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r12].
+
+End of section repeat 12.
+
+---
+
+# Section repeat 13
+
+[upstream]: https://example.com/r13
+[mirror]: https://example.org/r13
+[license-r13]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r13"
+
+## Subsection 13.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/13 "Example 13") and an
+![inline image](/img/example13.png "Caption 13"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r13] reference.
+
+Autolinks like <https://commonmark.org/13> and emails like <mail13@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 13</span> <kbd>Ctrl</kbd>+<kbd>13</kbd>.
+
+## Subsection 13.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/13)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x13 = 13
+  println(x13)
+  ```
+
+Nested ordered list:
+
+1. First level 13
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep13)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 13.3: block quotes
+
+> A simple block quote 13.
+> It spans two lines.
+
+> Outer block quote 13.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 13.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse13(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (13)
+    indented line two
+    val y13 = "with quotes \" and backslashes \\"
+
+## Subsection 13.5: emphasis edge cases
+
+Triple emphasis: ***foo 13 bar baz***
+Mixed: *foo **bar 13** baz*
+Adjacent: ****foo 13****
+Nested: *a *b *c 13* d* e*
+
+## Subsection 13.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r13].
+
+End of section repeat 13.
+
+---
+
+# Section repeat 14
+
+[upstream]: https://example.com/r14
+[mirror]: https://example.org/r14
+[license-r14]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r14"
+
+## Subsection 14.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/14 "Example 14") and an
+![inline image](/img/example14.png "Caption 14"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r14] reference.
+
+Autolinks like <https://commonmark.org/14> and emails like <mail14@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 14</span> <kbd>Ctrl</kbd>+<kbd>14</kbd>.
+
+## Subsection 14.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/14)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x14 = 14
+  println(x14)
+  ```
+
+Nested ordered list:
+
+1. First level 14
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep14)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 14.3: block quotes
+
+> A simple block quote 14.
+> It spans two lines.
+
+> Outer block quote 14.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 14.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse14(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (14)
+    indented line two
+    val y14 = "with quotes \" and backslashes \\"
+
+## Subsection 14.5: emphasis edge cases
+
+Triple emphasis: ***foo 14 bar baz***
+Mixed: *foo **bar 14** baz*
+Adjacent: ****foo 14****
+Nested: *a *b *c 14* d* e*
+
+## Subsection 14.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r14].
+
+End of section repeat 14.
+
+---
+
+# Section repeat 15
+
+[upstream]: https://example.com/r15
+[mirror]: https://example.org/r15
+[license-r15]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r15"
+
+## Subsection 15.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/15 "Example 15") and an
+![inline image](/img/example15.png "Caption 15"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r15] reference.
+
+Autolinks like <https://commonmark.org/15> and emails like <mail15@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 15</span> <kbd>Ctrl</kbd>+<kbd>15</kbd>.
+
+## Subsection 15.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/15)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x15 = 15
+  println(x15)
+  ```
+
+Nested ordered list:
+
+1. First level 15
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep15)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 15.3: block quotes
+
+> A simple block quote 15.
+> It spans two lines.
+
+> Outer block quote 15.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 15.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse15(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (15)
+    indented line two
+    val y15 = "with quotes \" and backslashes \\"
+
+## Subsection 15.5: emphasis edge cases
+
+Triple emphasis: ***foo 15 bar baz***
+Mixed: *foo **bar 15** baz*
+Adjacent: ****foo 15****
+Nested: *a *b *c 15* d* e*
+
+## Subsection 15.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r15].
+
+End of section repeat 15.
+
+---
+
+# Section repeat 16
+
+[upstream]: https://example.com/r16
+[mirror]: https://example.org/r16
+[license-r16]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r16"
+
+## Subsection 16.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/16 "Example 16") and an
+![inline image](/img/example16.png "Caption 16"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r16] reference.
+
+Autolinks like <https://commonmark.org/16> and emails like <mail16@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 16</span> <kbd>Ctrl</kbd>+<kbd>16</kbd>.
+
+## Subsection 16.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/16)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x16 = 16
+  println(x16)
+  ```
+
+Nested ordered list:
+
+1. First level 16
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep16)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 16.3: block quotes
+
+> A simple block quote 16.
+> It spans two lines.
+
+> Outer block quote 16.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 16.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse16(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (16)
+    indented line two
+    val y16 = "with quotes \" and backslashes \\"
+
+## Subsection 16.5: emphasis edge cases
+
+Triple emphasis: ***foo 16 bar baz***
+Mixed: *foo **bar 16** baz*
+Adjacent: ****foo 16****
+Nested: *a *b *c 16* d* e*
+
+## Subsection 16.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r16].
+
+End of section repeat 16.
+
+---
+
+# Section repeat 17
+
+[upstream]: https://example.com/r17
+[mirror]: https://example.org/r17
+[license-r17]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r17"
+
+## Subsection 17.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/17 "Example 17") and an
+![inline image](/img/example17.png "Caption 17"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r17] reference.
+
+Autolinks like <https://commonmark.org/17> and emails like <mail17@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 17</span> <kbd>Ctrl</kbd>+<kbd>17</kbd>.
+
+## Subsection 17.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/17)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x17 = 17
+  println(x17)
+  ```
+
+Nested ordered list:
+
+1. First level 17
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep17)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 17.3: block quotes
+
+> A simple block quote 17.
+> It spans two lines.
+
+> Outer block quote 17.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 17.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse17(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (17)
+    indented line two
+    val y17 = "with quotes \" and backslashes \\"
+
+## Subsection 17.5: emphasis edge cases
+
+Triple emphasis: ***foo 17 bar baz***
+Mixed: *foo **bar 17** baz*
+Adjacent: ****foo 17****
+Nested: *a *b *c 17* d* e*
+
+## Subsection 17.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r17].
+
+End of section repeat 17.
+
+---
+
+# Section repeat 18
+
+[upstream]: https://example.com/r18
+[mirror]: https://example.org/r18
+[license-r18]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r18"
+
+## Subsection 18.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/18 "Example 18") and an
+![inline image](/img/example18.png "Caption 18"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r18] reference.
+
+Autolinks like <https://commonmark.org/18> and emails like <mail18@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 18</span> <kbd>Ctrl</kbd>+<kbd>18</kbd>.
+
+## Subsection 18.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/18)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x18 = 18
+  println(x18)
+  ```
+
+Nested ordered list:
+
+1. First level 18
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep18)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 18.3: block quotes
+
+> A simple block quote 18.
+> It spans two lines.
+
+> Outer block quote 18.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 18.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse18(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (18)
+    indented line two
+    val y18 = "with quotes \" and backslashes \\"
+
+## Subsection 18.5: emphasis edge cases
+
+Triple emphasis: ***foo 18 bar baz***
+Mixed: *foo **bar 18** baz*
+Adjacent: ****foo 18****
+Nested: *a *b *c 18* d* e*
+
+## Subsection 18.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r18].
+
+End of section repeat 18.
+
+---
+
+# Section repeat 19
+
+[upstream]: https://example.com/r19
+[mirror]: https://example.org/r19
+[license-r19]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r19"
+
+## Subsection 19.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/19 "Example 19") and an
+![inline image](/img/example19.png "Caption 19"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r19] reference.
+
+Autolinks like <https://commonmark.org/19> and emails like <mail19@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 19</span> <kbd>Ctrl</kbd>+<kbd>19</kbd>.
+
+## Subsection 19.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/19)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x19 = 19
+  println(x19)
+  ```
+
+Nested ordered list:
+
+1. First level 19
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep19)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 19.3: block quotes
+
+> A simple block quote 19.
+> It spans two lines.
+
+> Outer block quote 19.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 19.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse19(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (19)
+    indented line two
+    val y19 = "with quotes \" and backslashes \\"
+
+## Subsection 19.5: emphasis edge cases
+
+Triple emphasis: ***foo 19 bar baz***
+Mixed: *foo **bar 19** baz*
+Adjacent: ****foo 19****
+Nested: *a *b *c 19* d* e*
+
+## Subsection 19.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r19].
+
+End of section repeat 19.
+
+---
+
+# Section repeat 20
+
+[upstream]: https://example.com/r20
+[mirror]: https://example.org/r20
+[license-r20]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r20"
+
+## Subsection 20.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/20 "Example 20") and an
+![inline image](/img/example20.png "Caption 20"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r20] reference.
+
+Autolinks like <https://commonmark.org/20> and emails like <mail20@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 20</span> <kbd>Ctrl</kbd>+<kbd>20</kbd>.
+
+## Subsection 20.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/20)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x20 = 20
+  println(x20)
+  ```
+
+Nested ordered list:
+
+1. First level 20
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep20)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 20.3: block quotes
+
+> A simple block quote 20.
+> It spans two lines.
+
+> Outer block quote 20.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 20.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse20(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (20)
+    indented line two
+    val y20 = "with quotes \" and backslashes \\"
+
+## Subsection 20.5: emphasis edge cases
+
+Triple emphasis: ***foo 20 bar baz***
+Mixed: *foo **bar 20** baz*
+Adjacent: ****foo 20****
+Nested: *a *b *c 20* d* e*
+
+## Subsection 20.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r20].
+
+End of section repeat 20.

--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -1,0 +1,106 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
+import gossamer.*
+import hellenism.*, classloaders.threadContext
+import hieroglyph.*, charDecoders.utf8, textSanitizers.strict
+import probably.*
+import proscenium.*
+import quantitative.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.system
+import turbulence.*
+import vacuous.*
+
+object Benchmarks extends Suite(m"Punctuation benchmarks"):
+  sealed trait Information extends Dimension
+  sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
+  val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+
+  given byteDesignation: Designation[Bytes[1]] = () => t"B"
+  given decimalizer:     Decimalizer            = Decimalizer(2)
+  given device:          BenchmarkDevice        = LocalhostDevice
+  given prefixes:        Prefixes               = Prefixes(List(Kilo, Mega, Giga, Tera))
+
+  // ─── inputs ───────────────────────────────────────────────────────────────
+  // Loaded once from the bench module's classpath. `lazy val` means the cost
+  // of the read isn't paid until the first benchmark touches the input, and
+  // the same `Text` instance is reused across iterations so neither GC nor
+  // I/O contaminates the timing.
+
+  lazy val small:           Text = cp"/punctuation/small.md".read[Text]
+  lazy val medium:          Text = cp"/punctuation/medium.md".read[Text]
+  lazy val stressMix:       Text = cp"/punctuation/stress-mix.md".read[Text]
+  lazy val emphasisStress:  Text = cp"/punctuation/emphasis-stress.md".read[Text]
+
+  // ─── helpers ──────────────────────────────────────────────────────────────
+  // Each helper returns an `Int` derived from the parse result so the JIT
+  // cannot dead-code the call. `children.length` is cheap and structurally
+  // exercises the entire parse — anything elided would zero this out.
+
+  def parseJava(text: Text): Int = Commonmark.parse(text).children.length
+
+  // ─── benchmarks ───────────────────────────────────────────────────────────
+
+  def run(): Unit =
+    val bench = Bench()
+
+    val smallSize:          Quantity[Bytes[1]] = small.s.getBytes("UTF-8").nn.length*Byte
+    val mediumSize:         Quantity[Bytes[1]] = medium.s.getBytes("UTF-8").nn.length*Byte
+    val stressMixSize:      Quantity[Bytes[1]] = stressMix.s.getBytes("UTF-8").nn.length*Byte
+    val emphasisStressSize: Quantity[Bytes[1]] = emphasisStress.s.getBytes("UTF-8").nn.length*Byte
+
+    suite(m"Java baseline (commonmark-java 0.27.0)"):
+      bench(m"parse small (~2 KB, mixed prose)")
+       (target = 1*Second, operationSize = smallSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.small) }
+
+      bench(m"parse medium (~19 KB, real README)")
+       (target = 1*Second, operationSize = mediumSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.medium) }
+
+      bench(m"parse stress-mix (~38 KB, every feature)")
+       (target = 1*Second, operationSize = stressMixSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.stressMix) }
+
+      bench(m"parse emphasis-stress (~4 KB, inline-dense)")
+       (target = 1*Second, operationSize = emphasisStressSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.emphasisStress) }


### PR DESCRIPTION
Adds a `punctuation.bench` Mill module that times the existing Java-backed
`Commonmark.parse` against four representative Markdown documents, giving a
frozen measurement baseline for the planned native CommonMark parser.

---

A new benchmark module is available:

```
mill punctuation.bench.run
```

It measures `Commonmark.parse` throughput against four fixtures:

- a ~2 KB prose page (concatenated web content)
- a ~19 KB real README (`quantitative/doc/basics.md`)
- a ~38 KB synthetic document exercising every CommonMark feature
- a ~4 KB inline-dense document focused on the emphasis algorithm

Results are reported as MB/s by Sedentary's `Bench`, with the four cases
flagged as baselines for comparison once additional parser implementations
are added.