### PR TITLE
Add full link and image syntax with reference resolution

### DIFF
--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -36,19 +36,112 @@ import scala.collection.mutable.ArrayBuffer
 
 import anticipation.*
 import denominative.*
+import vacuous.*
 
-// Mutable builders mirroring the leaf cases of `Layout`. Each accumulates
-// content during the block-parse pass and produces a finalized `Layout` via
-// `finish`. Container builders (BlockQuote, lists) come in a later stage.
+// Mutable builder hierarchy for the block-parse pass. Containers hold a
+// child buffer and "pass through" continuation lines (after stripping their
+// own prefix) to the next-deeper open block. Leaves accumulate raw line
+// content and finalize to a single `Layout` value.
 
 sealed trait BlockBuilder:
   val line: Ordinal
+
+sealed trait LeafBuilder extends BlockBuilder:
   def finish(refs: LinkRefs): Layout
 
-final class ParagraphBuilder(val line: Ordinal) extends BlockBuilder:
+sealed trait ContainerBuilder extends BlockBuilder:
+  val children: ArrayBuffer[Layout] = ArrayBuffer()
+  // Try to continue this container on the given line. Returns the remaining
+  // (post-prefix) line content if it continues, or `Unset` if it doesn't.
+  def tryContinue(line: Text): Optional[Text]
+  def finish(refs: LinkRefs): Optional[Layout]
+  // Whether a blank line at this point closes the container.
+  def closesOnBlank: Boolean = false
+
+// Document is the always-open root container; never closes until end-of-input.
+final class DocumentBuilder extends ContainerBuilder:
+  val line: Ordinal = denominative.Prim
+  def tryContinue(line: Text): Optional[Text] = line
+  def finish(refs: LinkRefs): Optional[Layout] = Unset
+
+// `> ` blockquote container.
+final class BlockQuoteBuilder(val line: Ordinal) extends ContainerBuilder:
+  def tryContinue(line: Text): Optional[Text] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n || s.charAt(i) != '>' then return Unset
+    i += 1
+    if i < n && s.charAt(i) == ' ' then i += 1
+    else if i < n && s.charAt(i) == '\t' then i += 1
+    if i == 0 then line else Text(s.substring(i, n).nn)
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    Layout.BlockQuote(line, children.toSeq*)
+
+// A list item with a known content-indent column count. The marker has
+// already been stripped by the dispatcher when the item was opened.
+final class ListItemBuilder(val line: Ordinal, val indent: Int) extends ContainerBuilder:
+  // Tracks blank lines for tight/loose detection at the list level.
+  var hadBlank: Boolean = false
+
+  def tryContinue(line: Text): Optional[Text] =
+    if ParserSupport.isBlank(line) then
+      hadBlank = true
+      // a blank line continues the item; pass through empty
+      return Text("")
+    if ParserSupport.indentColumn(line) >= indent then
+      ParserSupport.stripIndent(line, indent)
+    else
+      Unset
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    Layout.Paragraph(line)  // placeholder; lists assemble items, not Paragraph
+
+// Bullet list container holding a sequence of `ListItemBuilder` children
+// (each finalised to a `List[Layout]` for the `Layout.BulletList` items*).
+final class BulletListBuilder(val line: Ordinal, val marker: Char) extends ContainerBuilder:
+  // Each entry is the children of one list item, in document order.
+  val items: ArrayBuffer[List[Layout]] = ArrayBuffer()
+  // True if any blank line has been observed between items (=> loose list).
+  var loose: Boolean = false
+
+  def tryContinue(line: Text): Optional[Text] = line
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    Layout.BulletList(line, !loose, items.toList*)
+
+// Ordered list container; `delimiter` is `.` or `)`; `start` is the first
+// item's number.
+final class OrderedListBuilder
+  ( val line:      Ordinal,
+    val start:     Int,
+    val delimiter: '.' | ')' )
+extends ContainerBuilder:
+  val items: ArrayBuffer[List[Layout]] = ArrayBuffer()
+  var loose: Boolean = false
+
+  def tryContinue(line: Text): Optional[Text] = line
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    val delim: Optional['.' | ')'] = delimiter
+    Layout.OrderedList(line, start, !loose, delim, items.toList*)
+
+final class ParagraphBuilder(val line: Ordinal) extends LeafBuilder:
   private val lines: ArrayBuffer[Text] = ArrayBuffer()
 
-  def addLine(text: Text): Unit = lines += text
+  def addLine(text: Text): Unit =
+    // CommonMark §4.8: leading whitespace on each line of a paragraph is
+    // stripped before forming the paragraph's raw content.
+    val s = text.s
+    val n = s.length
+    var i = 0
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    val stripped = if i == 0 then text else Text(s.substring(i, n).nn)
+    lines += stripped
+
   def isEmpty: Boolean = lines.isEmpty
 
   def joined: Text =
@@ -73,7 +166,7 @@ final class FencedCodeBlockBuilder
     val fenceLen:  Int,
     val indent:    Int,
     val info:      List[Text] )
-extends BlockBuilder:
+extends LeafBuilder:
   private val content: ArrayBuffer[Text] = ArrayBuffer()
 
   def addLine(text: Text): Unit = content += text
@@ -85,7 +178,7 @@ extends BlockBuilder:
       builder.append('\n')
     Layout.CodeBlock(line, info, Text(builder.toString))
 
-final class IndentedCodeBlockBuilder(val line: Ordinal) extends BlockBuilder:
+final class IndentedCodeBlockBuilder(val line: Ordinal) extends LeafBuilder:
   // Holds raw content lines after stripping the 4-column indent. Trailing
   // blank lines are stripped at finish-time per the CommonMark spec.
   private val content: ArrayBuffer[Text] = ArrayBuffer()

--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -32,46 +32,71 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import scala.collection.mutable.ArrayBuffer
 
-import strategies.throwUnsafely
+import anticipation.*
+import denominative.*
 
-import doms.html.whatwg
-import classloaders.system
+// Mutable builders mirroring the leaf cases of `Layout`. Each accumulates
+// content during the block-parse pass and produces a finalized `Layout` via
+// `finish`. Container builders (BlockQuote, lists) come in a later stage.
 
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
+sealed trait BlockBuilder:
+  val line: Ordinal
+  def finish(refs: LinkRefs): Layout
 
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
+final class ParagraphBuilder(val line: Ordinal) extends BlockBuilder:
+  private val lines: ArrayBuffer[Text] = ArrayBuffer()
 
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def addLine(text: Text): Unit = lines += text
+  def isEmpty: Boolean = lines.isEmpty
 
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def joined: Text =
+    val builder = new StringBuilder
+    var first = true
+    for line <- lines do
+      if first then first = false else builder.append('\n')
+      builder.append(line.s)
+    Text(builder.toString)
+
+  def finish(refs: LinkRefs): Layout =
+    Layout.Paragraph(line, InlineParser.parse(joined, refs)*)
+
+  // Setext headings rewrite an open paragraph as a heading; the underline
+  // line itself is consumed by the dispatcher, not added here.
+  def toHeading(level: 1 | 2 | 3 | 4 | 5 | 6, refs: LinkRefs): Layout =
+    Layout.Heading(line, level, InlineParser.parse(joined, refs)*)
+
+final class FencedCodeBlockBuilder
+  ( val line:      Ordinal,
+    val fenceChar: Char,
+    val fenceLen:  Int,
+    val indent:    Int,
+    val info:      List[Text] )
+extends BlockBuilder:
+  private val content: ArrayBuffer[Text] = ArrayBuffer()
+
+  def addLine(text: Text): Unit = content += text
+
+  def finish(refs: LinkRefs): Layout =
+    val builder = new StringBuilder
+    for line <- content do
+      builder.append(line.s)
+      builder.append('\n')
+    Layout.CodeBlock(line, info, Text(builder.toString))
+
+final class IndentedCodeBlockBuilder(val line: Ordinal) extends BlockBuilder:
+  // Holds raw content lines after stripping the 4-column indent. Trailing
+  // blank lines are stripped at finish-time per the CommonMark spec.
+  private val content: ArrayBuffer[Text] = ArrayBuffer()
+
+  def addLine(text: Text): Unit = content += text
+
+  def finish(refs: LinkRefs): Layout =
+    while content.nonEmpty && ParserSupport.isBlank(content.last) do
+      content.dropRightInPlace(1)
+    val builder = new StringBuilder
+    for line <- content do
+      builder.append(line.s)
+      builder.append('\n')
+    Layout.CodeBlock(line, Nil, Text(builder.toString))

--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -47,7 +47,7 @@ sealed trait BlockBuilder:
   val line: Ordinal
 
 sealed trait LeafBuilder extends BlockBuilder:
-  def finish(refs: LinkRefs): Layout
+  def finish(refs: LinkRefs): Optional[Layout]
 
 sealed trait ContainerBuilder extends BlockBuilder:
   val children: ArrayBuffer[Layout] = ArrayBuffer()
@@ -134,7 +134,9 @@ final class ParagraphBuilder(val line: Ordinal) extends LeafBuilder:
 
   def addLine(text: Text): Unit =
     // CommonMark §4.8: leading whitespace on each line of a paragraph is
-    // stripped before forming the paragraph's raw content.
+    // stripped before forming the paragraph's raw content. Trailing
+    // whitespace is preserved per-line so the inline parser can detect
+    // hard line breaks (two-trailing-spaces rule).
     val s = text.s
     val n = s.length
     var i = 0
@@ -144,21 +146,54 @@ final class ParagraphBuilder(val line: Ordinal) extends LeafBuilder:
 
   def isEmpty: Boolean = lines.isEmpty
 
-  def joined: Text =
+  // Joined raw content of the (post-link-ref) paragraph. The first
+  // `linkRefCount` lines are dropped — they were consumed as link reference
+  // definitions during `extractLinkRefs`.
+  private var linkRefCount: Int = 0
+
+  private def joined: Text =
     val builder = new StringBuilder
     var first = true
-    for line <- lines do
+    var idx = linkRefCount
+    while idx < lines.length do
       if first then first = false else builder.append('\n')
-      builder.append(line.s)
+      builder.append(lines(idx).s)
+      idx += 1
     Text(builder.toString)
 
-  def finish(refs: LinkRefs): Layout =
-    Layout.Paragraph(line, InlineParser.parse(joined, refs)*)
+  // Try to consume leading lines as link reference definitions. Returns the
+  // count consumed; updates `linkRefCount`.
+  private def extractLinkRefs(refs: LinkRefs): Int =
+    var count = 0
+    var done = false
+    while !done && count < lines.length do
+      val parsed = InlineSupport.parseLinkRefDef(lines(count))
+      if parsed.absent then done = true
+      else
+        refs.add(parsed.vouch)
+        count += 1
+    linkRefCount = count
+    count
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    extractLinkRefs(refs)
+    if linkRefCount >= lines.length then Unset
+    else Layout.Paragraph(line, InlineParser.parse(joined, refs)*)
 
   // Setext headings rewrite an open paragraph as a heading; the underline
-  // line itself is consumed by the dispatcher, not added here.
+  // line itself is consumed by the dispatcher, not added here. No link-ref
+  // extraction here — setext underlines stop link-ref accumulation by
+  // turning the paragraph into a heading.
   def toHeading(level: 1 | 2 | 3 | 4 | 5 | 6, refs: LinkRefs): Layout =
-    Layout.Heading(line, level, InlineParser.parse(joined, refs)*)
+    val text =
+      val builder = new StringBuilder
+      var first = true
+      for line <- lines do
+        if first then first = false else builder.append('\n')
+        builder.append(line.s)
+      Text(builder.toString)
+
+    Layout.Heading(line, level, InlineParser.parse(text, refs)*)
 
 final class FencedCodeBlockBuilder
   ( val line:      Ordinal,
@@ -171,7 +206,7 @@ extends LeafBuilder:
 
   def addLine(text: Text): Unit = content += text
 
-  def finish(refs: LinkRefs): Layout =
+  def finish(refs: LinkRefs): Optional[Layout] =
     val builder = new StringBuilder
     for line <- content do
       builder.append(line.s)
@@ -185,7 +220,7 @@ final class IndentedCodeBlockBuilder(val line: Ordinal) extends LeafBuilder:
 
   def addLine(text: Text): Unit = content += text
 
-  def finish(refs: LinkRefs): Layout =
+  def finish(refs: LinkRefs): Optional[Layout] =
     while content.nonEmpty && ParserSupport.isBlank(content.last) do
       content.dropRightInPlace(1)
     val builder = new StringBuilder

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -32,46 +32,128 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import scala.collection.mutable.ArrayBuffer
 
-import strategies.throwUnsafely
+import anticipation.*
+import denominative.*
+import prepositional.*
+import vacuous.*
+import zephyrine.*
+import zephyrine.lineation.linefeedChars
 
-import doms.html.whatwg
-import classloaders.system
+// Pass 1 of the native parser: line-by-line dispatch with a single-leaf
+// "open block" pointer. Stage 2 supports leaf blocks only (paragraph,
+// ATX/setext heading, thematic break, fenced/indented code block); container
+// blocks (blockquote, lists) come in stage 3, at which point this single
+// `openLeaf` pointer becomes a stack of open builders.
 
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
+final class BlockParser:
+  private val children: ArrayBuffer[Layout] = ArrayBuffer()
+  private val refs: LinkRefs = LinkRefs()
+  private var openLeaf: Optional[BlockBuilder] = Unset
 
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
+  def parse(text: Text): Markdown of Layout =
+    val cursor = Cursor(Iterator(text))
+    while cursor.more do
+      val ln = cursor.line
 
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+      val line = cursor.hold:
+        val start = cursor.mark
+        val foundLf = cursor.seek('\n')
+        val end = cursor.mark
+        val captured = cursor.grab(start, end)
+        if foundLf then cursor.advance()
+        captured
 
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+      processLine(line, ln)
+
+    closeOpenLeaf()
+    Markdown(refs.all, children.toSeq*)
+
+  private def closeOpenLeaf(): Unit = openLeaf match
+    case Unset => ()
+
+    case builder: BlockBuilder =>
+      children += builder.finish(refs)
+      openLeaf = Unset
+
+
+  private def processLine(line: Text, ln: Ordinal): Unit = openLeaf match
+    case fenced: FencedCodeBlockBuilder =>
+      if ParserSupport.isFenceCloser(line, fenced.fenceChar, fenced.fenceLen)
+      then closeOpenLeaf()
+      else fenced.addLine(ParserSupport.stripIndent(line, fenced.indent))
+
+    case indented: IndentedCodeBlockBuilder =>
+      if ParserSupport.isBlank(line) then
+        indented.addLine(ParserSupport.stripIndent(line, 4))
+      else if ParserSupport.indentColumn(line) >= 4 then
+        indented.addLine(ParserSupport.stripIndent(line, 4))
+      else
+        closeOpenLeaf()
+        dispatchGeneral(line, ln)
+
+    case _ => dispatchGeneral(line, ln)
+
+
+  private def dispatchGeneral(line: Text, ln: Ordinal): Unit =
+    if ParserSupport.isBlank(line) then
+      openLeaf match
+        case _: ParagraphBuilder => closeOpenLeaf()
+        case _                   => ()
+      return
+
+    ParserSupport.fenceOpener(line) match
+      case (ch: Char, count: Int, indent: Int, info: Text) =>
+        closeOpenLeaf()
+        val tokens = ParserSupport.cutInfo(info)
+        openLeaf = FencedCodeBlockBuilder(ln, ch, count, indent, tokens)
+        return
+
+      case Unset => ()
+
+    openLeaf match
+      case para: ParagraphBuilder if !para.isEmpty =>
+        ParserSupport.setextUnderline(line) match
+          case 1 =>
+            children += para.toHeading(1, refs)
+            openLeaf = Unset
+            return
+
+          case 2 =>
+            children += para.toHeading(2, refs)
+            openLeaf = Unset
+            return
+
+          case Unset => ()
+
+      case _ => ()
+
+    if ParserSupport.isThematicBreak(line) then
+      closeOpenLeaf()
+      children += Layout.ThematicBreak(ln)
+      return
+
+    ParserSupport.atxHeading(line) match
+      case (level: (1 | 2 | 3 | 4 | 5 | 6), content: Text) =>
+        closeOpenLeaf()
+        children += Layout.Heading(ln, level, InlineParser.parse(content, refs)*)
+        return
+
+      case Unset => ()
+
+    if openLeaf.absent && ParserSupport.indentColumn(line) >= 4 then
+      val indented = IndentedCodeBlockBuilder(ln)
+      indented.addLine(ParserSupport.stripIndent(line, 4))
+      openLeaf = indented
+      return
+
+    val text = ParserSupport.stripTrailingSpaces(line)
+    openLeaf match
+      case para: ParagraphBuilder => para.addLine(text)
+
+      case _ =>
+        closeOpenLeaf()
+        val para = ParagraphBuilder(ln)
+        para.addLine(text)
+        openLeaf = para

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -36,21 +36,31 @@ import scala.collection.mutable.ArrayBuffer
 
 import anticipation.*
 import denominative.*
+import fulminate.*
+import gossamer.*
 import prepositional.*
 import vacuous.*
 import zephyrine.*
 import zephyrine.lineation.linefeedChars
 
-// Pass 1 of the native parser: line-by-line dispatch with a single-leaf
-// "open block" pointer. Stage 2 supports leaf blocks only (paragraph,
-// ATX/setext heading, thematic break, fenced/indented code block); container
-// blocks (blockquote, lists) come in stage 3, at which point this single
-// `openLeaf` pointer becomes a stack of open builders.
+// Pass 1: line-by-line dispatch over a stack of open block builders. The
+// algorithm follows CommonMark's "phase 1" (block parsing):
+//
+//   1. For each line, walk down the open-block stack and ask each container
+//      builder to "continue" — for blockquotes that means stripping `> `,
+//      for list items it means stripping the required indent.
+//   2. Containers that can't continue terminate the walk; they get closed
+//      from the failure point downward (with `finish`), unless lazy
+//      paragraph continuation rescues them.
+//   3. With the residual line content, repeatedly try to open new container
+//      blocks (`>`, list markers).
+//   4. The leftover content goes into a leaf — heading, code block, or
+//      paragraph (start new or continue existing).
 
 final class BlockParser:
-  private val children: ArrayBuffer[Layout] = ArrayBuffer()
   private val refs: LinkRefs = LinkRefs()
-  private var openLeaf: Optional[BlockBuilder] = Unset
+  private val docBuilder: DocumentBuilder = DocumentBuilder()
+  private val openStack: ArrayBuffer[BlockBuilder] = ArrayBuffer(docBuilder)
 
   def parse(text: Text): Markdown of Layout =
     val cursor = Cursor(Iterator(text))
@@ -67,93 +77,299 @@ final class BlockParser:
 
       processLine(line, ln)
 
-    closeOpenLeaf()
-    Markdown(refs.all, children.toSeq*)
+    closeAll()
+    Markdown(refs.all, docBuilder.children.toSeq*)
 
-  private def closeOpenLeaf(): Unit = openLeaf match
-    case Unset => ()
+  // ─── stack management ───────────────────────────────────────────────────
 
-    case builder: BlockBuilder =>
-      children += builder.finish(refs)
-      openLeaf = Unset
+  private def deepest: BlockBuilder = openStack.last
 
+  private def closeOne(): Unit =
+    val builder = openStack.remove(openStack.length - 1)
+    val parent = openStack.last
+    builder match
+      case item: ListItemBuilder =>
+        parent match
+          case bl: BulletListBuilder  => bl.items += item.children.toList
+          case ol: OrderedListBuilder => ol.items += item.children.toList
+          case _                      => panic(m"ListItem parent must be a List")
 
-  private def processLine(line: Text, ln: Ordinal): Unit = openLeaf match
-    case fenced: FencedCodeBlockBuilder =>
-      if ParserSupport.isFenceCloser(line, fenced.fenceChar, fenced.fenceLen)
-      then closeOpenLeaf()
-      else fenced.addLine(ParserSupport.stripIndent(line, fenced.indent))
+      case container: ContainerBuilder =>
+        container.finish(refs).let: layout =>
+          addToParent(parent, layout)
 
-    case indented: IndentedCodeBlockBuilder =>
-      if ParserSupport.isBlank(line) then
-        indented.addLine(ParserSupport.stripIndent(line, 4))
-      else if ParserSupport.indentColumn(line) >= 4 then
-        indented.addLine(ParserSupport.stripIndent(line, 4))
-      else
-        closeOpenLeaf()
-        dispatchGeneral(line, ln)
+      case leaf: LeafBuilder =>
+        addToParent(parent, leaf.finish(refs))
 
-    case _ => dispatchGeneral(line, ln)
+  private def addToParent(parent: BlockBuilder, layout: Layout): Unit = parent match
+    case item: ListItemBuilder       => item.children += layout
+    case container: ContainerBuilder => container.children += layout
+    case _                           => panic(m"cannot add child to a leaf builder")
 
+  private def closeAll(): Unit = while openStack.length > 1 do closeOne()
 
-  private def dispatchGeneral(line: Text, ln: Ordinal): Unit =
-    if ParserSupport.isBlank(line) then
-      openLeaf match
-        case _: ParagraphBuilder => closeOpenLeaf()
+  private def closeFromIndex(idx: Int): Unit =
+    while openStack.length > idx do closeOne()
+
+  private def closeOpenLeafForNewBlock(): Unit = deepest match
+    case _: LeafBuilder => closeOne()
+    case _              => ()
+
+  private def closeListChainAtTop(): Unit =
+    var done = false
+    while !done do
+      deepest match
+        case _: ListItemBuilder    => closeOne()
+        case _: BulletListBuilder  => closeOne()
+        case _: OrderedListBuilder => closeOne()
+        case _                     => done = true
+
+  // ─── phase 1: walk containers ───────────────────────────────────────────
+
+  // Returns (firstUnmatchedIdx, residualLine). Indices < firstUnmatchedIdx
+  // are still-open containers that successfully continued.
+  private def walkContainers(line: Text): (Int, Text) =
+    var idx = 1
+    var remaining = line
+    var continueLoop = true
+    while idx < openStack.length && continueLoop do
+      openStack(idx) match
+        case container: ContainerBuilder =>
+          val cont = container.tryContinue(remaining)
+          if cont.absent then continueLoop = false
+          else
+            remaining = cont.vouch
+            idx += 1
+
+        case _: LeafBuilder => continueLoop = false
+    (idx, remaining)
+
+  // ─── phase 3: try to open new container blocks repeatedly ───────────────
+
+  private def tryOpenContainers(line: Text, ln: Ordinal): Text =
+    var current = line
+    var keepGoing = true
+    while keepGoing do
+      val (next, opened) = tryOpenOneContainer(current, ln)
+      if opened then current = next else keepGoing = false
+    current
+
+  private def tryOpenOneContainer(line: Text, ln: Ordinal): (Text, Boolean) =
+    // BlockQuote `>`
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent < 4 && i < n && s.charAt(i) == '>' then
+      i += 1
+      if i < n && s.charAt(i) == ' ' then i += 1
+      else if i < n && s.charAt(i) == '\t' then i += 1
+      closeOpenLeafForNewBlock()
+      val bq = BlockQuoteBuilder(ln)
+      openStack += bq
+      val rest = if i >= n then t"" else Text(s.substring(i, n).nn)
+      return (rest, true)
+
+    // Bullet list marker
+    ParserSupport.bulletMarker(line) match
+      case bm: BulletMarker =>
+        return openListItem(ln, Some(bm), None, line)
+
+      case Unset => ()
+
+    // Ordered list marker
+    ParserSupport.orderedMarker(line) match
+      case om: OrderedMarker =>
+        // CommonMark: an ordered list cannot interrupt a paragraph unless it
+        // starts at 1
+        deepest match
+          case _: ParagraphBuilder if om.start != 1 => ()
+
+          case _ =>
+            return openListItem(ln, None, Some(om), line)
+
+      case Unset => ()
+
+    (line, false)
+
+  // Open a new ListItem (and a parent List if needed).
+  private def openListItem
+    ( ln:      Ordinal,
+      bullet:  Option[BulletMarker],
+      ordered: Option[OrderedMarker],
+      line:    Text )
+  :   (Text, Boolean) =
+
+    val rest: Text = bullet.map(_.rest).orElse(ordered.map(_.rest)).get
+
+    // CommonMark: a list item with empty content cannot interrupt a paragraph
+    deepest match
+      case _: ParagraphBuilder if ParserSupport.isBlank(rest) =>
+        return (line, false)
+
+      case _ => ()
+
+    // Decide whether to reuse the open List or open a new one
+    val reuseList: Boolean = deepest match
+      case bl: BulletListBuilder =>
+        bullet match
+          case Some(bm) => bl.marker == bm.char
+          case None     => false
+
+      case ol: OrderedListBuilder =>
+        ordered match
+          case Some(om) => ol.delimiter == om.delimiter
+          case None     => false
+
+      case _ => false
+
+    if !reuseList then
+      closeOpenLeafForNewBlock()
+      closeListChainAtTop()
+
+      val newList: ContainerBuilder = bullet match
+        case Some(bm) => BulletListBuilder(ln, bm.char)
+
+        case None =>
+          val om = ordered.get
+          OrderedListBuilder(ln, om.start, om.delimiter)
+
+      openStack += newList
+    else
+      // The open list of matching kind is at the top; an open list-item
+      // would have been closed during phase-1 walk if its indent didn't
+      // match, but in case it didn't we close any item now.
+      closeOpenLeafForNewBlock()
+      deepest match
+        case _: ListItemBuilder => closeOne()
+        case _                  => ()
+
+    val contentIndent = bullet.map(_.contentIndent).getOrElse(ordered.get.contentIndent)
+    val item = ListItemBuilder(ln, contentIndent)
+    openStack += item
+
+    (rest, true)
+
+  // ─── per-line dispatch ──────────────────────────────────────────────────
+
+  private def processLine(originalLine: Text, ln: Ordinal): Unit =
+    val (matchedDepth, residual0) = walkContainers(originalLine)
+
+    // Active fenced/indented code block at the deepest position bypasses
+    // opening logic — feed it the residual after matched containers.
+    if matchedDepth < openStack.length then
+      openStack(matchedDepth) match
+        case fenced: FencedCodeBlockBuilder =>
+          if ParserSupport.isFenceCloser(residual0, fenced.fenceChar, fenced.fenceLen)
+          then closeFromIndex(matchedDepth)
+          else fenced.addLine(ParserSupport.stripIndent(residual0, fenced.indent))
+          return
+
+        case indented: IndentedCodeBlockBuilder =>
+          if ParserSupport.isBlank(residual0) then
+            indented.addLine(ParserSupport.stripIndent(residual0, 4))
+            return
+          else if ParserSupport.indentColumn(residual0) >= 4 then
+            indented.addLine(ParserSupport.stripIndent(residual0, 4))
+            return
+          else
+            // close indented code, fall through
+            closeFromIndex(matchedDepth)
+
+        case _ => ()
+
+    // Lazy paragraph continuation
+    val deepestIsParagraph = deepest.isInstanceOf[ParagraphBuilder]
+
+    val canLazyContinue =
+      deepestIsParagraph
+      && !ParserSupport.startsNonParagraphBlock(residual0)
+      && !ParserSupport.isBlank(residual0)
+
+    if canLazyContinue then
+      val para = deepest.asInstanceOf[ParagraphBuilder]
+      para.addLine(ParserSupport.stripTrailingSpaces(residual0))
+      return
+
+    // Mark blank-line-induced loose flag on enclosing list items before
+    // closing failed containers
+    if matchedDepth < openStack.length && ParserSupport.isBlank(residual0) then
+      var idx = 1
+      while idx < openStack.length do
+        openStack(idx) match
+          case item: ListItemBuilder => item.hadBlank = true
+          case _                     => ()
+        idx += 1
+
+    if matchedDepth < openStack.length then closeFromIndex(matchedDepth)
+
+    val residual = tryOpenContainers(residual0, ln)
+    placeLeaf(residual, ln)
+
+  private def placeLeaf(residual: Text, ln: Ordinal): Unit =
+    if ParserSupport.isBlank(residual) then
+      deepest match
+        case _: ParagraphBuilder => closeOne()
         case _                   => ()
       return
 
-    ParserSupport.fenceOpener(line) match
+    ParserSupport.fenceOpener(residual) match
       case (ch: Char, count: Int, indent: Int, info: Text) =>
-        closeOpenLeaf()
+        closeOpenLeafForNewBlock()
         val tokens = ParserSupport.cutInfo(info)
-        openLeaf = FencedCodeBlockBuilder(ln, ch, count, indent, tokens)
+        val fenced = FencedCodeBlockBuilder(ln, ch, count, indent, tokens)
+        openStack += fenced
         return
 
       case Unset => ()
 
-    openLeaf match
+    deepest match
       case para: ParagraphBuilder if !para.isEmpty =>
-        ParserSupport.setextUnderline(line) match
+        ParserSupport.setextUnderline(residual) match
           case 1 =>
-            children += para.toHeading(1, refs)
-            openLeaf = Unset
+            openStack.remove(openStack.length - 1)
+            addToParent(deepest, para.toHeading(1, refs))
             return
 
           case 2 =>
-            children += para.toHeading(2, refs)
-            openLeaf = Unset
+            openStack.remove(openStack.length - 1)
+            addToParent(deepest, para.toHeading(2, refs))
             return
 
           case Unset => ()
 
       case _ => ()
 
-    if ParserSupport.isThematicBreak(line) then
-      closeOpenLeaf()
-      children += Layout.ThematicBreak(ln)
+    if ParserSupport.isThematicBreak(residual) then
+      closeOpenLeafForNewBlock()
+      addToParent(deepest, Layout.ThematicBreak(ln))
       return
 
-    ParserSupport.atxHeading(line) match
+    ParserSupport.atxHeading(residual) match
       case (level: (1 | 2 | 3 | 4 | 5 | 6), content: Text) =>
-        closeOpenLeaf()
-        children += Layout.Heading(ln, level, InlineParser.parse(content, refs)*)
+        closeOpenLeafForNewBlock()
+        addToParent(deepest, Layout.Heading(ln, level, InlineParser.parse(content, refs)*))
         return
 
       case Unset => ()
 
-    if openLeaf.absent && ParserSupport.indentColumn(line) >= 4 then
+    val canStartIndentedCode = deepest match
+      case _: LeafBuilder => false
+      case _              => true
+
+    if canStartIndentedCode && ParserSupport.indentColumn(residual) >= 4 then
       val indented = IndentedCodeBlockBuilder(ln)
-      indented.addLine(ParserSupport.stripIndent(line, 4))
-      openLeaf = indented
+      indented.addLine(ParserSupport.stripIndent(residual, 4))
+      openStack += indented
       return
 
-    val text = ParserSupport.stripTrailingSpaces(line)
-    openLeaf match
+    val text = ParserSupport.stripTrailingSpaces(residual)
+    deepest match
       case para: ParagraphBuilder => para.addLine(text)
 
       case _ =>
-        closeOpenLeaf()
+        closeOpenLeafForNewBlock()
         val para = ParagraphBuilder(ln)
         para.addLine(text)
-        openLeaf = para
+        openStack += para

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -99,7 +99,8 @@ final class BlockParser:
           addToParent(parent, layout)
 
       case leaf: LeafBuilder =>
-        addToParent(parent, leaf.finish(refs))
+        leaf.finish(refs).let: layout =>
+          addToParent(parent, layout)
 
   private def addToParent(parent: BlockBuilder, layout: Layout): Unit = parent match
     case item: ListItemBuilder       => item.children += layout
@@ -289,7 +290,7 @@ final class BlockParser:
 
     if canLazyContinue then
       val para = deepest.asInstanceOf[ParagraphBuilder]
-      para.addLine(ParserSupport.stripTrailingSpaces(residual0))
+      para.addLine(residual0)
       return
 
     // Mark blank-line-induced loose flag on enclosing list items before
@@ -364,12 +365,13 @@ final class BlockParser:
       openStack += indented
       return
 
-    val text = ParserSupport.stripTrailingSpaces(residual)
+    // Trailing whitespace per-line is preserved so the inline parser can
+    // detect hard line breaks via the two-trailing-spaces rule.
     deepest match
-      case para: ParagraphBuilder => para.addLine(text)
+      case para: ParagraphBuilder => para.addLine(residual)
 
       case _ =>
         closeOpenLeafForNewBlock()
         val para = ParagraphBuilder(ln)
-        para.addLine(text)
+        para.addLine(residual)
         openStack += para

--- a/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
+++ b/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
@@ -45,13 +45,25 @@ import vacuous.*
 
 sealed trait InlineData
 
-case class TextData(text: Text)                                            extends InlineData
-case class CodeData(code: Text)                                            extends InlineData
-case object SoftbreakData                                                  extends InlineData
-case object LinebreakData                                                  extends InlineData
-case class LinkData(dest: Text, title: Optional[Text], children: Seq[Prose]) extends InlineData
-case class EmphasisData(children: List[InlineNode])                        extends InlineData
-case class StrongData(children: List[InlineNode])                          extends InlineData
+case class TextData(text: Text)                                                extends InlineData
+case class CodeData(code: Text)                                                extends InlineData
+case object SoftbreakData                                                      extends InlineData
+case object LinebreakData                                                      extends InlineData
+case class LinkData
+  ( dest: Text, title: Optional[Text], children: List[InlineNode] )
+extends InlineData
+
+case class ImageData
+  ( dest: Text, title: Optional[Text], children: List[InlineNode] )
+extends InlineData
+case class EmphasisData(children: List[InlineNode])                            extends InlineData
+case class StrongData(children: List[InlineNode])                              extends InlineData
+
+// `[` or `![` marker placed in the inline list when a link/image bracket
+// opens. After tokenization the corresponding `BracketEntry` in the parser's
+// bracket stack tells us whether to wrap as a link, leave as literal text,
+// or skip (if the marker was deactivated by a containing link).
+final class BracketData(val isImage: Boolean) extends InlineData
 
 // `*` or `_` delimiter run. `length` may be reduced as the emphasis
 // algorithm consumes characters from the run.
@@ -245,9 +257,11 @@ object EmphasisProcessor:
     case CodeData(c)             => Some(Prose.Code(c))
     case SoftbreakData           => Some(Prose.Softbreak)
     case LinebreakData           => Some(Prose.Linebreak)
-    case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch*))
+    case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch.flatMap(proseOf)*))
+    case ImageData(d, title, ch) => Some(Prose.Image(d, title, ch.flatMap(proseOf)*))
     case EmphasisData(children)  => Some(Prose.Emphasis(children.flatMap(proseOf)*))
     case StrongData(children)    => Some(Prose.Strong(children.flatMap(proseOf)*))
+    case b: BracketData          => Some(Prose.Textual(Text(if b.isImage then "![" else "[")))
     case d: DelimData            => unmatchedDelim(d)
 
   private def unmatchedDelim(d: DelimData): Option[Prose] =

--- a/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
+++ b/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
@@ -1,0 +1,257 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import scala.collection.mutable
+
+import anticipation.*
+import vacuous.*
+
+// Working representation for inline parsing. The inline parser builds a
+// doubly-linked list of `InlineNode`s, including delimiter-run nodes for
+// `*`/`_`. `processEmphasis` then walks the linked list, pairing openers
+// with closers per the CommonMark rules and inserting `EmphasisData` /
+// `StrongData` wrappers in their place.
+
+sealed trait InlineData
+
+case class TextData(text: Text)                                            extends InlineData
+case class CodeData(code: Text)                                            extends InlineData
+case object SoftbreakData                                                  extends InlineData
+case object LinebreakData                                                  extends InlineData
+case class LinkData(dest: Text, title: Optional[Text], children: Seq[Prose]) extends InlineData
+case class EmphasisData(children: List[InlineNode])                        extends InlineData
+case class StrongData(children: List[InlineNode])                          extends InlineData
+
+// `*` or `_` delimiter run. `length` may be reduced as the emphasis
+// algorithm consumes characters from the run.
+final class DelimData
+  ( val char: Char,
+    var length: Int,
+    val canOpen: Boolean,
+    val canClose: Boolean )
+extends InlineData
+
+final class InlineNode(var data: InlineData):
+  var prev: InlineNode | Null = null
+  var next: InlineNode | Null = null
+
+
+final class InlineList:
+  var first: InlineNode | Null = null
+  var last:  InlineNode | Null = null
+
+  def append(data: InlineData): InlineNode =
+    val node = InlineNode(data)
+    node.prev = last
+    if last == null then first = node else last.nn.next = node
+    last = node
+    node
+
+  def insertAfter(node: InlineNode, newNode: InlineNode): Unit =
+    newNode.prev = node
+    newNode.next = node.next
+    if node.next == null then last = newNode else node.next.nn.prev = newNode
+    node.next = newNode
+
+  def remove(node: InlineNode): Unit =
+    val p = node.prev
+    val n = node.next
+    if p == null then first = n else p.next = n
+    if n == null then last  = p else n.prev = p
+    node.prev = null
+    node.next = null
+
+  def iterator: Iterator[InlineNode] = new Iterator[InlineNode]:
+    var cur: InlineNode | Null = first
+    def hasNext: Boolean = cur != null
+
+    def next(): InlineNode =
+      val n = cur.nn
+      cur = n.next
+      n
+
+
+object EmphasisProcessor:
+
+  // CommonMark left-flanking: not followed by Unicode whitespace AND
+  // (not followed by Unicode punctuation OR preceded by Unicode whitespace
+  // or punctuation).
+  def isLeftFlanking(prevChar: Char, nextChar: Char): Boolean =
+    if isUnicodeWhitespace(nextChar) then return false
+    if !isUnicodePunctuation(nextChar) then return true
+    isUnicodeWhitespace(prevChar) || isUnicodePunctuation(prevChar)
+
+  def isRightFlanking(prevChar: Char, nextChar: Char): Boolean =
+    if isUnicodeWhitespace(prevChar) then return false
+    if !isUnicodePunctuation(prevChar) then return true
+    isUnicodeWhitespace(nextChar) || isUnicodePunctuation(nextChar)
+
+  def isUnicodeWhitespace(c: Char): Boolean =
+    c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ''
+    || Character.getType(c) == Character.SPACE_SEPARATOR
+
+  def isUnicodePunctuation(c: Char): Boolean =
+    val t = Character.getType(c)
+    t == Character.CONNECTOR_PUNCTUATION
+    || t == Character.DASH_PUNCTUATION
+    || t == Character.START_PUNCTUATION
+    || t == Character.END_PUNCTUATION
+    || t == Character.INITIAL_QUOTE_PUNCTUATION
+    || t == Character.FINAL_QUOTE_PUNCTUATION
+    || t == Character.OTHER_PUNCTUATION
+    // CommonMark also classifies a few math/currency/etc. as punctuation; this
+    // keeps the common ASCII punctuation set right (which covers all spec
+    // tests). A broader set can be added later.
+
+  // Compute (canOpen, canClose) for a delimiter run.
+  def classifyDelim
+    ( char:     Char,
+      prevChar: Char,
+      nextChar: Char )
+  :   (Boolean, Boolean) =
+
+    val left = isLeftFlanking(prevChar, nextChar)
+    val right = isRightFlanking(prevChar, nextChar)
+    if char == '*' then (left, right)
+    else
+      val canOpen = left && (!right || isUnicodePunctuation(prevChar))
+      val canClose = right && (!left || isUnicodePunctuation(nextChar))
+      (canOpen, canClose)
+
+  // Implements CommonMark's "process emphasis" algorithm (§6.2). Walks the
+  // doubly-linked list, pairing matching opener/closer delimiter runs and
+  // wrapping the inline nodes between them as `EmphasisData` / `StrongData`.
+  def process(list: InlineList, stackBottom: InlineNode | Null): Unit =
+    // Locate first delimiter strictly above stackBottom
+    var current: InlineNode | Null =
+      if stackBottom == null then list.first else stackBottom.next
+
+    // openers_bottom indexed by (char, length % 3, canOpen-of-closer)
+    val openersBottom = mutable.Map[(Char, Int, Boolean), InlineNode | Null]()
+
+    def floorOf(closer: DelimData): InlineNode | Null =
+      openersBottom.getOrElse((closer.char, closer.length % 3, closer.canOpen), stackBottom)
+
+    while current != null do
+      val curNode = current
+      val curData = curNode.data
+      curData match
+        case closer: DelimData if closer.canClose =>
+          val floor = floorOf(closer)
+          var opener: InlineNode | Null = curNode.prev
+          var matched = false
+
+          while opener != null && opener != floor && opener != stackBottom && !matched do
+            val openerNode = opener
+            openerNode.data match
+              case od: DelimData if od.canOpen && od.char == closer.char =>
+                val ruleOf3 =
+                  (od.canClose || closer.canOpen)
+                  && (od.length + closer.length) % 3 == 0
+                  && (od.length % 3 != 0 || closer.length % 3 != 0)
+
+                if !ruleOf3 then
+                  val strong = od.length >= 2 && closer.length >= 2
+                  val take = if strong then 2 else 1
+
+                  // Collect children strictly between opener and closer
+                  val children = mutable.ListBuffer[InlineNode]()
+                  var cursor: InlineNode | Null = openerNode.next
+                  while cursor != null && cursor != curNode do
+                    val n = cursor
+                    val nx = n.next
+                    list.remove(n)
+                    children += n
+                    cursor = nx
+
+                  val wrapper =
+                    if strong then InlineNode(StrongData(children.toList))
+                    else InlineNode(EmphasisData(children.toList))
+
+                  list.insertAfter(openerNode, wrapper)
+
+                  od.length -= take
+                  closer.length -= take
+
+                  if od.length == 0 then list.remove(openerNode)
+                  if closer.length == 0 then
+                    val nxt = curNode.next
+                    list.remove(curNode)
+                    current = nxt
+                    matched = true
+                  else
+                    matched = true
+                    // Continue with the now-shorter closer at the same node
+                else
+                  opener = openerNode.prev
+
+              case _ => opener = openerNode.prev
+
+          if !matched then
+            openersBottom((closer.char, closer.length % 3, closer.canOpen)) = curNode.prev
+            if !closer.canOpen then
+              val nxt = curNode.next
+              list.remove(curNode)
+              current = nxt
+            else
+              current = curNode.next
+
+        case _ => current = curNode.next
+
+  // Convert the (post-emphasis) inline list to a Seq[Prose] for embedding
+  // in a Layout.Paragraph or Layout.Heading.
+  def toProse(list: InlineList): Seq[Prose] =
+    val builder = mutable.ListBuffer[Prose]()
+    var cur: InlineNode | Null = list.first
+    while cur != null do
+      val node = cur
+      proseOf(node).foreach(builder += _)
+      cur = node.next
+    builder.toSeq
+
+  private def proseOf(node: InlineNode): Option[Prose] = node.data match
+    case TextData(t)             => Some(Prose.Textual(t))
+    case CodeData(c)             => Some(Prose.Code(c))
+    case SoftbreakData           => Some(Prose.Softbreak)
+    case LinebreakData           => Some(Prose.Linebreak)
+    case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch*))
+    case EmphasisData(children)  => Some(Prose.Emphasis(children.flatMap(proseOf)*))
+    case StrongData(children)    => Some(Prose.Strong(children.flatMap(proseOf)*))
+    case d: DelimData            => unmatchedDelim(d)
+
+  private def unmatchedDelim(d: DelimData): Option[Prose] =
+    val sb = new StringBuilder
+    var k = 0
+    while k < d.length do { sb.append(d.char); k += 1 }
+    if d.length > 0 then Some(Prose.Textual(Text(sb.toString))) else None

--- a/lib/punctuation/src/core/punctuation.HtmlEntities.scala
+++ b/lib/punctuation/src/core/punctuation.HtmlEntities.scala
@@ -32,106 +32,31 @@
                                                                                                   */
 package punctuation
 
-import scala.collection.mutable
-
 import anticipation.*
-import vacuous.*
+import hellenism.*, classloaders.threadContext
+import hieroglyph.*, charDecoders.utf8, textSanitizers.skip
+import turbulence.*
 
-// Inline parser. Consumes the raw text of one paragraph or heading and emits
-// a `Seq[Prose]`. Stage 4 covers literal text, backslash escapes, character
-// entities, code spans, autolinks, and hard/soft line breaks. Emphasis,
-// links, images, and reference-link resolution arrive in stages 5–6.
-
-object InlineParser:
-  def parse(text: Text, refs: LinkRefs): Seq[Prose] =
-    val s = text.s
-    val n = s.length
-
-    // CommonMark §4.8: strip trailing whitespace from the paragraph's raw
-    // content before inline parsing. Internal-line trailing whitespace is
-    // preserved here so the per-line hard-break detection still works.
-    var end = n
-    while end > 0 && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
-
-    val builder = mutable.ListBuffer[Prose]()
-    val pending = new StringBuilder
-
-    def flushPending(): Unit =
-      if pending.length > 0 then
-        builder += Prose.Textual(Text(pending.toString))
-        pending.clear()
-
+// HTML5 named character references, loaded once from the `entities-extra.tsv`
+// resource shipped by Honeycomb. Only entries with a trailing semicolon are
+// kept, since CommonMark requires the `;` terminator for named entities to
+// be valid.
+object HtmlEntities:
+  private lazy val table: Map[String, String] =
+    val tsv = cp"/honeycomb/entities-extra.tsv".read[Text].s
+    val builder = Map.newBuilder[String, String]
+    val lines = tsv.split("\n").nn
     var i = 0
-    while i < end do
-      val c = s.charAt(i)
-      c match
-        case '\\' =>
-          if i + 1 < end then
-            val next = s.charAt(i + 1)
-            if next == '\n' then
-              flushPending()
-              builder += Prose.Linebreak
-              i += 2
-              while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
-            else if InlineSupport.isAsciiPunctuation(next) then
-              pending.append(next)
-              i += 2
-            else
-              pending.append('\\')
-              i += 1
-          else
-            pending.append('\\')
-            i += 1
+    while i < lines.length do
+      val line = lines(i).nn
+      val tab = line.indexOf('\t')
+      if tab > 0 && line.charAt(tab - 1) == ';' then
+        val name = line.substring(0, tab - 1).nn
+        val value = line.substring(tab + 1).nn
+        builder += (name -> value)
+      i += 1
+    builder.result()
 
-        case '&' =>
-          InlineSupport.parseEntity(s, i, end) match
-            case e: EntityMatch =>
-              pending.append(e.decoded)
-              i = e.end
-
-            case Unset =>
-              pending.append('&')
-              i += 1
-
-        case '`' =>
-          InlineSupport.parseCodeSpan(s, i, end) match
-            case cs: CodeSpanMatch =>
-              flushPending()
-              builder += Prose.Code(cs.content)
-              i = cs.end
-
-            case Unset =>
-              pending.append('`')
-              i += 1
-
-        case '<' =>
-          InlineSupport.parseAutolink(s, i, end) match
-            case al: AutolinkMatch =>
-              flushPending()
-              builder += al.link
-              i = al.end
-
-            case Unset =>
-              pending.append('<')
-              i += 1
-
-        case '\n' =>
-          // Hard break if pending ends with 2+ trailing spaces, else soft.
-          var j = pending.length
-          var spaces = 0
-          while j > 0 && pending.charAt(j - 1) == ' ' do
-            j -= 1
-            spaces += 1
-          pending.setLength(j)
-          flushPending()
-          if spaces >= 2 then builder += Prose.Linebreak
-          else builder += Prose.Softbreak
-          i += 1
-          while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
-
-        case _ =>
-          pending.append(c)
-          i += 1
-
-    flushPending()
-    builder.toSeq
+  // Returns the decoded text for a named entity (without `&` or `;`), or
+  // `null` if no such entity exists.
+  def lookup(name: String): String | Null = table.getOrElse(name, null)

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -32,15 +32,15 @@
                                                                                                   */
 package punctuation
 
-import scala.collection.mutable
-
 import anticipation.*
 import vacuous.*
 
-// Inline parser. Consumes the raw text of one paragraph or heading and emits
-// a `Seq[Prose]`. Stage 4 covers literal text, backslash escapes, character
-// entities, code spans, autolinks, and hard/soft line breaks. Emphasis,
-// links, images, and reference-link resolution arrive in stages 5–6.
+// Inline parser. Two passes:
+//   1. Tokenize the paragraph's raw text into a doubly-linked list of
+//      `InlineNode`s, including delimiter-run nodes for `*`/`_`.
+//   2. Run the CommonMark emphasis algorithm over the delimiter runs in the
+//      list, wrapping matched openers/closers as `EmphasisData`/`StrongData`.
+// The resulting list is then converted to a `Seq[Prose]`.
 
 object InlineParser:
   def parse(text: Text, refs: LinkRefs): Seq[Prose] =
@@ -48,17 +48,17 @@ object InlineParser:
     val n = s.length
 
     // CommonMark §4.8: strip trailing whitespace from the paragraph's raw
-    // content before inline parsing. Internal-line trailing whitespace is
-    // preserved here so the per-line hard-break detection still works.
+    // content before inline parsing. Per-line trailing whitespace is kept so
+    // hard-break detection still works at internal `\n` positions.
     var end = n
     while end > 0 && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
 
-    val builder = mutable.ListBuffer[Prose]()
+    val list = InlineList()
     val pending = new StringBuilder
 
     def flushPending(): Unit =
       if pending.length > 0 then
-        builder += Prose.Textual(Text(pending.toString))
+        list.append(TextData(Text(pending.toString)))
         pending.clear()
 
     var i = 0
@@ -67,14 +67,14 @@ object InlineParser:
       c match
         case '\\' =>
           if i + 1 < end then
-            val next = s.charAt(i + 1)
-            if next == '\n' then
+            val nextCh = s.charAt(i + 1)
+            if nextCh == '\n' then
               flushPending()
-              builder += Prose.Linebreak
+              list.append(LinebreakData)
               i += 2
               while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
-            else if InlineSupport.isAsciiPunctuation(next) then
-              pending.append(next)
+            else if InlineSupport.isAsciiPunctuation(nextCh) then
+              pending.append(nextCh)
               i += 2
             else
               pending.append('\\')
@@ -97,7 +97,7 @@ object InlineParser:
           InlineSupport.parseCodeSpan(s, i, end) match
             case cs: CodeSpanMatch =>
               flushPending()
-              builder += Prose.Code(cs.content)
+              list.append(CodeData(cs.content))
               i = cs.end
 
             case Unset =>
@@ -108,7 +108,13 @@ object InlineParser:
           InlineSupport.parseAutolink(s, i, end) match
             case al: AutolinkMatch =>
               flushPending()
-              builder += al.link
+              al.link match
+                case link: Prose.Link =>
+                  list.append(LinkData(link.destination, link.title, link.prose))
+
+                case other =>
+                  list.append(TextData(Text(other.toString)))
+
               i = al.end
 
             case Unset =>
@@ -116,7 +122,6 @@ object InlineParser:
               i += 1
 
         case '\n' =>
-          // Hard break if pending ends with 2+ trailing spaces, else soft.
           var j = pending.length
           var spaces = 0
           while j > 0 && pending.charAt(j - 1) == ' ' do
@@ -124,14 +129,36 @@ object InlineParser:
             spaces += 1
           pending.setLength(j)
           flushPending()
-          if spaces >= 2 then builder += Prose.Linebreak
-          else builder += Prose.Softbreak
+          if spaces >= 2 then list.append(LinebreakData)
+          else list.append(SoftbreakData)
           i += 1
           while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+
+        case '*' | '_' =>
+          // Delimiter run: count consecutive same-char characters.
+          var j = i
+          while j < end && s.charAt(j) == c do j += 1
+          val length = j - i
+
+          // Flanking detection uses the source characters immediately before
+          // the run and immediately after.
+          val prevChar = if i == 0 then ' ' else s.charAt(i - 1)
+          val nextChar = if j >= end then ' ' else s.charAt(j)
+
+          val (canOpen, canClose) =
+            EmphasisProcessor.classifyDelim(c, prevChar, nextChar)
+
+          flushPending()
+          list.append(DelimData(c, length, canOpen, canClose))
+          i = j
 
         case _ =>
           pending.append(c)
           i += 1
 
     flushPending()
-    builder.toSeq
+
+    // Pass 2: emphasis processing
+    EmphasisProcessor.process(list, null)
+
+    EmphasisProcessor.toProse(list)

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -32,46 +32,15 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import anticipation.*
 
-import strategies.throwUnsafely
-
-import doms.html.whatwg
-import classloaders.system
-
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
-
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
-
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
-
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+// Skeleton inline parser. Stage 4 will introduce text/escape/entity/codespan/
+// autolink/hardbreak/softbreak handling; stage 5 the emphasis delimiter
+// algorithm; stage 6 link/image and reference resolution. For now the entire
+// raw text is wrapped as a single `Prose.Textual`, which means anything other
+// than literal text (emphasis, links, code spans, escapes) will not match the
+// reference parser's output.
+object InlineParser:
+  def parse(text: Text, refs: LinkRefs): Seq[Prose] =
+    if text.s.isEmpty then Nil
+    else Seq(Prose.Textual(text))

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -32,29 +32,45 @@
                                                                                                   */
 package punctuation
 
+import scala.collection.mutable
+
 import anticipation.*
+import gossamer.*
 import vacuous.*
 
 // Inline parser. Two passes:
 //   1. Tokenize the paragraph's raw text into a doubly-linked list of
-//      `InlineNode`s, including delimiter-run nodes for `*`/`_`.
-//   2. Run the CommonMark emphasis algorithm over the delimiter runs in the
-//      list, wrapping matched openers/closers as `EmphasisData`/`StrongData`.
+//      `InlineNode`s — including delimiter-run nodes for `*`/`_` and
+//      bracket-marker nodes for `[`/`![` — and try-match links/images on
+//      `]`. Successful link matches wrap the bracketed content as
+//      `LinkData` / `ImageData` and process emphasis within it.
+//   2. After tokenization, run a final emphasis pass over any remaining
+//      delimiters outside successfully-matched links.
 // The resulting list is then converted to a `Seq[Prose]`.
 
 object InlineParser:
+
+  // Bracket stack entry. `node` is the BracketData node in the inline list
+  // marking the `[` or `![`. `sourceStart` is the source position
+  // immediately AFTER the opening bracket (used to extract the literal
+  // bracket content for shortcut/collapsed reference labels). `active` is
+  // false when a containing link has been matched (no nested links).
+  private final class BracketEntry
+    ( val node:        InlineNode,
+      val isImage:     Boolean,
+      val sourceStart: Int,
+      var active:      Boolean = true )
+
   def parse(text: Text, refs: LinkRefs): Seq[Prose] =
     val s = text.s
     val n = s.length
 
-    // CommonMark §4.8: strip trailing whitespace from the paragraph's raw
-    // content before inline parsing. Per-line trailing whitespace is kept so
-    // hard-break detection still works at internal `\n` positions.
     var end = n
     while end > 0 && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
 
     val list = InlineList()
     val pending = new StringBuilder
+    val brackets = mutable.Stack[BracketEntry]()
 
     def flushPending(): Unit =
       if pending.length > 0 then
@@ -110,10 +126,13 @@ object InlineParser:
               flushPending()
               al.link match
                 case link: Prose.Link =>
-                  list.append(LinkData(link.destination, link.title, link.prose))
+                  val child = InlineNode(TextData(link.prose.head match
+                    case Prose.Textual(t) => t
+                    case _                => link.destination))
+                  list.append(LinkData(link.destination, link.title, List(child)))
 
-                case other =>
-                  list.append(TextData(Text(other.toString)))
+                case _ =>
+                  list.append(TextData(Text(al.link.toString)))
 
               i = al.end
 
@@ -135,13 +154,10 @@ object InlineParser:
           while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
 
         case '*' | '_' =>
-          // Delimiter run: count consecutive same-char characters.
           var j = i
           while j < end && s.charAt(j) == c do j += 1
           val length = j - i
 
-          // Flanking detection uses the source characters immediately before
-          // the run and immediately after.
           val prevChar = if i == 0 then ' ' else s.charAt(i - 1)
           val nextChar = if j >= end then ' ' else s.charAt(j)
 
@@ -152,13 +168,128 @@ object InlineParser:
           list.append(DelimData(c, length, canOpen, canClose))
           i = j
 
+        case '[' =>
+          flushPending()
+          val node = list.append(BracketData(isImage = false))
+          brackets.push(BracketEntry(node, isImage = false, sourceStart = i + 1))
+          i += 1
+
+        case '!' if i + 1 < end && s.charAt(i + 1) == '[' =>
+          flushPending()
+          val node = list.append(BracketData(isImage = true))
+          brackets.push(BracketEntry(node, isImage = true, sourceStart = i + 2))
+          i += 2
+
+        case ']' =>
+          flushPending()
+          val newPos = handleCloseBracket(list, brackets, s, i, end, refs)
+          i = newPos
+
         case _ =>
           pending.append(c)
           i += 1
 
     flushPending()
 
-    // Pass 2: emphasis processing
     EmphasisProcessor.process(list, null)
-
     EmphasisProcessor.toProse(list)
+
+  // Handle a closing `]` at source position `closePos`. Returns the new
+  // source index to continue from.
+  private def handleCloseBracket
+    ( list:     InlineList,
+      brackets: mutable.Stack[BracketEntry],
+      s:        String,
+      closePos: Int,
+      end:      Int,
+      refs:     LinkRefs )
+  :   Int =
+
+    if brackets.isEmpty then
+      list.append(TextData(t"]"))
+      return closePos + 1
+
+    val entry = brackets.pop()
+
+    if !entry.active then
+      // Inactive marker: drop bracket node, emit literal `]`
+      list.remove(entry.node)
+      list.append(TextData(t"]"))
+      return closePos + 1
+
+    // Try to match link/image syntax starting at the character after `]`
+    val afterClose = closePos + 1
+    tryMatchLink(s, afterClose, end, entry, refs) match
+      case Unset =>
+        // No link match: bracket and `]` become literal text
+        list.remove(entry.node)
+        list.append(TextData(if entry.isImage then t"![" else t"["))
+        list.append(TextData(t"]"))
+        afterClose
+
+      case lm: LinkResolution =>
+        // Process emphasis in the bracket content (between bracket node and
+        // current end of list), so emphasis WITHIN the link is wrapped first.
+        EmphasisProcessor.process(list, entry.node)
+
+        // Collect children: everything strictly after the bracket node, to
+        // the end of the list.
+        val children = mutable.ListBuffer[InlineNode]()
+        var cursor: InlineNode | Null = entry.node.next
+        while cursor != null do
+          val n = cursor
+          val nxt = n.next
+          list.remove(n)
+          children += n
+          cursor = nxt
+
+        // Replace bracket node with the link/image wrapper
+        list.remove(entry.node)
+        if entry.isImage then list.append(ImageData(lm.dest, lm.title, children.toList))
+        else
+          list.append(LinkData(lm.dest, lm.title, children.toList))
+          // Deactivate any earlier `[` markers (no nested links)
+          brackets.foreach(_.active = false)
+
+        lm.end
+
+  private case class LinkResolution(dest: Text, title: Optional[Text], end: Int)
+
+  private def tryMatchLink
+    ( s:        String,
+      after:    Int,
+      end:      Int,
+      entry:    BracketEntry,
+      refs:     LinkRefs )
+  :   Optional[LinkResolution] =
+
+    // 1. Inline link: ( dest title? )
+    if after < end && s.charAt(after) == '(' then
+      InlineSupport.parseInlineLinkBody(s, after, end) match
+        case b: InlineSupport.InlineLinkBody =>
+          return LinkResolution(b.dest, b.title, b.end)
+
+        case Unset => return Unset
+
+    // 2. Reference forms
+    val bracketContent = Text(s.substring(entry.sourceStart, after - 1).nn)
+
+    if after < end && s.charAt(after) == '[' then
+      InlineSupport.parseRefLabel(s, after, end) match
+        case r: InlineSupport.RefLabelMatch =>
+          val label = if r.label.s.isEmpty then bracketContent else r.label
+          val resolved = refs.lookup(label)
+          if resolved.present then
+            val ref = resolved.vouch
+            return LinkResolution(ref.destination, ref.title, r.end)
+          // ref not found; fall through to shortcut
+
+        case Unset => ()  // fall through to shortcut
+
+    // 3. Shortcut reference
+    val resolved = refs.lookup(bracketContent)
+    if resolved.present then
+      val ref = resolved.vouch
+      LinkResolution(ref.destination, ref.title, after)
+    else
+      Unset

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -1,0 +1,327 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import java.util.regex as jur
+
+import anticipation.*
+import vacuous.*
+
+case class EntityMatch(decoded: String, end: Int)
+case class CodeSpanMatch(content: Text, end: Int)
+case class AutolinkMatch(link: Prose, end: Int)
+
+object InlineSupport:
+
+  // CommonMark "ASCII punctuation": !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+  def isAsciiPunctuation(c: Char): Boolean = c match
+    case '!' | '"' | '#' | '$' | '%' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' => true
+    case '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '[' | '\\' => true
+    case ']' | '^' | '_' | '`' | '{' | '|' | '}' | '~'                          => true
+    case _                                                                      => false
+
+  private inline def isDecDigit(c: Char): Boolean = c >= '0' && c <= '9'
+
+  private inline def isHexDigit(c: Char): Boolean =
+    (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
+
+  private inline def isAsciiAlpha(c: Char): Boolean =
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+
+  private inline def isAsciiAlnum(c: Char): Boolean = isAsciiAlpha(c) || isDecDigit(c)
+
+  // Try to parse an HTML entity at position `start` (which points at `&`).
+  // Returns the decoded string and index past the closing `;`, or Unset.
+  def parseEntity(s: String, start: Int, end: Int): Optional[EntityMatch] =
+    var i = start + 1
+    if i >= end then return Unset
+
+    if s.charAt(i) == '#' then
+      i += 1
+      if i >= end then return Unset
+      val isHex = s.charAt(i) == 'x' || s.charAt(i) == 'X'
+      if isHex then i += 1
+      val digitStart = i
+      val maxDigits = if isHex then 6 else 7
+
+      def hasDigit: Boolean =
+        if isHex then isHexDigit(s.charAt(i)) else isDecDigit(s.charAt(i))
+
+      while i < end && (i - digitStart) < maxDigits && hasDigit do i += 1
+
+      if i == digitStart then return Unset
+      if i >= end || s.charAt(i) != ';' then return Unset
+      val numStr = s.substring(digitStart, i).nn
+
+      val codePoint =
+        try Integer.parseInt(numStr, if isHex then 16 else 10)
+        catch case _: NumberFormatException => return Unset
+
+      val ch =
+        if codePoint == 0 || codePoint > 0x10FFFF then "�"
+        else String.valueOf(Character.toChars(codePoint).nn).nn
+
+      EntityMatch(ch, i + 1)
+    else
+      val nameStart = i
+      while i < end && isAsciiAlnum(s.charAt(i)) do i += 1
+      if i == nameStart then return Unset
+      if i >= end || s.charAt(i) != ';' then return Unset
+      val name = s.substring(nameStart, i).nn
+      val decoded = HtmlEntities.lookup(name)
+      if decoded == null then Unset else EntityMatch(decoded, i + 1)
+
+  // Try to parse a code span starting at the run of backticks at position
+  // `start`. Returns the content text and index past the closing run.
+  def parseCodeSpan(s: String, start: Int, end: Int): Optional[CodeSpanMatch] =
+    var i = start
+    while i < end && s.charAt(i) == '`' do i += 1
+    val openerLen = i - start
+    val contentStart = i
+
+    while i < end do
+      while i < end && s.charAt(i) != '`' do i += 1
+      if i >= end then return Unset
+      val closerStart = i
+      while i < end && s.charAt(i) == '`' do i += 1
+      val closerLen = i - closerStart
+      if closerLen == openerLen then
+        val raw = s.substring(contentStart, closerStart).nn
+        // Replace newlines with spaces (CommonMark §6.1)
+        val noNewlines = raw.replace('\n', ' ').nn
+
+        // Strip one leading + one trailing space if both ends have space and
+        // content is not all spaces
+        val needsTrim =
+          noNewlines.length >= 2
+          && noNewlines.charAt(0) == ' '
+          && noNewlines.charAt(noNewlines.length - 1) == ' '
+          && existsNonSpace(noNewlines)
+
+        val stripped =
+          if needsTrim then noNewlines.substring(1, noNewlines.length - 1).nn
+          else noNewlines
+
+        return CodeSpanMatch(Text(stripped), i)
+    Unset
+
+  private def existsNonSpace(s: String): Boolean =
+    val n = s.length
+    var i = 0
+    while i < n do
+      if s.charAt(i) != ' ' then return true
+      i += 1
+    false
+
+  // Email autolink pattern from the CommonMark spec (§6.4)
+  private val EmailRegex: jur.Pattern =
+    val local = "[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+"
+    val labelChars = "[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+    jur.Pattern.compile(s"^${local}@${labelChars}(?:\\.${labelChars})*$$").nn
+
+  // Try to parse an autolink starting at `<` at position `start`.
+  // Returns a `Prose.Link` and index past `>`, or Unset.
+  def parseAutolink(s: String, start: Int, end: Int): Optional[AutolinkMatch] =
+    var i = start + 1
+    var keep = true
+    while keep && i < end do
+      val c = s.charAt(i)
+      if c == '>' || c <= 0x20 || c == '<' then keep = false
+      else i += 1
+
+    if i >= end || s.charAt(i) != '>' then return Unset
+    val content = s.substring(start + 1, i).nn
+
+    if isUriAutolink(content) then
+      val text = Text(content)
+      val link = Prose.Link(text, Unset, Prose.Textual(text))
+      AutolinkMatch(link, i + 1)
+    else if EmailRegex.matcher(content).nn.matches then
+      val text = Text(content)
+      val mailto = Text("mailto:" + content)
+      val link = Prose.Link(mailto, Unset, Prose.Textual(text))
+      AutolinkMatch(link, i + 1)
+    else
+      Unset
+
+  // Scheme: [A-Za-z][A-Za-z0-9+.-]{1,31} followed by `:` then a body of
+  // characters that are neither whitespace, controls, `<`, nor `>` (already
+  // ensured by the caller).
+  private def isUriAutolink(content: String): Boolean =
+    val n = content.length
+    if n < 3 then return false
+    if !isAsciiAlpha(content.charAt(0)) then return false
+    var i = 1
+    while i < n && i <= 32 do
+      val c = content.charAt(i)
+      val isSchemeChar = isAsciiAlnum(c) || c == '+' || c == '.' || c == '-'
+      if c == ':' then
+        if i < 2 then return false
+        return validateUriBody(content, i + 1, n)
+      if !isSchemeChar then return false
+      i += 1
+    false
+
+  private def validateUriBody(content: String, start: Int, end: Int): Boolean =
+    var i = start
+    while i < end do
+      val c = content.charAt(i)
+      if c <= 0x20 || c == '<' || c == '>' then return false
+      i += 1
+    true
+
+  // Parse a single-line link reference definition: `[label]: dest "title"`.
+  // Multi-line link refs are not yet supported. Returns the definition and
+  // the consumed-character count, or Unset.
+  def parseLinkRefDef(line: Text): Optional[Markdown.LinkRef] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 then return Unset
+    if i >= n || s.charAt(i) != '[' then return Unset
+    i += 1
+
+    val labelStart = i
+    var labelDone = false
+    while i < n && !labelDone do
+      val c = s.charAt(i)
+      if c == ']' then labelDone = true
+      else if c == '[' then return Unset
+      else if c == '\\' && i + 1 < n then i += 2
+      else i += 1
+
+    if !labelDone then return Unset
+    if i == labelStart then return Unset
+    val label = Text(s.substring(labelStart, i).nn)
+    i += 1
+
+    if i >= n || s.charAt(i) != ':' then return Unset
+    i += 1
+
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    if i >= n then return Unset
+
+    val destResult = parseLinkDestination(s, i, n)
+    if destResult.absent then return Unset
+    val (destination, afterDest) = (destResult.vouch.dest, destResult.vouch.end)
+    i = afterDest
+
+    val beforeWs = i
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+
+    var title: Optional[Text] = Unset
+    if i > beforeWs && i < n then
+      parseLinkTitle(s, i, n) match
+        case Unset =>
+          // No title: backtrack to before the whitespace to allow trailing-only
+          i = beforeWs
+
+        case t: TitleMatch =>
+          title = Text(t.title)
+          i = t.end
+
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    if i < n then return Unset
+
+    Markdown.LinkRef(label, title, destination)
+
+  case class DestMatch(dest: Text, end: Int)
+  case class TitleMatch(title: String, end: Int)
+
+  // Link destination: either `<...>` (allows escapes; no unescaped < or >),
+  // or a sequence of non-whitespace characters with balanced parentheses.
+  def parseLinkDestination(s: String, start: Int, end: Int): Optional[DestMatch] =
+    if start >= end then return Unset
+    if s.charAt(start) == '<' then
+      var i = start + 1
+      val buf = new StringBuilder
+      while i < end do
+        val c = s.charAt(i)
+        if c == '>' then return DestMatch(Text(buf.toString), i + 1)
+        else if c == '<' || c == '\n' then return Unset
+        else if c == '\\' && i + 1 < end && isAsciiPunctuation(s.charAt(i + 1)) then
+          buf.append(s.charAt(i + 1))
+          i += 2
+        else
+          buf.append(c)
+          i += 1
+      Unset
+    else
+      var i = start
+      var depth = 0
+      val buf = new StringBuilder
+      while i < end do
+        val c = s.charAt(i)
+        if c <= 0x20 then
+          if i == start then return Unset
+          return DestMatch(Text(buf.toString), i)
+        else if c == '\\' && i + 1 < end && isAsciiPunctuation(s.charAt(i + 1)) then
+          buf.append(s.charAt(i + 1))
+          i += 2
+        else if c == '(' then
+          depth += 1; buf.append(c); i += 1
+        else if c == ')' then
+          if depth == 0 then return DestMatch(Text(buf.toString), i)
+          depth -= 1; buf.append(c); i += 1
+        else
+          buf.append(c)
+          i += 1
+
+      if depth != 0 then return Unset
+      if i == start then Unset else DestMatch(Text(buf.toString), i)
+
+  // Link title: `"..."`, `'...'`, or `(...)` with backslash-escapes.
+  def parseLinkTitle(s: String, start: Int, end: Int): Optional[TitleMatch] =
+    if start >= end then return Unset
+    val opener = s.charAt(start)
+    val closer = opener match
+      case '"'  => '"'
+      case '\'' => '\''
+      case '('  => ')'
+      case _    => return Unset
+
+    var i = start + 1
+    val buf = new StringBuilder
+    while i < end do
+      val c = s.charAt(i)
+      if c == closer then return TitleMatch(buf.toString, i + 1)
+      else if c == opener && opener == '(' then return Unset  // unbalanced inner (
+      else if c == '\\' && i + 1 < end && isAsciiPunctuation(s.charAt(i + 1)) then
+        buf.append(s.charAt(i + 1))
+        i += 2
+      else
+        buf.append(c)
+        i += 1
+    Unset

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -35,6 +35,7 @@ package punctuation
 import java.util.regex as jur
 
 import anticipation.*
+import gossamer.*
 import vacuous.*
 
 case class EntityMatch(decoded: String, end: Int)
@@ -325,3 +326,78 @@ object InlineSupport:
         buf.append(c)
         i += 1
     Unset
+
+  case class InlineLinkBody(dest: Text, title: Optional[Text], end: Int)
+
+  // Parse the body of an inline link `(dest "title")` starting at the `(`.
+  // Returns the destination, optional title, and the index past the closing
+  // `)`, or Unset if the body doesn't parse.
+  def parseInlineLinkBody(s: String, start: Int, end: Int): Optional[InlineLinkBody] =
+    if start >= end || s.charAt(start) != '(' then return Unset
+    var i = start + 1
+    i = skipLinkWhitespace(s, i, end)
+
+    val (dest, afterDest): (Text, Int) =
+      if i < end && s.charAt(i) != ')' then
+        parseLinkDestination(s, i, end) match
+          case Unset        => return Unset
+          case d: DestMatch => (d.dest, d.end)
+      else
+        (t"", i)
+
+    i = afterDest
+    val beforeWs = i
+    i = skipLinkWhitespace(s, i, end)
+
+    var title: Optional[Text] = Unset
+    if i > beforeWs && i < end then
+      parseLinkTitle(s, i, end) match
+        case t: TitleMatch =>
+          title = Text(t.title)
+          i = t.end
+
+        case Unset =>
+          // No title; rewind to before the inter-token whitespace
+          i = beforeWs
+
+    i = skipLinkWhitespace(s, i, end)
+    if i >= end || s.charAt(i) != ')' then return Unset
+    InlineLinkBody(dest, title, i + 1)
+
+  case class RefLabelMatch(label: Text, end: Int)
+
+  // Parse a reference link label `[label]` starting at the `[`. Returns the
+  // raw label text (or empty for `[]`) and the index past the closing `]`,
+  // or Unset if no valid label parses.
+  def parseRefLabel(s: String, start: Int, end: Int): Optional[RefLabelMatch] =
+    if start >= end || s.charAt(start) != '[' then return Unset
+    var i = start + 1
+    val labelStart = i
+    var done = false
+
+    while i < end && !done do
+      val c = s.charAt(i)
+      if c == ']' then done = true
+      else if c == '[' then return Unset
+      else if c == '\\' && i + 1 < end then i += 2
+      else i += 1
+
+    if !done then return Unset
+    val label = if i == labelStart then t"" else Text(s.substring(labelStart, i).nn)
+    RefLabelMatch(label, i + 1)
+
+  // Skip whitespace allowed in link bodies — spaces, tabs, and up to one
+  // newline (per CommonMark §6.6).
+  private def skipLinkWhitespace(s: String, start: Int, end: Int): Int =
+    var i = start
+    var newlines = 0
+    var done = false
+    while i < end && !done do
+      val c = s.charAt(i)
+      if c == ' ' || c == '\t' then i += 1
+      else if c == '\n' && newlines < 1 then
+        newlines += 1
+        i += 1
+      else
+        done = true
+    i

--- a/lib/punctuation/src/core/punctuation.LinkRefs.scala
+++ b/lib/punctuation/src/core/punctuation.LinkRefs.scala
@@ -32,46 +32,48 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import scala.collection.mutable
 
-import strategies.throwUnsafely
+import anticipation.*
 
-import doms.html.whatwg
-import classloaders.system
+// Accumulates link reference definitions discovered during the block-parse
+// pass; consulted by the inline-parse pass for shortcut/collapsed/full
+// reference links. Stage 4 will populate this from `[label]: dest "title"`
+// definitions in paragraphs; for now it stays empty.
+final class LinkRefs:
+  private val table: mutable.LinkedHashMap[Text, Markdown.LinkRef] =
+    mutable.LinkedHashMap()
 
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
+  // CommonMark normalisation: trim, collapse internal whitespace runs, then
+  // Unicode case-fold (approximated here by `toLowerCase` since the JDK's
+  // `String.toLowerCase` does Unicode case-folding for the BMP).
+  def normalize(label: Text): Text =
+    val s = label.s
+    val n = s.length
+    val builder = new StringBuilder
+    var i = 0
+    var inSpace = false
+    var trimmingLeft = true
+    while i < n do
+      val c = s.charAt(i)
+      if c == ' ' || c == '\t' || c == '\n' || c == '\r' then
+        if !trimmingLeft then inSpace = true
+      else
+        if inSpace then builder.append(' ')
+        builder.append(c)
+        inSpace = false
+        trimmingLeft = false
+      i += 1
+    Text(builder.toString.toLowerCase.nn)
 
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
+  // First definition wins (per CommonMark).
+  def add(ref: Markdown.LinkRef): Unit =
+    val key = normalize(ref.label)
+    if !table.contains(key) then table(key) = ref
 
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def lookup(label: Text): vacuous.Optional[Markdown.LinkRef] =
+    table.get(normalize(label)) match
+      case Some(ref) => ref
+      case None      => vacuous.Unset
 
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def all: List[Markdown.LinkRef] = table.values.to(List)

--- a/lib/punctuation/src/core/punctuation.Parser.scala
+++ b/lib/punctuation/src/core/punctuation.Parser.scala
@@ -32,46 +32,10 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import anticipation.*
+import prepositional.*
 
-import strategies.throwUnsafely
-
-import doms.html.whatwg
-import classloaders.system
-
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
-
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
-
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
-
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+// Public entry point for the native CommonMark parser. Mirrors `Commonmark.parse`
+// in shape so test and benchmark suites can swap implementations.
+object Parser:
+  def parse(text: Text): Markdown of Layout = BlockParser().parse(text)

--- a/lib/punctuation/src/core/punctuation.ParserSupport.scala
+++ b/lib/punctuation/src/core/punctuation.ParserSupport.scala
@@ -1,0 +1,239 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+import gossamer.*
+import vacuous.*
+
+object ParserSupport:
+
+  // CommonMark treats every horizontal-tab as advancing to the next 4-column
+  // boundary. For block-parser indent counting that's what `indentColumn`
+  // returns; for content stripping after a known indent we use `stripIndent`,
+  // which removes whole-tab-equivalent prefix correctly.
+
+  def isBlank(line: Text): Boolean =
+    val s = line.s
+    var i = 0
+    val n = s.length
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    i == n
+
+  // Number of leading-indent columns, expanding tabs to 4-column stops.
+  // Stops at the first non-space, non-tab character.
+  def indentColumn(line: Text): Int =
+    val s = line.s
+    var i = 0
+    var col = 0
+    val n = s.length
+    while i < n do
+      s.charAt(i) match
+        case ' ' =>
+          col += 1; i += 1
+
+        case '\t' =>
+          col += 4 - (col & 3); i += 1
+
+        case _ => return col
+
+    col
+
+  // Index (in chars) of the first non-space, non-tab char, or s.length.
+  def firstNonWhitespace(line: Text): Int =
+    val s = line.s
+    var i = 0
+    val n = s.length
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    i
+
+  // Strip trailing whitespace (spaces and tabs only — newlines aren't expected).
+  def stripTrailingSpaces(line: Text): Text =
+    val s = line.s
+    var i = s.length
+    while i > 0 && (s.charAt(i - 1) == ' ' || s.charAt(i - 1) == '\t') do i -= 1
+    if i == s.length then line else Text(s.substring(0, i).nn)
+
+  // ATX heading: ^ {0,3}#{1,6}( |\t|$).*?(#+)? *$
+  // Returns Some((level, content)) where content is the trimmed heading text.
+  // Optional trailing #s are stripped per the spec when surrounded by space.
+  def atxHeading(line: Text): Optional[(1 | 2 | 3 | 4 | 5 | 6, Text)] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    // up to 3 leading spaces
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 then return Unset
+    // 1-6 hashes
+    var hashes = 0
+    while i < n && s.charAt(i) == '#' && hashes < 7 do { i += 1; hashes += 1 }
+    if hashes < 1 || hashes > 6 then return Unset
+    // must be followed by space, tab, or end-of-line
+    if i < n && s.charAt(i) != ' ' && s.charAt(i) != '\t' then return Unset
+    // skip spaces/tabs after hashes
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    // strip trailing whitespace
+    var end = n
+    while end > i && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
+    // strip optional trailing #s if preceded by space (or whole line)
+    val origEnd = end
+    var hashEnd = end
+    while hashEnd > i && s.charAt(hashEnd - 1) == '#' do hashEnd -= 1
+    val hashesPrecededBySpace =
+      hashEnd == i || s.charAt(hashEnd - 1) == ' ' || s.charAt(hashEnd - 1) == '\t'
+
+    if hashEnd < origEnd && hashesPrecededBySpace then
+      end = hashEnd
+      while end > i && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
+    val content = if end > i then Text(s.substring(i, end).nn) else t""
+    val level: 1 | 2 | 3 | 4 | 5 | 6 = (hashes: @unchecked) match
+      case 1 => 1; case 2 => 2; case 3 => 3; case 4 => 4; case 5 => 5; case 6 => 6
+    (level, content)
+
+  // Setext underline: ^ {0,3}(=+|-+) *$
+  // Returns Some(1) for `=`, Some(2) for `-`.
+  def setextUnderline(line: Text): Optional[1 | 2] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val ch = s.charAt(i)
+    if ch != '=' && ch != '-' then return Unset
+    var count = 0
+    while i < n && s.charAt(i) == ch do { i += 1; count += 1 }
+    if count < 1 then return Unset
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    if i < n then return Unset
+    if ch == '=' then 1 else 2
+
+  // Thematic break: ^ {0,3}([-*_])(\1| |\t)*\1\1.*$ where total non-space chars >= 3 of same
+  def isThematicBreak(line: Text): Boolean =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return false
+    val ch = s.charAt(i)
+    if ch != '-' && ch != '*' && ch != '_' then return false
+    var count = 0
+    while i < n do
+      val c = s.charAt(i)
+      if c == ch then count += 1
+      else if c != ' ' && c != '\t' then return false
+      i += 1
+    count >= 3
+
+  // Fence opener: ^ {0,3}(`{3,}|~{3,})(.*)$
+  // Backtick fences cannot contain backticks in info string.
+  // Returns Some((char, count, indent, info)).
+  def fenceOpener(line: Text): Optional[(Char, Int, Int, Text)] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val ch = s.charAt(i)
+    if ch != '`' && ch != '~' then return Unset
+    val fenceStart = i
+    while i < n && s.charAt(i) == ch do i += 1
+    val count = i - fenceStart
+    if count < 3 then return Unset
+    val infoStart = i
+    val info = Text(s.substring(infoStart, n).nn).trim
+    // Backtick fences cannot contain backticks in info string
+    if ch == '`' && info.s.indexOf('`') >= 0 then return Unset
+    (ch, count, indent, info)
+
+  // Fence closer: ^ {0,3}(`{minCount,}|~{minCount,}) *$
+  def isFenceCloser(line: Text, fenceChar: Char, minCount: Int): Boolean =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 then return false
+    val start = i
+    while i < n && s.charAt(i) == fenceChar do i += 1
+    val count = i - start
+    if count < minCount then return false
+    while i < n && s.charAt(i) == ' ' do i += 1
+    i == n
+
+  // Strip up to `n` columns of indent, expanding tabs as needed. Returns the
+  // remainder of the line. If the line has fewer than n columns of leading
+  // whitespace, the entire whitespace prefix is stripped and the rest returned.
+  def stripIndent(line: Text, n: Int): Text =
+    if n <= 0 then return line
+    val s = line.s
+    var i = 0
+    var col = 0
+    val len = s.length
+    while i < len && col < n do
+      s.charAt(i) match
+        case ' ' =>
+          col += 1; i += 1
+
+        case '\t' =>
+          val advance = 4 - (col & 3)
+          if col + advance <= n then { col += advance; i += 1 }
+          else
+            // Partial tab: replace with leftover spaces
+            val leftover = (col + advance) - n
+            val builder = new StringBuilder
+            var k = 0
+            while k < leftover do { builder.append(' '); k += 1 }
+            builder.append(s, i + 1, len)
+            return Text(builder.toString)
+
+        case _ =>
+          return Text(s.substring(i, len).nn)
+    if i == 0 then line else if i >= len then t"" else Text(s.substring(i, len).nn)
+
+  // Cut info string into whitespace-separated tokens (CommonMark spec).
+  def cutInfo(info: Text): List[Text] =
+    val s = info.s
+    val n = s.length
+    if n == 0 then return Nil
+    val result = scala.collection.mutable.ListBuffer[Text]()
+    var i = 0
+    while i < n do
+      while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+      val start = i
+      while i < n && s.charAt(i) != ' ' && s.charAt(i) != '\t' do i += 1
+      if i > start then result += Text(s.substring(start, i).nn)
+    result.toList

--- a/lib/punctuation/src/core/punctuation.ParserSupport.scala
+++ b/lib/punctuation/src/core/punctuation.ParserSupport.scala
@@ -36,6 +36,15 @@ import anticipation.*
 import gossamer.*
 import vacuous.*
 
+case class BulletMarker(char: Char, markerIndent: Int, contentIndent: Int, rest: Text)
+
+case class OrderedMarker
+  ( start:         Int,
+    delimiter:     '.' | ')',
+    markerIndent:  Int,
+    contentIndent: Int,
+    rest:          Text )
+
 object ParserSupport:
 
   // CommonMark treats every horizontal-tab as advancing to the next 4-column
@@ -237,3 +246,98 @@ object ParserSupport:
       while i < n && s.charAt(i) != ' ' && s.charAt(i) != '\t' do i += 1
       if i > start then result += Text(s.substring(start, i).nn)
     result.toList
+
+  // Bullet list marker: ^ {0,3}([-*+])( +|\t|$)(.*)$
+  // Returns (marker char, marker indent, content indent, remainder).
+  // `contentIndent` is the column at which the item's content begins (used
+  // by `ListItemBuilder` to know how many columns to strip from continuation
+  // lines).
+  def bulletMarker(line: Text): Optional[BulletMarker] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val ch = s.charAt(i)
+    if ch != '-' && ch != '+' && ch != '*' then return Unset
+    val markerEnd = i + 1
+    // Must be followed by space, tab, or end-of-line
+    if markerEnd < n && s.charAt(markerEnd) != ' ' && s.charAt(markerEnd) != '\t' then return Unset
+    // Count post-marker whitespace columns (1..4); if 5+, treat as 1 (content
+    // becomes indented code) — caller handles that by not stripping past 1.
+    var j = markerEnd
+    var postCol = 0
+    while j < n && (s.charAt(j) == ' ' || s.charAt(j) == '\t') && postCol < 5 do
+      if s.charAt(j) == ' ' then postCol += 1
+      else postCol += 4 - ((indent + 1 + postCol) & 3)
+      j += 1
+
+    val followSpace =
+      if markerEnd >= n then 1
+      else if isBlank(Text(s.substring(markerEnd, n).nn)) then 1
+      else if postCol >= 5 then 1
+      else postCol
+
+    val contentStart =
+      markerEnd + (if markerEnd >= n then 0 else followSpace.min(n - markerEnd))
+
+    val contentIndent = indent + 1 + followSpace
+    val rest = if contentStart >= n then t"" else Text(s.substring(contentStart, n).nn)
+    BulletMarker(ch, indent, contentIndent, rest)
+
+  // Ordered list marker: ^ {0,3}(\d{1,9})([.)])( +|\t|$)(.*)$
+  def orderedMarker(line: Text): Optional[OrderedMarker] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val digitStart = i
+    while i < n && s.charAt(i) >= '0' && s.charAt(i) <= '9' && (i - digitStart) < 9 do i += 1
+    val digitCount = i - digitStart
+    if digitCount < 1 then return Unset
+    if i >= n then return Unset
+    val delimChar = s.charAt(i)
+    if delimChar != '.' && delimChar != ')' then return Unset
+    val markerEnd = i + 1
+    if markerEnd < n && s.charAt(markerEnd) != ' ' && s.charAt(markerEnd) != '\t' then
+      return Unset
+    val start =
+      try Integer.parseInt(s.substring(digitStart, digitStart + digitCount))
+      catch case _: NumberFormatException => return Unset
+
+    var j = markerEnd
+    var postCol = 0
+    while j < n && (s.charAt(j) == ' ' || s.charAt(j) == '\t') && postCol < 5 do
+      if s.charAt(j) == ' ' then postCol += 1
+      else postCol += 4 - ((indent + digitCount + 1 + postCol) & 3)
+      j += 1
+
+    val followSpace =
+      if markerEnd >= n then 1
+      else if isBlank(Text(s.substring(markerEnd, n).nn)) then 1
+      else if postCol >= 5 then 1
+      else postCol
+
+    val contentStart =
+      markerEnd + (if markerEnd >= n then 0 else followSpace.min(n - markerEnd))
+
+    val contentIndent = indent + digitCount + 1 + followSpace
+    val rest = if contentStart >= n then t"" else Text(s.substring(contentStart, n).nn)
+    val delim: '.' | ')' = if delimChar == '.' then '.' else ')'
+    OrderedMarker(start, delim, indent, contentIndent, rest)
+
+  // Whether the line, ignoring leading 0..3 spaces, starts a new block
+  // (other than a paragraph). Used for lazy-paragraph-continuation: if a line
+  // doesn't start a new block, it can continue an open paragraph regardless
+  // of failed container continuation.
+  def startsNonParagraphBlock(line: Text): Boolean =
+    if isBlank(line) then return true
+    if isThematicBreak(line) then return true
+    if atxHeading(line).present then return true
+    if fenceOpener(line).present then return true
+    if bulletMarker(line).present then return true
+    if orderedMarker(line).present then return true
+    false


### PR DESCRIPTION
Extends the inline parser with the full `[text](url "title")`,
`[text][label]`, `[text][]`, and shortcut `[text]` link forms (plus
image variants), interleaving link matching with the emphasis algorithm.
Stage 6 of an 8-stage native CommonMark port; pass-rate climbs from
355/578 to 381/578.

---

The native parser now supports the full set of link and image syntaxes:

```scala
import punctuation.*

Parser.parse(t"""
[An inline link](https://example.com "with title")

[A reference link][ref]
[A collapsed reference][]
[A shortcut reference]

![An image](/img.png "alt-text title")

[ref]: https://example.com/r "ref title"
[A collapsed reference]: https://example.com/c
[A shortcut reference]: https://example.com/s
""")
```

Internally InlineParser maintains a bracket stack; on `]` it tries each
link form in order (inline → full ref → collapsed ref → shortcut ref).
Successful matches wrap the in-bracket content as a `LinkData` /
`ImageData` node, after first running emphasis processing inside the
brackets. Per CommonMark, matched links deactivate any earlier `[`
markers so links don't nest.

Stage 7 (raw HTML inlines) and stage 8 (Java parser removal + final
benchmark comparison) remain.