### PR TITLE
Compare native parser against Java baseline in benchmark suite

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -834,6 +834,7 @@ object punctuation extends Library:
   object html extends Component(core)
   object ansi extends Component(core, harlequin.core)
   object test extends Tests(core, html, ansi, jacinta.core, telekinesis.core, sedentary.core, quantitative.units)
+  object bench extends Benchmarks(core, quantitative.units)
 
 object quantitative extends Library:
   object core extends Component(hypotenuse.core, gossamer.core, anticipation.opaque, anticipation.time, probably.core)

--- a/lib/punctuation/res/bench/punctuation/emphasis-stress.md
+++ b/lib/punctuation/res/bench/punctuation/emphasis-stress.md
@@ -1,0 +1,136 @@
+# Emphasis stress
+
+A fixture of pure inline density, designed to isolate inline-parser cost from
+block-parser cost. Almost no block structure: just paragraphs packed with
+emphasis runs, links, code spans, autolinks, escapes, and entities. The
+delimiter-stack algorithm and the rule-of-3 length pairing are exercised
+heavily.
+
+[a]: https://example.com/a "title a"
+[b]: https://example.org/b 'title b'
+[c]: https://example.net/c (paren title c)
+[deep]: https://example.com/deep
+
+Paragraph one: *single em* and **double strong** and ***triple ems*** and
+****quad runs**** and *****five***** and ******six****** in a row, with `code`
+and [a link](https://example.com) and ![an image](/i.png "alt") and an
+autolink <https://example.org> and a [reference][a] and a [collapsed][] and a
+shortcut [c] reference. Backslash escapes \* \_ \[ \] \\ and entities &amp;
+&#42; &#x2A; &copy; appear too.
+
+Paragraph two — the gnarly cases for the rule of 3:
+*foo***bar
+**foo***bar
+***foo*bar**
+**foo*bar***
+*foo *bar* baz*
+**foo **bar** baz**
+***foo ***bar*** baz***
+*a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*
+
+Paragraph three — alternating asterisk and underscore (different delimiters
+do not pair with each other):
+*a_b_c*
+_a*b*c_
+**a__b__c**
+__a**b**c__
+***a___b___c***
+
+Paragraph four — Unicode flanking (left/right flanking rules with punctuation
+and whitespace boundaries):
+".*foo*."
+"(*foo*)"
+"a*b*c"
+"a *b* c"
+"a* b *c"
+"_foo_."
+"(_foo_)"
+"a_b_c"
+"a _b_ c"
+
+Paragraph five — long runs and adjacent runs:
+**********foo**********
+__________foo__________
+*****foo*****bar*****baz*****
+*foo**bar***baz****qux*****quux*
+
+Paragraph six — links and images mixed with emphasis:
+[*italic link*](https://x)
+[**bold link**](https://x)
+[***both link***](https://x)
+*[italic around link](https://x)*
+**[bold around link](https://x)**
+*outer **inner [link](https://x) inner** outer*
+![*italic image*](/i.png)
+*[image](/i.png) and ![embedded](/e.png)*
+
+Paragraph seven — code spans inside emphasis (code spans take precedence):
+*foo `code` bar*
+**foo `code` bar**
+*`code` foo*
+*foo `co*de` bar*
+*foo \`code\` bar*
+
+Paragraph eight — references inside emphasis:
+*[a]*
+**[b]**
+***[c]***
+*[a][a] [b][] [c]*
+**[deep][]**
+
+Paragraph nine — backslash escapes inside delimiter runs:
+*foo\*bar*
+**foo\**bar**
+*foo\_bar*
+*foo\\bar*
+\*not emphasis\*
+\**not strong\**
+\*\*emphasis around escapes\*\*
+
+Paragraph ten — autolinks and HTML inlines mixed with emphasis:
+*<https://example.com>*
+**<mail@example.com>**
+*<span>html</span>*
+**<em>nested em</em>**
+*foo <span>span</span> bar*
+
+Paragraph eleven — adjacent emphasis runs must not merge:
+*foo* *bar* *baz*
+**foo** **bar** **baz**
+*foo***bar***baz*
+**foo*bar*baz**
+
+Paragraph twelve — pathological-ish nested cases (still well-formed):
+*a *b *c *d *e *f *g *h *i *j* k* l* m* n* o* p* q* r*
+**a **b **c **d **e **f **g** h** i** j** k** l** m** n**
+
+Paragraph thirteen — link reference resolution stress:
+[a][a] [a][b] [a][c] [b][a] [b][b] [b][c] [c][a] [c][b] [c][c]
+[a] [b] [c] [deep] [a][] [b][] [c][] [deep][]
+![a][a] ![b][b] ![c][c] ![deep][deep]
+[**bold ref**][a] [*italic ref*][b] [`code ref`][c]
+
+Paragraph fourteen — entities packed densely:
+&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;&amp;
+&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;&#42;
+&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;&#x2A;
+&copy;&reg;&trade;&hellip;&mdash;&ndash;
+&lt;&gt;&quot;&apos;&nbsp;
+
+Paragraph fifteen — code spans of varied lengths:
+`a` ``b`` ```c``` ````d```` `e``f``g`
+`with backtick \` inside`
+`` `interior` ``
+``` ``two backticks`` ```
+`spaces   preserved`
+`  trim leading and trailing  `
+
+Paragraph sixteen — final mixed paragraph hitting everything:
+The *quick* **brown** ***fox*** [jumps](https://x) over the [lazy][a] dog with
+`inline code` and an ![image](/i.png) and an autolink <https://example.org>
+plus an entity &amp; and a backslash escape \* and a hard break\
+on the next line and a soft
+break wrapping here, all in one *italic **strong** italic* and one **strong
+*italic* strong** and one ***strong-italic [link](https://x) strong-italic***.
+
+[collapsed]: https://example.com/collapsed

--- a/lib/punctuation/res/bench/punctuation/medium.md
+++ b/lib/punctuation/res/bench/punctuation/medium.md
@@ -1,0 +1,437 @@
+All Quantitative terms and types are defined in the `quantitative` package,
+```scala
+import quantitative.*
+```
+and exported to the `soundness` package:
+```scala
+import soundness.*
+```
+
+### `Quantity` types
+
+Physical quantities can be represented by different `Quantity` types, with an appropriate parameter that encodes
+the value's units. We can create a quantity by multiplying an existing `Double` (or any numeric type) by some
+unit value, such as `Metre` or `Joule`, which are just `Quantity` values equal to `1.0` of the appropriate unit.
+For example:
+```amok
+syntax  scala
+##
+val distance = 58.3*Metre
+```
+
+The types of these values will be inferred. The value `distance` will get the type `Quantity[Metres[1]]`, since
+its value is a number of metres (raised to the power `1`).
+
+In general, types representing units are written in the plural (for example, `Metres`, `Feet`, `Candelas`), with
+a bias for distinction when the singular name is often used in the plural; for example, the type is `Kelvins`
+even though "Kelvins" and "Kelvin" are both commonly used for plural values. Unit instances are always named in
+the singular.
+
+We can compute an `area` value by squaring the distance,
+```amok
+syntax  scala
+##
+val area = distance*distance
+```
+which should have units of square metres (`m²`). Quantitative represents this as the type, `Quantity[Metres[2]]`; the
+`2` singleton literal value represents the metres being squared. Likewise, a volume would have the parameter
+`Metres[3]`.
+
+### Representation and displaying
+
+Each quantity, regardless of its units, is represented in the JVM as a `Double` using an opaque type
+alias.
+
+The precise types, representing units, are known statically, but are erased by runtime. Hence, all
+dimensionality checking takes place at compiletime, after which, operations on `Quantity`s will be
+operations on `Double`s, and will achieve similar performance.
+
+The raw `Double` value of a `Quantity` can always be obtained with `Quantity#value`
+
+Due to this representation, the `toString` method on `Quantity`s is the same as `Double`s `toString`,
+so the `toString` representations will show just the raw numerical value, without any units. In
+general, `toString` should not be used. A `gossamer.Show` instance is provided to produce
+human-readable `Text` values, so calling `show` on a `Quantity` will produce much better output.
+
+### Derived units
+
+We can also define:
+```amok
+syntax  scala
+##
+val energy = Joule*28000
+```
+
+The type of the `energy` value _could_ have been defined as `Quantity[Joule[1]]`, but 1 J is equivalent to 1
+kg⋅m²⋅s¯², and it's more useful for the type to reflect a product of thes more basic units (even though we
+can still use the `Joule` value to construct it).
+
+Metres, seconds and kilograms are all SI base units. Kilograms are a little different, since _nominally_, a
+kilogram is one thousand grams (while a gram is _not_ an SI base unit), and this has a small implication on
+the way we construct such units.
+
+Quantitative provides general syntax for metric naming conventions, allowing prefixes such as `Nano` or `Mega`
+to be applied to existing unit values to specify the appropriate scale to the value. Hence, a kilogram value
+is written, `Kilo(Gram)`. But since the SI base unit is the kilogram, this and any other multiple of `Gram`,
+such as `Micro(Gram)`, will use the type `Kilogram`, or more precisely, `Kilogram[1]`.
+
+Therefore, the type of `energy` is `Quantity[Grams[1] & Metres[2] & Second[-2]]`, using a combination of three
+base units raised to different powers. They are combined into an intersection type with the `&` type operator,
+which provides the useful property that the order of the intersection is unimportant;
+`Second[-2] & Metres[2] & Grams[1]` is an _identical_ type, much as kg m²s¯² and s¯²m²kg are identical
+units.
+
+Just as we could construct an area by multiplying two lengths, we can compute a new value with appropriate units
+by combining, say, `area` and `energy`,
+```amok
+syntax  scala
+##
+val volume = distance*distance*distance
+val energyDensity = energy/volume
+```
+and its type will be inferred with the parameter `Kilogram[1] & Metres[-1] & Second[-2]`.
+
+If we had instead calculated `energy/area`, whose units do not include metres, the type parameter would be just
+`Kilogram[1] & Second[-2]`; the redundant `Metres[0]` would be automatically removed from the conjunction.
+
+We can go further. For example, the ["SUVAT" equations of motion](https://en.wikipedia.org/wiki/Equations_of_motion)
+can be safely implemented as methods, and
+their dimensionality will be checked at compiletime. For example, the equation,
+```mathml
+<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>s</mi><mo>=</mo><mi>u</mi><mi>t</mi><mo>+</mo><mfrac><mn>1</mn><mn>2</mn></mfrac><mi>a</mi><msup><mi>t</mi><mn>2</mn></msup></math>
+```
+calculating a distance (`s`) from an initial velocity (`u`), acceleration (`a`) and time (`t`) can be
+implemented using Quantitative `Quantity`s with,
+```amok
+syntax  scala
+##
+type Velocity = Quantity[Metres[1] & Seconds[-1]]
+type Time = Quantity[Seconds[1]]
+type Acceleration = Quantity[Metres[1] & Seconds[-2]]
+type Distance = Quantity[Metres[1]]
+
+def s(u: Velocity, t: Time, a: Acceleration): Distance =
+  u*t + 0.5*a*t*t
+```
+or more verbosely,
+```amok
+syntax  scala
+##
+def distance
+    (velocity0: Quantity[Metres[1] & Seconds[-1]],
+     time: Quantity[Seconds[1]],
+     acceleration: Quantity[Metres[1] & Seconds[-2]])
+        :   Quantity[Metres[1]] =
+
+  velocity0*time + 0.5*acceleration*time*time
+```
+
+While the method arguments have more complex types, the expression, `u*t + 0.5*a*t*t`, is checked for
+dimensional consistency. If we had written `t + 0.5*a*t*t` or `u*t + 0.5*a*a*t` instead, these would
+have produced errors at compiletime.
+
+### Combining mixed units
+
+Kilograms, metres and seconds are units of in the mass, length and time dimensions, which are never
+interchangeable. Yet we sometimes need to work with different units of the same dimension, such as
+feet, metres, yards and miles as different (but interchangeable) units of length; or kilograms and
+pounds, as units of mass.
+
+Each type representing units, such as `Metres` or `Kilograms`, must be a subtype of the `Units` type,
+which is parameterized with its power (with a singleton literal integer) and a _dimension_, i.e. another type
+representing the nature of the measurement. For `Metres` the dimension is `Length`; for `Kilograms` it is
+`Mass`; `Candela`'s is `Luminosity`.
+
+`Metres[PowerType]` is a subtype of `Units[PowerType, Length]`, where `PowerType` must be a singleton
+integer type. More specifically, `Metres[1]` would be a subtype of `Units[1, Length]`.
+
+Note that there are no special dimensions for compound units, like energy, since the time, length and mass
+components of the units of an energy quantity will be associated with the `Second`, `Metres` and `Kilogram`
+types respectively.
+
+Encoding the dimension in the type makes it possible to freely mix different units of the same dimension.
+
+It is possible to create new length or mass units, such as `Inch` or `Pound`, which share the `Length` or `Mass`
+dimensions. This allows them to be considered equivalent in some calculations, if a conversion coefficient is
+available.
+
+Quantitative defines a variety of imperial measurements, and will automatically convert units of the same
+dimension to the same units in multiplications and divisions. For example,
+```amok
+syntax  scala
+##
+val width = 0.3*Metre
+val height = 5*Inch
+val area2 = width*height
+```
+will infer the type `Quantity[Metres[2]]` for `area`.
+
+However, the conversion of one of the units from inches to metres was necessary only to avoid a mixture of
+`Inches` and `Metres` in the resultant type, but the expression, `height*height` would produce a value with the
+units, `Inches[2]`, performing no unnecessary conversions.
+
+### Conversions
+
+#### Addition & subtraction
+
+Addition and subtraction are possible between quantities which share the same dimension.
+
+We can safely add an inch and a metre,
+```amok
+syntax  scala
+##
+val length = 1*Inch + 1*Metre
+```
+but we can't subtract a second from a litre:
+```amok
+syntax  scala
+error  Lit..ond
+  caption  This will not compile because litres and seconds are incompatible
+##
+val nonsense = Litre - Second
+
+```
+
+For the addition and subtraction of values with mixed units, the question arises of which units the result
+should take. Quantitative will use the _principal unit_ for the dimension, which is determined by the presence
+of a unique contextual `PrincipalUnit` instance, parameterized on `Dimension` and `Units` types.
+
+In general, if the units for the same dimension don't match between the operands, then the principal unit
+will be used for both. This may mean that adding a foot to a mile produces a result measured in metres,
+but a new `PrincipalUnit[Length, Miles[1]]()` contextual value could always be provided in-scope,
+which will take precedence over the `PrincipalUnit[Length, Metres[1]]` in scope.
+
+Some additional contextual values may be required, though. See [below](#conversion-ratios) for more
+information on conversions.
+
+#### Inequality Comparisons
+
+Likewise, we can compare units in like or mixed values with the four standard inequality operators
+(`<`, `>`, `<=`, `>=`). These will return `true` or `false` if the operands have the same dimension,
+even if they have different units, for example,
+```amok
+syntax  scala
+highlight  8..Metre  This returns true.
+##
+8*Foot < 4*Metre
+
+```
+while incompatible units will result in a compile error.
+
+#### Equality
+
+Equality between different `Quantity` values should be treated with care, since all such values are
+represented as `Double`s at runtime, and the JVM's standard equality will not take units into
+account. So, by default, `3*Foot == 3*Metre` will yield `true`, since `3.0 == 3.0`!
+
+This is highly undesirable, but luckily there's a solution:
+```amok
+syntax  scala
+##
+import language.strictEquality
+```
+
+This turns on Scala's strict-equality feature, which forbids comparisons between any two types unless
+a corresponding `CanEqual[LeftOperandType, RightOperandType]` exists in scope for the appropriate
+operand types. Quantitative provides just such an instance for `Quantity` instances with the same units.
+
+The runtime equality check, however, is performed in exactly the same way: by comparing two `Double`s.
+That is absolutely fine if we know the units are identical, but it does not allow equality comparisons
+between `Quantity`s of the same dimension and different units.
+
+For this, there are two possibilities:
+- convert one of the `Quantity`s to the units of the other
+- test `left <= right && left >= right`, which will only be true if `left` equals `right`
+
+#### Conversion ratios
+
+In order to automatically convert between two units, Quantitative needs to know the ratio between them.
+This is provided with a contextual `Ratio` value for the appropriate pair of units: one with the
+power `1` and the other with the power `-1`. The rate of conversion should be specified as a singleton
+literal `Double` as the second parameter. The `given` may be `erased`, if using Scala's erased definitions.
+
+For example,
+```amok
+syntax     scala
+highlight  erased  We can make the value erased.
+##
+erased given Ratio[Kilograms[1] & Tons[-1], 1016.0469088] = ###
+
+```
+which specifies that there are about 1016 kilograms in a ton, and will be used if Quantitative ever needs
+to convert between kilograms and tons.
+
+By making the conversion rate a _type_ (a singleton literal, specifically), its value is available at
+compiletime, even while the `given` is `erased`. This has the further advantage that any calculations on
+`Quantity`s which need to use the conversion ratio in a calculation involving other constants will use
+constant folding to automatically perform arithmetic operations on constants at compiletime, saving the
+performance cost of doing these at runtime.
+
+### Explicit Conversions
+
+To convert a quantity to different units, we can use the `in` method, passing it an _unapplied_ units type
+constructor, such as `Hour` or `Furlong`. The significance of the type being "unapplied" is that a units type
+constructor is typically _applied_ to an integer singleton type, such as `Metres[2]` representing square
+metres. Each dimension in a quantity must have the same units, no matter what its power, so it doesn't make
+sense to specify that power when converting.
+
+So, `(10*Metre).in[Yards]`, would create a value representing approximately 10.94 yards, while,
+`(3*Foot * 1*Metre * 0.4*Centi(Metre)).in[Inches]`, would calculate a volume in cubic inches.
+
+If a quantity includes units in multiple dimensions, these can be converted in steps, for example,
+```amok
+syntax  scala
+highlight  Mi..es  First convert into miles per second...
+highlight  Ho..rs  ...and then convert the seconds into hours.
+##
+val distance2 = 100*Metre
+val time = 9.8*Second
+val speed = distance2/time
+val mph = speed.in[Miles].in[Hours]
+
+```
+
+### SI definitions
+
+There are seven SI base dimensions, with corresponding units, which are defined by Quantitative:
+ - `Length` with units type, `Metres`, and unit value, `Metre`
+ - `Mass` with units, `Kilograms`, and unit value, `Kilogram`
+ - `Time` with units, `Seconds`, and unit value, `Second`
+ - `Current` with units, `Amperes`, and unit value, `Ampere`
+ - `Luminosity` with units, `Candelas`, and unit value, `Candela`
+ - `AmountOfSubstance` with units, `Moles`, and unit value, `Mole`
+ - `Temperature` with units, `Kelvins`, and unit value, `Kelvin`
+
+As well as these, the following SI derived unit values are defined in terms of the base units:
+ - `Hertz`, for measuring frequency, as one per second
+ - `Newton`, for measuring force, as one metre-kilogram per square second
+ - `Pascal`, for measuring pressure, as one Newton per square metre
+ - `Joule`, for measuring energy, as one Newton-metre
+ - `Watt`, for measuring power, as one Joule per second
+ - `Coulomb`, for measuring electric charge, as one second-Ampere
+ - `Volt`, for measuring electric potential, as one Watt per Ampere
+ - `Farad`, for measuring electrical capacitance, as one Coulomb per Volt
+ - `Ohm`, for measuring electrical resistance, as one Volt per Ampere
+ - `Siemens`, for measuring electrical conductance, as one Ampere per Volt
+ - `Weber`, for measuring magnetic flux, as one Volt-second
+ - `Tesla`, for measuring magnetic flux density, as one Weber per square metre
+ - `Henry`, for measuring electrical inductance, as one Weber per Ampere
+ - `Lux`, for measuring illuminance, as one Candela per square metre
+ - `Becquerel`, for measuring radioactivity, as one per second
+ - `Gray`, for measuring ionizing radiation dose, as one Joule per kilogram
+ - `Sievert`, for measuring stochastic health risk of ionizing radiation, as one Joule per kilogram
+ - `Katal`, for measuring catalytic activity, as one mole per second
+
+## Defining your own units
+
+Quantitative provides implementations of a variety of useful (and some less useful) units from the
+metric system, CGS and imperial. It's also very easy to define your own units.
+
+Imagine we wanted to implement the FLOPS unit, for measuring the floating-point performance of a
+CPU: floating-point instructions per second.
+
+Trivially, we could create a value,
+```amok
+syntax  scala
+##
+val SimpleFlop = 1.0/Second
+```
+and use it in equations such as, `1000000*SimpleFlop * Minute` to yield an absolute number representing
+the number of floating-point instructions that could (theoretically) be calculated in one minute by
+a one-megaFLOP CPU.
+
+But this definition is just a value, not a unit. We can tweak the definition slightly to,
+```amok
+syntax  scala
+##
+val Flop = MetricUnit(1.0/Second)
+```
+and it becomes possible to use metric prefixes on the value. So we could rewrite the above expression
+as, `Mega(Flop) * Minute`.
+
+### Introducing new dimensions
+
+The result is just a `Double`, though, which is a little unsatisfactory, since it represents
+something more specific: a number of instructions. To do better, we need to introduce a new
+`Dimension`, distinct from length, mass and other dimensions, and representing a CPU's
+performance,
+```amok
+syntax  scala
+##
+trait CpuPerformance extends Dimension
+```
+and create a `Flops` type corresponding to this dimension:
+```amok
+syntax  scala
+##
+import rudiments.*
+trait Flops[PowerType <: Nat]
+extends Units[PowerType, CpuPerformance]
+
+val Flop: MetricUnit[Flops[1]] = MetricUnit(1)
+```
+
+The type parameter, `PowerType`, is a necessary part of this definition, and must be constrained on
+the `Nat` type defined in [Rudiments](https://github.com/propensive/rudiments/), which is just an
+alias for `Int & Singleton`. If you are using Scala's erased definitions, both `CpuPerformance` and
+`Flops` may be made `sealed trait`s to reduce the bytecode size slightly.
+
+With these definitions, we can now write `Mega(Flop) * Minute` to get a result with the dimensions
+"FLOPS-seconds", represented by the type, `Quantity[Flops[1] & Seconds[1]]`.
+
+If we want to show the FLOPS value as `Text`, a symbolic name is required. This can be specified
+with a contextual instance of `UnitName[Flops[1]]`,
+```amok
+syntax  scala
+##
+given UnitName[Flops[1]] = () => t"FLOPS"
+```
+which will allow `show` to be called on a quantity involving FLOPs.
+
+### Describing physical quantities
+
+English provides many names for physical quantities, including the familiar base dimensions of
+_length_, _mass_, _time_ and so on, as well as combinations of these, such as _velocity_,
+_acceleration_ and _electrical resistance_.
+
+Definitions of names for many of these physical quantities are already defined, and will appear in
+error messages when a mismatch occurs.
+```amok
+syntax  scala
+error   M..)  
+  caption
+      the left operand represents velocity, but the right operand represents acceleration
+##
+Metre/Second + Metre/(Second*Second)
+
+```
+It is also possible to define your own, for example, here is the definition for "force":
+```amok
+syntax  scala
+##
+erased given DimensionName[Units[1, Mass] & Units[1, Length] & Units[-2, Time], "force"] = erasedValue
+```
+
+The singleton type `"force"` is the provided name for any units corresponding to the dimensions,
+mass×length×time¯².
+
+### Substituting simplified units
+
+While the SI base units can be used to describe the units of most physical quantities, there often
+exist simpler forms of their units. For example, the Joule, `J`, is equal to `kg⋅m²⋅s¯²`, and is
+much easier to write.
+
+By default, Quantitative will use the latter form, but it is possible to define alternative
+representations of units where these exist, and Quantitative will use these whenever a quantity is
+displayed. A contextual value can be defined, such as the following,
+```amok
+syntax     scala
+##
+import gossamer.t
+
+given SubstituteUnits[Kilograms[1] & Metres[2] & Seconds[-2]](t"J")
+```
+and then a value such as, `2.8*Kilo(Joule)` will be rendered as `2800 J` instead of `2800 kg⋅m²⋅s¯²`.
+
+Note that this only applies if the quantity's units exactly match the type parameter of
+`SubstituteUnits`, and units such as Joule-seconds would still be displayed as `kg⋅m²⋅s¯¹`.

--- a/lib/punctuation/res/bench/punctuation/small.md
+++ b/lib/punctuation/res/bench/punctuation/small.md
@@ -1,0 +1,18 @@
+### Decoupled Integration
+
+Soundness is a vast ecosystem of small libraries, for many diverse applications. For specific needs, individual libraries can be selected à la carte, without introducing a complex graph of dependencies. Care has been taken to decouple libraries which aren't directly related, without compromising their integration. Soundness's typeclass-based approach has made it possible to avoid unnecessary dependencies through the careful specification of small interfaces.
+
+But Soundness also provides six bundles of libraries targetting different domains. These are web for web applications; data for data processing; sci for scientific applications; cli for command-line applications; test for testing; and, tool for tooling development. The base bundle provides a common set of fundamental libraries, and all includes everything.
+### Compositionality
+
+Monads are the foundation of functional programming, but they don't compose. Lifting every value into a monadic wrapper type is a burden that's familiar, but can never compose as easily as expressions.
+
+Soundness APIs are _direct-style_ APIs. They are designed to compose. And they're ready for a whole new level of safety with Scala's advanced _capture checking_ functionality.
+### Declarative Programming
+
+Declarative code is easier to reason about because it's independent of control flow. Its essential structure arises from scopes and contexts, and in Scala 3 it's possible with _contextual_ values. Declare a new given instance or import an existing one, and it's valid for the entire scope. And you decide whether that's just a method body, or your entire project—on a continuuum between local and global. There's less repetition, and your code is more maintainable.
+### Next Generation Scala
+
+Soundness was developed natively for Scala 3, and exploits its extensive new features to the limit. Its sound typesystem and powerful metaprogramming capabilities make it uniquely able to accommodate APIs that take full advantage of precise types without compromising your code's legibility.
+
+Soundness is evolved from the experience of Scala 2, but not held back by its legacy. No interface has been compromised in its expressiveness for compatibility with Scala 2. Adopting Soundness means a full-throated endorsement of the future of Scala.

--- a/lib/punctuation/res/bench/punctuation/stress-mix.md
+++ b/lib/punctuation/res/bench/punctuation/stress-mix.md
@@ -1,0 +1,1643 @@
+# Stress mix
+
+A synthetic Markdown document exercising every CommonMark feature in roughly
+representative proportions. The body of this file is a base section of ~4 KB,
+repeated several times below with minor variations so the parser does not
+benefit from caching effects on identical input.
+
+[upstream]: https://example.com/upstream "Upstream reference"
+[mirror]: https://example.org/mirror
+[license]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0"
+[ref-image]: /images/diagram.png "A diagram"
+
+## Section 1: prose with mixed inline content
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com "Example") and an
+![inline image](/img/example.png "Caption"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license] reference.
+
+Autolinks like <https://commonmark.org> and emails like <mail@example.com> are
+also exercised. So is escaping: \*not emphasis\* and \[not a link\] and \\.
+Hard line breaks come from a backslash\
+or two trailing spaces.  
+Soft breaks just wrap
+to the next line.
+
+Some HTML inlines: <span>raw</span> and <kbd>Ctrl</kbd>+<kbd>C</kbd>. An entity
+reference like &amp; or &#42; or &#x2A; should decode.
+
+## Section 2: headings of every level
+
+# H1 ATX
+## H2 ATX
+### H3 ATX
+#### H4 ATX
+##### H5 ATX
+###### H6 ATX
+
+Setext H1
+=========
+
+Setext H2
+---------
+
+## Section 3: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with a continuation paragraph.
+
+* another item with
+
+  > a nested blockquote inside.
+
+* third item with
+
+  ```scala
+  val x = 42
+  println(x)
+  ```
+
+Ordered list with nesting:
+
+1. First level
+   1. Second level
+      - mixed bullet at third level
+      - another bullet
+   2. Second level item two
+2. First level item two
+   1. Nested again
+3. First level item three with `inline code` and *emphasis*.
+
+Loose ordered list:
+
+1) item one with paragraph
+
+   continuing here.
+
+2) item two
+3) item three
+
+## Section 4: block quotes
+
+> A simple block quote.
+> It spans two lines.
+
+> Outer block quote.
+>
+> > Inner block quote.
+> > > Triple-nested block quote with **strong** content.
+>
+> Back to outer level with a [link][upstream].
+
+## Section 5: code blocks
+
+Fenced code block with info string:
+
+```scala
+def parse(text: Text): Markdown of Layout =
+  // walk the cursor line by line
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Fenced code block with no info:
+
+```
+plain   text   with   spaces
+preserved exactly as written
+```
+
+Indented code block:
+
+    indented line one
+    indented line two
+    val x = "with quotes \" and backslashes \\"
+
+Tilde fenced block:
+
+~~~rust
+fn main() {
+    println!("Hello, world!");
+}
+~~~
+
+## Section 6: thematic breaks
+
+Above:
+
+---
+
+Star form:
+
+***
+
+Underscore form:
+
+___
+
+## Section 7: emphasis edge cases
+
+Triple emphasis: ***foo bar baz***
+Mixed: *foo **bar** baz*
+Underscore mid-word: foo_bar_baz (not emphasis)
+Asterisk mid-word: foo*bar*baz (is emphasis)
+Adjacent runs: ****foo****
+Within strong: **foo *bar* baz**
+Nested deeply: *a *b *c* d* e*
+
+## Section 8: more references
+
+See also [upstream link][upstream] and the [mirror][] for backups, and consult
+the [license] before redistribution. The diagram is shown ![below][ref-image].
+
+> Quoted reference: pull from [upstream] daily.
+
+End of section.
+
+---
+
+# Section repeat 2
+
+[upstream]: https://example.com/upstream "Upstream reference"
+[mirror]: https://example.org/mirror
+
+## Section 1 (repeat 2): prose with mixed inline content
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/2 "Example two") and an
+![inline image](/img/example2.png "Caption two"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference.
+
+Autolinks like <https://example.org/2> are also exercised. Backslash escapes
+\*here\* and \[there\] and \\.
+
+Hard break\
+and another  
+soft break wrapping
+to the next line.
+
+## Section 2 (repeat 2): tight nested lists
+
+- root one
+  - child one
+    - grand-child one
+    - grand-child two with `code`
+  - child two with [link](https://example.com)
+- root two with **bold**
+- root three
+  - inner
+
+## Section 3 (repeat 2): block quotes and code
+
+> Outer.
+> > Middle.
+> > > Inner with *emphasis* and a [link](https://x).
+
+```scala
+final class Cursor[data]:
+  inline def advance(): Unit = pos += 1
+  inline def more: Boolean = pos < writeEnd || moreSlow()
+```
+
+    plain indented block
+    second line
+    third line
+
+## Section 4 (repeat 2): emphasis edge cases
+
+*a*b*c*d*e*
+**a**b**c**d**
+***a*b*c***
+*foo _bar_ baz*
+_foo *bar* baz_
+**foo *bar baz***
+
+End of repeat.
+
+---
+
+# Section repeat 3
+
+[upstream]: https://example.net/upstream
+[mirror]: https://example.net/mirror
+
+Long paragraph one with *italic*, **bold**, ***both***, `code`,
+[a link](https://example.com/three), an ![image](/img/three.png),
+[ref][upstream], [mirror][], and a final shortcut [upstream]. The paragraph
+continues for several lines to give the inline parser a real workout, with
+plenty of soft line breaks and the occasional hard break  
+right here. Backslash escapes \* \_ \[ \] \( \) \\ \` \! all show.
+
+> Quote with [inline](https://x) and **bold** and `code`.
+>
+> > Nested quote with *emphasis*.
+>
+> Back to outer.
+
+## Subsection
+
+1. Numbered with **strong**
+2. Another with [link](https://x)
+3. Third with `code`
+
+- Bulleted with *italic*
+- Another with [reference][upstream]
+- Third with autolink <https://example.org>
+
+```python
+def fib(n):
+    if n < 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+```
+
+    indented again
+    second line again
+
+End of section repeat 3.
+
+---
+
+# Section repeat 4
+
+A dense paragraph: *a* *b* *c* **d** **e** **f** ***g*** ***h*** `i` `j` `k`
+[a](https://x) [b](https://y) [c](https://z) ![d](/d.png) ![e](/e.png) <https://f>
+\* \_ \[ \] \( \) \\ \` \! &amp; &copy; &#x2A; <span>x</span>.
+
+> Quote line one.
+> Quote line two with `inline` and *em* and **strong**.
+>
+> > Inner quote.
+
+- list one
+  - nested
+    - deep
+      - very deep with *emphasis* and `code` and [link](https://x)
+- list two
+- list three with very long paragraph content that wraps across multiple lines
+  to exercise paragraph continuation handling within list items, including
+  some `inline code` and [links](https://example.org) along the way.
+
+```haskell
+factorial :: Integer -> Integer
+factorial 0 = 1
+factorial n = n * factorial (n - 1)
+```
+
+End of section repeat 4.
+
+---
+
+# Section repeat 5
+
+Triple-nested blockquote with mixed content:
+
+> outer
+> > middle with *emphasis*
+> > > inner with [link](https://x) and `code` and **bold**
+> > > and a continuation line.
+> > middle continuation.
+> outer continuation.
+
+Loose ordered list with code:
+
+1. Step one.
+
+   Continuation paragraph.
+
+   ```scala
+   def step1(): Unit = ()
+   ```
+
+2. Step two.
+
+   > A blockquote inside.
+
+3. Step three.
+
+Reference resolution stress:
+
+[a]: /url-a
+[b]: /url-b "title b"
+[c]: /url-c (paren title c)
+
+See [a], [b][], [c][a], and ![image][b].
+
+## Final emphasis stress
+
+*foo*bar*baz*
+**foo**bar**baz**
+***foo***bar***baz***
+_foo_bar_baz_ (no emphasis since underscore mid-word)
+__foo__bar__baz__
+*a **b** c*
+**a *b* c**
+***a **b** c***
+*a *b *c *d* e* f* g*
+
+End of stress-mix.md.
+
+---
+
+# Section repeat 6
+
+[upstream]: https://example.com/r6
+[mirror]: https://example.org/r6
+
+A section to add bulk and ensure the file crosses 50 KB. The body deliberately
+mixes features so the parser cannot exploit a narrow distribution: *italic*,
+**bold**, ***both***, `code`, [link](https://x), [ref][upstream],
+![image](/i.png), <https://example.org>, and HTML <span>inline</span>.
+
+> Quoted bulk content with **strong**, *emphasis*, `code`, and a [link][upstream]
+> and a hard break\
+> here.
+
+- bulk list item one with *emphasis*
+- bulk list item two with `code`
+- bulk list item three with [link](https://x)
+  - nested with **bold**
+  - nested with ![image](/i.png)
+- bulk list item four
+
+```scala
+object Bench:
+  def run(): Unit =
+    println("running")
+```
+
+    indented bulk
+    second line
+    third line
+
+# Section repeat 7
+
+[upstream]: https://example.com/r7
+
+Another bulk section with full feature mix.
+
+1. Ordered bulk one with *italic*
+2. Ordered bulk two with **bold**
+3. Ordered bulk three with `code`
+4. Ordered bulk four with [link](https://x)
+5. Ordered bulk five with [ref][upstream]
+
+> Bulk quote one.
+> Bulk quote two with `inline`.
+>
+> > Nested bulk quote.
+
+```rust
+fn bulk() -> i32 {
+    42
+}
+```
+
+End of bulk content.
+
+# Section repeat 8
+
+Ten paragraphs of mixed inline content follow.
+
+Paragraph 1: *a* **b** ***c*** `d` [e](https://e) ![f](/f.png) <https://g>.
+Paragraph 2: *foo* and **bar** and ***baz*** with `code` and [link](https://x).
+Paragraph 3: backslash escapes \* \_ \[ \] \\ and entities &amp; &#42;.
+Paragraph 4: HTML inlines <em>e</em> <strong>s</strong> <code>c</code>.
+Paragraph 5: hard break\
+on next line and soft  
+break here.
+Paragraph 6: long mixed prose with *italic*, **bold**, `code`, and a
+[link with title](https://example.com "title"), all on one paragraph.
+Paragraph 7: emphasis edge ***foo*bar*baz***.
+Paragraph 8: emphasis edge *foo **bar** baz*.
+Paragraph 9: emphasis edge **foo *bar* baz**.
+Paragraph 10: final paragraph with [ref-link][upstream].
+
+[upstream]: https://example.com/r8
+
+End of stress-mix.md.
+
+---
+
+# Section repeat 9
+
+[upstream]: https://example.com/r9
+[mirror]: https://example.org/r9
+[license-r9]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r9"
+
+## Subsection 9.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/9 "Example 9") and an
+![inline image](/img/example9.png "Caption 9"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r9] reference.
+
+Autolinks like <https://commonmark.org/9> and emails like <mail9@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 9</span> <kbd>Ctrl</kbd>+<kbd>9</kbd>.
+
+## Subsection 9.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/9)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x9 = 9
+  println(x9)
+  ```
+
+Nested ordered list:
+
+1. First level 9
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep9)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 9.3: block quotes
+
+> A simple block quote 9.
+> It spans two lines.
+
+> Outer block quote 9.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 9.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse9(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (9)
+    indented line two
+    val y9 = "with quotes \" and backslashes \\"
+
+## Subsection 9.5: emphasis edge cases
+
+Triple emphasis: ***foo 9 bar baz***
+Mixed: *foo **bar 9** baz*
+Adjacent: ****foo 9****
+Nested: *a *b *c 9* d* e*
+
+## Subsection 9.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r9].
+
+End of section repeat 9.
+
+---
+
+# Section repeat 10
+
+[upstream]: https://example.com/r10
+[mirror]: https://example.org/r10
+[license-r10]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r10"
+
+## Subsection 10.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/10 "Example 10") and an
+![inline image](/img/example10.png "Caption 10"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r10] reference.
+
+Autolinks like <https://commonmark.org/10> and emails like <mail10@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 10</span> <kbd>Ctrl</kbd>+<kbd>10</kbd>.
+
+## Subsection 10.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/10)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x10 = 10
+  println(x10)
+  ```
+
+Nested ordered list:
+
+1. First level 10
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep10)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 10.3: block quotes
+
+> A simple block quote 10.
+> It spans two lines.
+
+> Outer block quote 10.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 10.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse10(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (10)
+    indented line two
+    val y10 = "with quotes \" and backslashes \\"
+
+## Subsection 10.5: emphasis edge cases
+
+Triple emphasis: ***foo 10 bar baz***
+Mixed: *foo **bar 10** baz*
+Adjacent: ****foo 10****
+Nested: *a *b *c 10* d* e*
+
+## Subsection 10.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r10].
+
+End of section repeat 10.
+
+---
+
+# Section repeat 11
+
+[upstream]: https://example.com/r11
+[mirror]: https://example.org/r11
+[license-r11]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r11"
+
+## Subsection 11.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/11 "Example 11") and an
+![inline image](/img/example11.png "Caption 11"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r11] reference.
+
+Autolinks like <https://commonmark.org/11> and emails like <mail11@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 11</span> <kbd>Ctrl</kbd>+<kbd>11</kbd>.
+
+## Subsection 11.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/11)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x11 = 11
+  println(x11)
+  ```
+
+Nested ordered list:
+
+1. First level 11
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep11)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 11.3: block quotes
+
+> A simple block quote 11.
+> It spans two lines.
+
+> Outer block quote 11.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 11.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse11(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (11)
+    indented line two
+    val y11 = "with quotes \" and backslashes \\"
+
+## Subsection 11.5: emphasis edge cases
+
+Triple emphasis: ***foo 11 bar baz***
+Mixed: *foo **bar 11** baz*
+Adjacent: ****foo 11****
+Nested: *a *b *c 11* d* e*
+
+## Subsection 11.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r11].
+
+End of section repeat 11.
+
+---
+
+# Section repeat 12
+
+[upstream]: https://example.com/r12
+[mirror]: https://example.org/r12
+[license-r12]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r12"
+
+## Subsection 12.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/12 "Example 12") and an
+![inline image](/img/example12.png "Caption 12"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r12] reference.
+
+Autolinks like <https://commonmark.org/12> and emails like <mail12@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 12</span> <kbd>Ctrl</kbd>+<kbd>12</kbd>.
+
+## Subsection 12.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/12)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x12 = 12
+  println(x12)
+  ```
+
+Nested ordered list:
+
+1. First level 12
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep12)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 12.3: block quotes
+
+> A simple block quote 12.
+> It spans two lines.
+
+> Outer block quote 12.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 12.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse12(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (12)
+    indented line two
+    val y12 = "with quotes \" and backslashes \\"
+
+## Subsection 12.5: emphasis edge cases
+
+Triple emphasis: ***foo 12 bar baz***
+Mixed: *foo **bar 12** baz*
+Adjacent: ****foo 12****
+Nested: *a *b *c 12* d* e*
+
+## Subsection 12.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r12].
+
+End of section repeat 12.
+
+---
+
+# Section repeat 13
+
+[upstream]: https://example.com/r13
+[mirror]: https://example.org/r13
+[license-r13]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r13"
+
+## Subsection 13.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/13 "Example 13") and an
+![inline image](/img/example13.png "Caption 13"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r13] reference.
+
+Autolinks like <https://commonmark.org/13> and emails like <mail13@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 13</span> <kbd>Ctrl</kbd>+<kbd>13</kbd>.
+
+## Subsection 13.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/13)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x13 = 13
+  println(x13)
+  ```
+
+Nested ordered list:
+
+1. First level 13
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep13)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 13.3: block quotes
+
+> A simple block quote 13.
+> It spans two lines.
+
+> Outer block quote 13.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 13.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse13(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (13)
+    indented line two
+    val y13 = "with quotes \" and backslashes \\"
+
+## Subsection 13.5: emphasis edge cases
+
+Triple emphasis: ***foo 13 bar baz***
+Mixed: *foo **bar 13** baz*
+Adjacent: ****foo 13****
+Nested: *a *b *c 13* d* e*
+
+## Subsection 13.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r13].
+
+End of section repeat 13.
+
+---
+
+# Section repeat 14
+
+[upstream]: https://example.com/r14
+[mirror]: https://example.org/r14
+[license-r14]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r14"
+
+## Subsection 14.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/14 "Example 14") and an
+![inline image](/img/example14.png "Caption 14"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r14] reference.
+
+Autolinks like <https://commonmark.org/14> and emails like <mail14@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 14</span> <kbd>Ctrl</kbd>+<kbd>14</kbd>.
+
+## Subsection 14.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/14)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x14 = 14
+  println(x14)
+  ```
+
+Nested ordered list:
+
+1. First level 14
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep14)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 14.3: block quotes
+
+> A simple block quote 14.
+> It spans two lines.
+
+> Outer block quote 14.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 14.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse14(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (14)
+    indented line two
+    val y14 = "with quotes \" and backslashes \\"
+
+## Subsection 14.5: emphasis edge cases
+
+Triple emphasis: ***foo 14 bar baz***
+Mixed: *foo **bar 14** baz*
+Adjacent: ****foo 14****
+Nested: *a *b *c 14* d* e*
+
+## Subsection 14.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r14].
+
+End of section repeat 14.
+
+---
+
+# Section repeat 15
+
+[upstream]: https://example.com/r15
+[mirror]: https://example.org/r15
+[license-r15]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r15"
+
+## Subsection 15.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/15 "Example 15") and an
+![inline image](/img/example15.png "Caption 15"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r15] reference.
+
+Autolinks like <https://commonmark.org/15> and emails like <mail15@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 15</span> <kbd>Ctrl</kbd>+<kbd>15</kbd>.
+
+## Subsection 15.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/15)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x15 = 15
+  println(x15)
+  ```
+
+Nested ordered list:
+
+1. First level 15
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep15)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 15.3: block quotes
+
+> A simple block quote 15.
+> It spans two lines.
+
+> Outer block quote 15.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 15.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse15(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (15)
+    indented line two
+    val y15 = "with quotes \" and backslashes \\"
+
+## Subsection 15.5: emphasis edge cases
+
+Triple emphasis: ***foo 15 bar baz***
+Mixed: *foo **bar 15** baz*
+Adjacent: ****foo 15****
+Nested: *a *b *c 15* d* e*
+
+## Subsection 15.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r15].
+
+End of section repeat 15.
+
+---
+
+# Section repeat 16
+
+[upstream]: https://example.com/r16
+[mirror]: https://example.org/r16
+[license-r16]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r16"
+
+## Subsection 16.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/16 "Example 16") and an
+![inline image](/img/example16.png "Caption 16"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r16] reference.
+
+Autolinks like <https://commonmark.org/16> and emails like <mail16@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 16</span> <kbd>Ctrl</kbd>+<kbd>16</kbd>.
+
+## Subsection 16.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/16)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x16 = 16
+  println(x16)
+  ```
+
+Nested ordered list:
+
+1. First level 16
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep16)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 16.3: block quotes
+
+> A simple block quote 16.
+> It spans two lines.
+
+> Outer block quote 16.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 16.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse16(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (16)
+    indented line two
+    val y16 = "with quotes \" and backslashes \\"
+
+## Subsection 16.5: emphasis edge cases
+
+Triple emphasis: ***foo 16 bar baz***
+Mixed: *foo **bar 16** baz*
+Adjacent: ****foo 16****
+Nested: *a *b *c 16* d* e*
+
+## Subsection 16.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r16].
+
+End of section repeat 16.
+
+---
+
+# Section repeat 17
+
+[upstream]: https://example.com/r17
+[mirror]: https://example.org/r17
+[license-r17]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r17"
+
+## Subsection 17.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/17 "Example 17") and an
+![inline image](/img/example17.png "Caption 17"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r17] reference.
+
+Autolinks like <https://commonmark.org/17> and emails like <mail17@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 17</span> <kbd>Ctrl</kbd>+<kbd>17</kbd>.
+
+## Subsection 17.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/17)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x17 = 17
+  println(x17)
+  ```
+
+Nested ordered list:
+
+1. First level 17
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep17)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 17.3: block quotes
+
+> A simple block quote 17.
+> It spans two lines.
+
+> Outer block quote 17.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 17.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse17(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (17)
+    indented line two
+    val y17 = "with quotes \" and backslashes \\"
+
+## Subsection 17.5: emphasis edge cases
+
+Triple emphasis: ***foo 17 bar baz***
+Mixed: *foo **bar 17** baz*
+Adjacent: ****foo 17****
+Nested: *a *b *c 17* d* e*
+
+## Subsection 17.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r17].
+
+End of section repeat 17.
+
+---
+
+# Section repeat 18
+
+[upstream]: https://example.com/r18
+[mirror]: https://example.org/r18
+[license-r18]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r18"
+
+## Subsection 18.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/18 "Example 18") and an
+![inline image](/img/example18.png "Caption 18"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r18] reference.
+
+Autolinks like <https://commonmark.org/18> and emails like <mail18@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 18</span> <kbd>Ctrl</kbd>+<kbd>18</kbd>.
+
+## Subsection 18.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/18)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x18 = 18
+  println(x18)
+  ```
+
+Nested ordered list:
+
+1. First level 18
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep18)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 18.3: block quotes
+
+> A simple block quote 18.
+> It spans two lines.
+
+> Outer block quote 18.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 18.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse18(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (18)
+    indented line two
+    val y18 = "with quotes \" and backslashes \\"
+
+## Subsection 18.5: emphasis edge cases
+
+Triple emphasis: ***foo 18 bar baz***
+Mixed: *foo **bar 18** baz*
+Adjacent: ****foo 18****
+Nested: *a *b *c 18* d* e*
+
+## Subsection 18.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r18].
+
+End of section repeat 18.
+
+---
+
+# Section repeat 19
+
+[upstream]: https://example.com/r19
+[mirror]: https://example.org/r19
+[license-r19]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r19"
+
+## Subsection 19.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/19 "Example 19") and an
+![inline image](/img/example19.png "Caption 19"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r19] reference.
+
+Autolinks like <https://commonmark.org/19> and emails like <mail19@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 19</span> <kbd>Ctrl</kbd>+<kbd>19</kbd>.
+
+## Subsection 19.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/19)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x19 = 19
+  println(x19)
+  ```
+
+Nested ordered list:
+
+1. First level 19
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep19)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 19.3: block quotes
+
+> A simple block quote 19.
+> It spans two lines.
+
+> Outer block quote 19.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 19.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse19(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (19)
+    indented line two
+    val y19 = "with quotes \" and backslashes \\"
+
+## Subsection 19.5: emphasis edge cases
+
+Triple emphasis: ***foo 19 bar baz***
+Mixed: *foo **bar 19** baz*
+Adjacent: ****foo 19****
+Nested: *a *b *c 19* d* e*
+
+## Subsection 19.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r19].
+
+End of section repeat 19.
+
+---
+
+# Section repeat 20
+
+[upstream]: https://example.com/r20
+[mirror]: https://example.org/r20
+[license-r20]: https://www.apache.org/licenses/LICENSE-2.0 "Apache 2.0 r20"
+
+## Subsection 20.1: prose
+
+The quick *brown* fox **jumps** over the ***lazy*** dog. This sentence contains
+emphasis (`*`), strong (`**`), strong-emphasis (`***`), and `inline code` along
+with [an inline link](https://example.com/20 "Example 20") and an
+![inline image](/img/example20.png "Caption 20"). It also has a [reference link][upstream]
+and a collapsed [mirror][] reference and a shortcut [license-r20] reference.
+
+Autolinks like <https://commonmark.org/20> and emails like <mail20@example.com>
+are also exercised. Backslash escapes \\* \\_ \\[ \\] \\ and entities
+&amp; &#42; &#x2A; &copy; appear here too. Hard line break\
+right here, soft break  
+on the next line.
+
+HTML inlines: <span>raw 20</span> <kbd>Ctrl</kbd>+<kbd>20</kbd>.
+
+## Subsection 20.2: lists
+
+Tight bullet list:
+
+- alpha *italic*
+- beta **bold**
+- gamma `code`
+- delta [link](https://example.org/20)
+
+Loose bullet list:
+
+* one paragraph item
+
+  with continuation paragraph and `inline code`.
+
+* another item with
+
+  > nested blockquote with **bold**.
+
+* third item with fenced code:
+
+  ```scala
+  val x20 = 20
+  println(x20)
+  ```
+
+Nested ordered list:
+
+1. First level 20
+   1. Second level
+      - mixed bullet at third level
+      - with [link](https://example.com/deep20)
+   2. Second level item two
+2. First level item two
+3. First level item three with `code` and *emphasis*.
+
+## Subsection 20.3: block quotes
+
+> A simple block quote 20.
+> It spans two lines.
+
+> Outer block quote 20.
+>
+> > Inner block quote with *emphasis*.
+> > > Triple-nested block quote with **strong** and `code`.
+>
+> Back to outer with a [reference][upstream].
+
+## Subsection 20.4: code blocks
+
+Fenced code block:
+
+```scala
+def parse20(text: Text): Markdown of Layout =
+  val cursor = Cursor(Iterator(text))
+  while cursor.more do cursor.advance()
+```
+
+Indented code block:
+
+    indented line one (20)
+    indented line two
+    val y20 = "with quotes \" and backslashes \\"
+
+## Subsection 20.5: emphasis edge cases
+
+Triple emphasis: ***foo 20 bar baz***
+Mixed: *foo **bar 20** baz*
+Adjacent: ****foo 20****
+Nested: *a *b *c 20* d* e*
+
+## Subsection 20.6: more references
+
+See [upstream link][upstream], [mirror][], and [license-r20].
+
+End of section repeat 20.

--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -1,0 +1,106 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
+import gossamer.*
+import hellenism.*, classloaders.threadContext
+import hieroglyph.*, charDecoders.utf8, textSanitizers.strict
+import probably.*
+import proscenium.*
+import quantitative.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.system
+import turbulence.*
+import vacuous.*
+
+object Benchmarks extends Suite(m"Punctuation benchmarks"):
+  sealed trait Information extends Dimension
+  sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
+  val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+
+  given byteDesignation: Designation[Bytes[1]] = () => t"B"
+  given decimalizer:     Decimalizer            = Decimalizer(2)
+  given device:          BenchmarkDevice        = LocalhostDevice
+  given prefixes:        Prefixes               = Prefixes(List(Kilo, Mega, Giga, Tera))
+
+  // ─── inputs ───────────────────────────────────────────────────────────────
+  // Loaded once from the bench module's classpath. `lazy val` means the cost
+  // of the read isn't paid until the first benchmark touches the input, and
+  // the same `Text` instance is reused across iterations so neither GC nor
+  // I/O contaminates the timing.
+
+  lazy val small:           Text = cp"/punctuation/small.md".read[Text]
+  lazy val medium:          Text = cp"/punctuation/medium.md".read[Text]
+  lazy val stressMix:       Text = cp"/punctuation/stress-mix.md".read[Text]
+  lazy val emphasisStress:  Text = cp"/punctuation/emphasis-stress.md".read[Text]
+
+  // ─── helpers ──────────────────────────────────────────────────────────────
+  // Each helper returns an `Int` derived from the parse result so the JIT
+  // cannot dead-code the call. `children.length` is cheap and structurally
+  // exercises the entire parse — anything elided would zero this out.
+
+  def parseJava(text: Text): Int = Commonmark.parse(text).children.length
+
+  // ─── benchmarks ───────────────────────────────────────────────────────────
+
+  def run(): Unit =
+    val bench = Bench()
+
+    val smallSize:          Quantity[Bytes[1]] = small.s.getBytes("UTF-8").nn.length*Byte
+    val mediumSize:         Quantity[Bytes[1]] = medium.s.getBytes("UTF-8").nn.length*Byte
+    val stressMixSize:      Quantity[Bytes[1]] = stressMix.s.getBytes("UTF-8").nn.length*Byte
+    val emphasisStressSize: Quantity[Bytes[1]] = emphasisStress.s.getBytes("UTF-8").nn.length*Byte
+
+    suite(m"Java baseline (commonmark-java 0.27.0)"):
+      bench(m"parse small (~2 KB, mixed prose)")
+       (target = 1*Second, operationSize = smallSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.small) }
+
+      bench(m"parse medium (~19 KB, real README)")
+       (target = 1*Second, operationSize = mediumSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.medium) }
+
+      bench(m"parse stress-mix (~38 KB, every feature)")
+       (target = 1*Second, operationSize = stressMixSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.stressMix) }
+
+      bench(m"parse emphasis-stress (~4 KB, inline-dense)")
+       (target = 1*Second, operationSize = emphasisStressSize, baseline = Baseline(compare = Min)):
+        '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.emphasisStress) }

--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -76,7 +76,8 @@ object Benchmarks extends Suite(m"Punctuation benchmarks"):
   // cannot dead-code the call. `children.length` is cheap and structurally
   // exercises the entire parse — anything elided would zero this out.
 
-  def parseJava(text: Text): Int = Commonmark.parse(text).children.length
+  def parseJava(text: Text):   Int = Commonmark.parse(text).children.length
+  def parseNative(text: Text): Int = Parser.parse(text).children.length
 
   // ─── benchmarks ───────────────────────────────────────────────────────────
 
@@ -88,19 +89,38 @@ object Benchmarks extends Suite(m"Punctuation benchmarks"):
     val stressMixSize:      Quantity[Bytes[1]] = stressMix.s.getBytes("UTF-8").nn.length*Byte
     val emphasisStressSize: Quantity[Bytes[1]] = emphasisStress.s.getBytes("UTF-8").nn.length*Byte
 
-    suite(m"Java baseline (commonmark-java 0.27.0)"):
-      bench(m"parse small (~2 KB, mixed prose)")
+    suite(m"Small input (~2 KB, mixed prose)"):
+      bench(m"Java parser (commonmark-java 0.27.0)")
        (target = 1*Second, operationSize = smallSize, baseline = Baseline(compare = Min)):
         '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.small) }
 
-      bench(m"parse medium (~19 KB, real README)")
+      bench(m"Native parser")
+       (target = 1*Second, operationSize = smallSize):
+        '{ punctuation.Benchmarks.parseNative(punctuation.Benchmarks.small) }
+
+    suite(m"Medium input (~19 KB, real README)"):
+      bench(m"Java parser (commonmark-java 0.27.0)")
        (target = 1*Second, operationSize = mediumSize, baseline = Baseline(compare = Min)):
         '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.medium) }
 
-      bench(m"parse stress-mix (~38 KB, every feature)")
+      bench(m"Native parser")
+       (target = 1*Second, operationSize = mediumSize):
+        '{ punctuation.Benchmarks.parseNative(punctuation.Benchmarks.medium) }
+
+    suite(m"Stress-mix (~38 KB, every feature)"):
+      bench(m"Java parser (commonmark-java 0.27.0)")
        (target = 1*Second, operationSize = stressMixSize, baseline = Baseline(compare = Min)):
         '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.stressMix) }
 
-      bench(m"parse emphasis-stress (~4 KB, inline-dense)")
+      bench(m"Native parser")
+       (target = 1*Second, operationSize = stressMixSize):
+        '{ punctuation.Benchmarks.parseNative(punctuation.Benchmarks.stressMix) }
+
+    suite(m"Emphasis-stress (~4 KB, inline-dense)"):
+      bench(m"Java parser (commonmark-java 0.27.0)")
        (target = 1*Second, operationSize = emphasisStressSize, baseline = Baseline(compare = Min)):
         '{ punctuation.Benchmarks.parseJava(punctuation.Benchmarks.emphasisStress) }
+
+      bench(m"Native parser")
+       (target = 1*Second, operationSize = emphasisStressSize):
+        '{ punctuation.Benchmarks.parseNative(punctuation.Benchmarks.emphasisStress) }

--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -36,19 +36,112 @@ import scala.collection.mutable.ArrayBuffer
 
 import anticipation.*
 import denominative.*
+import vacuous.*
 
-// Mutable builders mirroring the leaf cases of `Layout`. Each accumulates
-// content during the block-parse pass and produces a finalized `Layout` via
-// `finish`. Container builders (BlockQuote, lists) come in a later stage.
+// Mutable builder hierarchy for the block-parse pass. Containers hold a
+// child buffer and "pass through" continuation lines (after stripping their
+// own prefix) to the next-deeper open block. Leaves accumulate raw line
+// content and finalize to a single `Layout` value.
 
 sealed trait BlockBuilder:
   val line: Ordinal
+
+sealed trait LeafBuilder extends BlockBuilder:
   def finish(refs: LinkRefs): Layout
 
-final class ParagraphBuilder(val line: Ordinal) extends BlockBuilder:
+sealed trait ContainerBuilder extends BlockBuilder:
+  val children: ArrayBuffer[Layout] = ArrayBuffer()
+  // Try to continue this container on the given line. Returns the remaining
+  // (post-prefix) line content if it continues, or `Unset` if it doesn't.
+  def tryContinue(line: Text): Optional[Text]
+  def finish(refs: LinkRefs): Optional[Layout]
+  // Whether a blank line at this point closes the container.
+  def closesOnBlank: Boolean = false
+
+// Document is the always-open root container; never closes until end-of-input.
+final class DocumentBuilder extends ContainerBuilder:
+  val line: Ordinal = denominative.Prim
+  def tryContinue(line: Text): Optional[Text] = line
+  def finish(refs: LinkRefs): Optional[Layout] = Unset
+
+// `> ` blockquote container.
+final class BlockQuoteBuilder(val line: Ordinal) extends ContainerBuilder:
+  def tryContinue(line: Text): Optional[Text] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n || s.charAt(i) != '>' then return Unset
+    i += 1
+    if i < n && s.charAt(i) == ' ' then i += 1
+    else if i < n && s.charAt(i) == '\t' then i += 1
+    if i == 0 then line else Text(s.substring(i, n).nn)
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    Layout.BlockQuote(line, children.toSeq*)
+
+// A list item with a known content-indent column count. The marker has
+// already been stripped by the dispatcher when the item was opened.
+final class ListItemBuilder(val line: Ordinal, val indent: Int) extends ContainerBuilder:
+  // Tracks blank lines for tight/loose detection at the list level.
+  var hadBlank: Boolean = false
+
+  def tryContinue(line: Text): Optional[Text] =
+    if ParserSupport.isBlank(line) then
+      hadBlank = true
+      // a blank line continues the item; pass through empty
+      return Text("")
+    if ParserSupport.indentColumn(line) >= indent then
+      ParserSupport.stripIndent(line, indent)
+    else
+      Unset
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    Layout.Paragraph(line)  // placeholder; lists assemble items, not Paragraph
+
+// Bullet list container holding a sequence of `ListItemBuilder` children
+// (each finalised to a `List[Layout]` for the `Layout.BulletList` items*).
+final class BulletListBuilder(val line: Ordinal, val marker: Char) extends ContainerBuilder:
+  // Each entry is the children of one list item, in document order.
+  val items: ArrayBuffer[List[Layout]] = ArrayBuffer()
+  // True if any blank line has been observed between items (=> loose list).
+  var loose: Boolean = false
+
+  def tryContinue(line: Text): Optional[Text] = line
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    Layout.BulletList(line, !loose, items.toList*)
+
+// Ordered list container; `delimiter` is `.` or `)`; `start` is the first
+// item's number.
+final class OrderedListBuilder
+  ( val line:      Ordinal,
+    val start:     Int,
+    val delimiter: '.' | ')' )
+extends ContainerBuilder:
+  val items: ArrayBuffer[List[Layout]] = ArrayBuffer()
+  var loose: Boolean = false
+
+  def tryContinue(line: Text): Optional[Text] = line
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    val delim: Optional['.' | ')'] = delimiter
+    Layout.OrderedList(line, start, !loose, delim, items.toList*)
+
+final class ParagraphBuilder(val line: Ordinal) extends LeafBuilder:
   private val lines: ArrayBuffer[Text] = ArrayBuffer()
 
-  def addLine(text: Text): Unit = lines += text
+  def addLine(text: Text): Unit =
+    // CommonMark §4.8: leading whitespace on each line of a paragraph is
+    // stripped before forming the paragraph's raw content.
+    val s = text.s
+    val n = s.length
+    var i = 0
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    val stripped = if i == 0 then text else Text(s.substring(i, n).nn)
+    lines += stripped
+
   def isEmpty: Boolean = lines.isEmpty
 
   def joined: Text =
@@ -73,7 +166,7 @@ final class FencedCodeBlockBuilder
     val fenceLen:  Int,
     val indent:    Int,
     val info:      List[Text] )
-extends BlockBuilder:
+extends LeafBuilder:
   private val content: ArrayBuffer[Text] = ArrayBuffer()
 
   def addLine(text: Text): Unit = content += text
@@ -85,7 +178,7 @@ extends BlockBuilder:
       builder.append('\n')
     Layout.CodeBlock(line, info, Text(builder.toString))
 
-final class IndentedCodeBlockBuilder(val line: Ordinal) extends BlockBuilder:
+final class IndentedCodeBlockBuilder(val line: Ordinal) extends LeafBuilder:
   // Holds raw content lines after stripping the 4-column indent. Trailing
   // blank lines are stripped at finish-time per the CommonMark spec.
   private val content: ArrayBuffer[Text] = ArrayBuffer()

--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -32,46 +32,71 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import scala.collection.mutable.ArrayBuffer
 
-import strategies.throwUnsafely
+import anticipation.*
+import denominative.*
 
-import doms.html.whatwg
-import classloaders.system
+// Mutable builders mirroring the leaf cases of `Layout`. Each accumulates
+// content during the block-parse pass and produces a finalized `Layout` via
+// `finish`. Container builders (BlockQuote, lists) come in a later stage.
 
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
+sealed trait BlockBuilder:
+  val line: Ordinal
+  def finish(refs: LinkRefs): Layout
 
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
+final class ParagraphBuilder(val line: Ordinal) extends BlockBuilder:
+  private val lines: ArrayBuffer[Text] = ArrayBuffer()
 
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def addLine(text: Text): Unit = lines += text
+  def isEmpty: Boolean = lines.isEmpty
 
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def joined: Text =
+    val builder = new StringBuilder
+    var first = true
+    for line <- lines do
+      if first then first = false else builder.append('\n')
+      builder.append(line.s)
+    Text(builder.toString)
+
+  def finish(refs: LinkRefs): Layout =
+    Layout.Paragraph(line, InlineParser.parse(joined, refs)*)
+
+  // Setext headings rewrite an open paragraph as a heading; the underline
+  // line itself is consumed by the dispatcher, not added here.
+  def toHeading(level: 1 | 2 | 3 | 4 | 5 | 6, refs: LinkRefs): Layout =
+    Layout.Heading(line, level, InlineParser.parse(joined, refs)*)
+
+final class FencedCodeBlockBuilder
+  ( val line:      Ordinal,
+    val fenceChar: Char,
+    val fenceLen:  Int,
+    val indent:    Int,
+    val info:      List[Text] )
+extends BlockBuilder:
+  private val content: ArrayBuffer[Text] = ArrayBuffer()
+
+  def addLine(text: Text): Unit = content += text
+
+  def finish(refs: LinkRefs): Layout =
+    val builder = new StringBuilder
+    for line <- content do
+      builder.append(line.s)
+      builder.append('\n')
+    Layout.CodeBlock(line, info, Text(builder.toString))
+
+final class IndentedCodeBlockBuilder(val line: Ordinal) extends BlockBuilder:
+  // Holds raw content lines after stripping the 4-column indent. Trailing
+  // blank lines are stripped at finish-time per the CommonMark spec.
+  private val content: ArrayBuffer[Text] = ArrayBuffer()
+
+  def addLine(text: Text): Unit = content += text
+
+  def finish(refs: LinkRefs): Layout =
+    while content.nonEmpty && ParserSupport.isBlank(content.last) do
+      content.dropRightInPlace(1)
+    val builder = new StringBuilder
+    for line <- content do
+      builder.append(line.s)
+      builder.append('\n')
+    Layout.CodeBlock(line, Nil, Text(builder.toString))

--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -47,7 +47,7 @@ sealed trait BlockBuilder:
   val line: Ordinal
 
 sealed trait LeafBuilder extends BlockBuilder:
-  def finish(refs: LinkRefs): Layout
+  def finish(refs: LinkRefs): Optional[Layout]
 
 sealed trait ContainerBuilder extends BlockBuilder:
   val children: ArrayBuffer[Layout] = ArrayBuffer()
@@ -134,7 +134,9 @@ final class ParagraphBuilder(val line: Ordinal) extends LeafBuilder:
 
   def addLine(text: Text): Unit =
     // CommonMark §4.8: leading whitespace on each line of a paragraph is
-    // stripped before forming the paragraph's raw content.
+    // stripped before forming the paragraph's raw content. Trailing
+    // whitespace is preserved per-line so the inline parser can detect
+    // hard line breaks (two-trailing-spaces rule).
     val s = text.s
     val n = s.length
     var i = 0
@@ -144,21 +146,54 @@ final class ParagraphBuilder(val line: Ordinal) extends LeafBuilder:
 
   def isEmpty: Boolean = lines.isEmpty
 
-  def joined: Text =
+  // Joined raw content of the (post-link-ref) paragraph. The first
+  // `linkRefCount` lines are dropped — they were consumed as link reference
+  // definitions during `extractLinkRefs`.
+  private var linkRefCount: Int = 0
+
+  private def joined: Text =
     val builder = new StringBuilder
     var first = true
-    for line <- lines do
+    var idx = linkRefCount
+    while idx < lines.length do
       if first then first = false else builder.append('\n')
-      builder.append(line.s)
+      builder.append(lines(idx).s)
+      idx += 1
     Text(builder.toString)
 
-  def finish(refs: LinkRefs): Layout =
-    Layout.Paragraph(line, InlineParser.parse(joined, refs)*)
+  // Try to consume leading lines as link reference definitions. Returns the
+  // count consumed; updates `linkRefCount`.
+  private def extractLinkRefs(refs: LinkRefs): Int =
+    var count = 0
+    var done = false
+    while !done && count < lines.length do
+      val parsed = InlineSupport.parseLinkRefDef(lines(count))
+      if parsed.absent then done = true
+      else
+        refs.add(parsed.vouch)
+        count += 1
+    linkRefCount = count
+    count
+
+  def finish(refs: LinkRefs): Optional[Layout] =
+    extractLinkRefs(refs)
+    if linkRefCount >= lines.length then Unset
+    else Layout.Paragraph(line, InlineParser.parse(joined, refs)*)
 
   // Setext headings rewrite an open paragraph as a heading; the underline
-  // line itself is consumed by the dispatcher, not added here.
+  // line itself is consumed by the dispatcher, not added here. No link-ref
+  // extraction here — setext underlines stop link-ref accumulation by
+  // turning the paragraph into a heading.
   def toHeading(level: 1 | 2 | 3 | 4 | 5 | 6, refs: LinkRefs): Layout =
-    Layout.Heading(line, level, InlineParser.parse(joined, refs)*)
+    val text =
+      val builder = new StringBuilder
+      var first = true
+      for line <- lines do
+        if first then first = false else builder.append('\n')
+        builder.append(line.s)
+      Text(builder.toString)
+
+    Layout.Heading(line, level, InlineParser.parse(text, refs)*)
 
 final class FencedCodeBlockBuilder
   ( val line:      Ordinal,
@@ -171,7 +206,7 @@ extends LeafBuilder:
 
   def addLine(text: Text): Unit = content += text
 
-  def finish(refs: LinkRefs): Layout =
+  def finish(refs: LinkRefs): Optional[Layout] =
     val builder = new StringBuilder
     for line <- content do
       builder.append(line.s)
@@ -185,7 +220,7 @@ final class IndentedCodeBlockBuilder(val line: Ordinal) extends LeafBuilder:
 
   def addLine(text: Text): Unit = content += text
 
-  def finish(refs: LinkRefs): Layout =
+  def finish(refs: LinkRefs): Optional[Layout] =
     while content.nonEmpty && ParserSupport.isBlank(content.last) do
       content.dropRightInPlace(1)
     val builder = new StringBuilder

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -32,46 +32,128 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import scala.collection.mutable.ArrayBuffer
 
-import strategies.throwUnsafely
+import anticipation.*
+import denominative.*
+import prepositional.*
+import vacuous.*
+import zephyrine.*
+import zephyrine.lineation.linefeedChars
 
-import doms.html.whatwg
-import classloaders.system
+// Pass 1 of the native parser: line-by-line dispatch with a single-leaf
+// "open block" pointer. Stage 2 supports leaf blocks only (paragraph,
+// ATX/setext heading, thematic break, fenced/indented code block); container
+// blocks (blockquote, lists) come in stage 3, at which point this single
+// `openLeaf` pointer becomes a stack of open builders.
 
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
+final class BlockParser:
+  private val children: ArrayBuffer[Layout] = ArrayBuffer()
+  private val refs: LinkRefs = LinkRefs()
+  private var openLeaf: Optional[BlockBuilder] = Unset
 
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
+  def parse(text: Text): Markdown of Layout =
+    val cursor = Cursor(Iterator(text))
+    while cursor.more do
+      val ln = cursor.line
 
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+      val line = cursor.hold:
+        val start = cursor.mark
+        val foundLf = cursor.seek('\n')
+        val end = cursor.mark
+        val captured = cursor.grab(start, end)
+        if foundLf then cursor.advance()
+        captured
 
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+      processLine(line, ln)
+
+    closeOpenLeaf()
+    Markdown(refs.all, children.toSeq*)
+
+  private def closeOpenLeaf(): Unit = openLeaf match
+    case Unset => ()
+
+    case builder: BlockBuilder =>
+      children += builder.finish(refs)
+      openLeaf = Unset
+
+
+  private def processLine(line: Text, ln: Ordinal): Unit = openLeaf match
+    case fenced: FencedCodeBlockBuilder =>
+      if ParserSupport.isFenceCloser(line, fenced.fenceChar, fenced.fenceLen)
+      then closeOpenLeaf()
+      else fenced.addLine(ParserSupport.stripIndent(line, fenced.indent))
+
+    case indented: IndentedCodeBlockBuilder =>
+      if ParserSupport.isBlank(line) then
+        indented.addLine(ParserSupport.stripIndent(line, 4))
+      else if ParserSupport.indentColumn(line) >= 4 then
+        indented.addLine(ParserSupport.stripIndent(line, 4))
+      else
+        closeOpenLeaf()
+        dispatchGeneral(line, ln)
+
+    case _ => dispatchGeneral(line, ln)
+
+
+  private def dispatchGeneral(line: Text, ln: Ordinal): Unit =
+    if ParserSupport.isBlank(line) then
+      openLeaf match
+        case _: ParagraphBuilder => closeOpenLeaf()
+        case _                   => ()
+      return
+
+    ParserSupport.fenceOpener(line) match
+      case (ch: Char, count: Int, indent: Int, info: Text) =>
+        closeOpenLeaf()
+        val tokens = ParserSupport.cutInfo(info)
+        openLeaf = FencedCodeBlockBuilder(ln, ch, count, indent, tokens)
+        return
+
+      case Unset => ()
+
+    openLeaf match
+      case para: ParagraphBuilder if !para.isEmpty =>
+        ParserSupport.setextUnderline(line) match
+          case 1 =>
+            children += para.toHeading(1, refs)
+            openLeaf = Unset
+            return
+
+          case 2 =>
+            children += para.toHeading(2, refs)
+            openLeaf = Unset
+            return
+
+          case Unset => ()
+
+      case _ => ()
+
+    if ParserSupport.isThematicBreak(line) then
+      closeOpenLeaf()
+      children += Layout.ThematicBreak(ln)
+      return
+
+    ParserSupport.atxHeading(line) match
+      case (level: (1 | 2 | 3 | 4 | 5 | 6), content: Text) =>
+        closeOpenLeaf()
+        children += Layout.Heading(ln, level, InlineParser.parse(content, refs)*)
+        return
+
+      case Unset => ()
+
+    if openLeaf.absent && ParserSupport.indentColumn(line) >= 4 then
+      val indented = IndentedCodeBlockBuilder(ln)
+      indented.addLine(ParserSupport.stripIndent(line, 4))
+      openLeaf = indented
+      return
+
+    val text = ParserSupport.stripTrailingSpaces(line)
+    openLeaf match
+      case para: ParagraphBuilder => para.addLine(text)
+
+      case _ =>
+        closeOpenLeaf()
+        val para = ParagraphBuilder(ln)
+        para.addLine(text)
+        openLeaf = para

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -36,21 +36,31 @@ import scala.collection.mutable.ArrayBuffer
 
 import anticipation.*
 import denominative.*
+import fulminate.*
+import gossamer.*
 import prepositional.*
 import vacuous.*
 import zephyrine.*
 import zephyrine.lineation.linefeedChars
 
-// Pass 1 of the native parser: line-by-line dispatch with a single-leaf
-// "open block" pointer. Stage 2 supports leaf blocks only (paragraph,
-// ATX/setext heading, thematic break, fenced/indented code block); container
-// blocks (blockquote, lists) come in stage 3, at which point this single
-// `openLeaf` pointer becomes a stack of open builders.
+// Pass 1: line-by-line dispatch over a stack of open block builders. The
+// algorithm follows CommonMark's "phase 1" (block parsing):
+//
+//   1. For each line, walk down the open-block stack and ask each container
+//      builder to "continue" — for blockquotes that means stripping `> `,
+//      for list items it means stripping the required indent.
+//   2. Containers that can't continue terminate the walk; they get closed
+//      from the failure point downward (with `finish`), unless lazy
+//      paragraph continuation rescues them.
+//   3. With the residual line content, repeatedly try to open new container
+//      blocks (`>`, list markers).
+//   4. The leftover content goes into a leaf — heading, code block, or
+//      paragraph (start new or continue existing).
 
 final class BlockParser:
-  private val children: ArrayBuffer[Layout] = ArrayBuffer()
   private val refs: LinkRefs = LinkRefs()
-  private var openLeaf: Optional[BlockBuilder] = Unset
+  private val docBuilder: DocumentBuilder = DocumentBuilder()
+  private val openStack: ArrayBuffer[BlockBuilder] = ArrayBuffer(docBuilder)
 
   def parse(text: Text): Markdown of Layout =
     val cursor = Cursor(Iterator(text))
@@ -67,93 +77,299 @@ final class BlockParser:
 
       processLine(line, ln)
 
-    closeOpenLeaf()
-    Markdown(refs.all, children.toSeq*)
+    closeAll()
+    Markdown(refs.all, docBuilder.children.toSeq*)
 
-  private def closeOpenLeaf(): Unit = openLeaf match
-    case Unset => ()
+  // ─── stack management ───────────────────────────────────────────────────
 
-    case builder: BlockBuilder =>
-      children += builder.finish(refs)
-      openLeaf = Unset
+  private def deepest: BlockBuilder = openStack.last
 
+  private def closeOne(): Unit =
+    val builder = openStack.remove(openStack.length - 1)
+    val parent = openStack.last
+    builder match
+      case item: ListItemBuilder =>
+        parent match
+          case bl: BulletListBuilder  => bl.items += item.children.toList
+          case ol: OrderedListBuilder => ol.items += item.children.toList
+          case _                      => panic(m"ListItem parent must be a List")
 
-  private def processLine(line: Text, ln: Ordinal): Unit = openLeaf match
-    case fenced: FencedCodeBlockBuilder =>
-      if ParserSupport.isFenceCloser(line, fenced.fenceChar, fenced.fenceLen)
-      then closeOpenLeaf()
-      else fenced.addLine(ParserSupport.stripIndent(line, fenced.indent))
+      case container: ContainerBuilder =>
+        container.finish(refs).let: layout =>
+          addToParent(parent, layout)
 
-    case indented: IndentedCodeBlockBuilder =>
-      if ParserSupport.isBlank(line) then
-        indented.addLine(ParserSupport.stripIndent(line, 4))
-      else if ParserSupport.indentColumn(line) >= 4 then
-        indented.addLine(ParserSupport.stripIndent(line, 4))
-      else
-        closeOpenLeaf()
-        dispatchGeneral(line, ln)
+      case leaf: LeafBuilder =>
+        addToParent(parent, leaf.finish(refs))
 
-    case _ => dispatchGeneral(line, ln)
+  private def addToParent(parent: BlockBuilder, layout: Layout): Unit = parent match
+    case item: ListItemBuilder       => item.children += layout
+    case container: ContainerBuilder => container.children += layout
+    case _                           => panic(m"cannot add child to a leaf builder")
 
+  private def closeAll(): Unit = while openStack.length > 1 do closeOne()
 
-  private def dispatchGeneral(line: Text, ln: Ordinal): Unit =
-    if ParserSupport.isBlank(line) then
-      openLeaf match
-        case _: ParagraphBuilder => closeOpenLeaf()
+  private def closeFromIndex(idx: Int): Unit =
+    while openStack.length > idx do closeOne()
+
+  private def closeOpenLeafForNewBlock(): Unit = deepest match
+    case _: LeafBuilder => closeOne()
+    case _              => ()
+
+  private def closeListChainAtTop(): Unit =
+    var done = false
+    while !done do
+      deepest match
+        case _: ListItemBuilder    => closeOne()
+        case _: BulletListBuilder  => closeOne()
+        case _: OrderedListBuilder => closeOne()
+        case _                     => done = true
+
+  // ─── phase 1: walk containers ───────────────────────────────────────────
+
+  // Returns (firstUnmatchedIdx, residualLine). Indices < firstUnmatchedIdx
+  // are still-open containers that successfully continued.
+  private def walkContainers(line: Text): (Int, Text) =
+    var idx = 1
+    var remaining = line
+    var continueLoop = true
+    while idx < openStack.length && continueLoop do
+      openStack(idx) match
+        case container: ContainerBuilder =>
+          val cont = container.tryContinue(remaining)
+          if cont.absent then continueLoop = false
+          else
+            remaining = cont.vouch
+            idx += 1
+
+        case _: LeafBuilder => continueLoop = false
+    (idx, remaining)
+
+  // ─── phase 3: try to open new container blocks repeatedly ───────────────
+
+  private def tryOpenContainers(line: Text, ln: Ordinal): Text =
+    var current = line
+    var keepGoing = true
+    while keepGoing do
+      val (next, opened) = tryOpenOneContainer(current, ln)
+      if opened then current = next else keepGoing = false
+    current
+
+  private def tryOpenOneContainer(line: Text, ln: Ordinal): (Text, Boolean) =
+    // BlockQuote `>`
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent < 4 && i < n && s.charAt(i) == '>' then
+      i += 1
+      if i < n && s.charAt(i) == ' ' then i += 1
+      else if i < n && s.charAt(i) == '\t' then i += 1
+      closeOpenLeafForNewBlock()
+      val bq = BlockQuoteBuilder(ln)
+      openStack += bq
+      val rest = if i >= n then t"" else Text(s.substring(i, n).nn)
+      return (rest, true)
+
+    // Bullet list marker
+    ParserSupport.bulletMarker(line) match
+      case bm: BulletMarker =>
+        return openListItem(ln, Some(bm), None, line)
+
+      case Unset => ()
+
+    // Ordered list marker
+    ParserSupport.orderedMarker(line) match
+      case om: OrderedMarker =>
+        // CommonMark: an ordered list cannot interrupt a paragraph unless it
+        // starts at 1
+        deepest match
+          case _: ParagraphBuilder if om.start != 1 => ()
+
+          case _ =>
+            return openListItem(ln, None, Some(om), line)
+
+      case Unset => ()
+
+    (line, false)
+
+  // Open a new ListItem (and a parent List if needed).
+  private def openListItem
+    ( ln:      Ordinal,
+      bullet:  Option[BulletMarker],
+      ordered: Option[OrderedMarker],
+      line:    Text )
+  :   (Text, Boolean) =
+
+    val rest: Text = bullet.map(_.rest).orElse(ordered.map(_.rest)).get
+
+    // CommonMark: a list item with empty content cannot interrupt a paragraph
+    deepest match
+      case _: ParagraphBuilder if ParserSupport.isBlank(rest) =>
+        return (line, false)
+
+      case _ => ()
+
+    // Decide whether to reuse the open List or open a new one
+    val reuseList: Boolean = deepest match
+      case bl: BulletListBuilder =>
+        bullet match
+          case Some(bm) => bl.marker == bm.char
+          case None     => false
+
+      case ol: OrderedListBuilder =>
+        ordered match
+          case Some(om) => ol.delimiter == om.delimiter
+          case None     => false
+
+      case _ => false
+
+    if !reuseList then
+      closeOpenLeafForNewBlock()
+      closeListChainAtTop()
+
+      val newList: ContainerBuilder = bullet match
+        case Some(bm) => BulletListBuilder(ln, bm.char)
+
+        case None =>
+          val om = ordered.get
+          OrderedListBuilder(ln, om.start, om.delimiter)
+
+      openStack += newList
+    else
+      // The open list of matching kind is at the top; an open list-item
+      // would have been closed during phase-1 walk if its indent didn't
+      // match, but in case it didn't we close any item now.
+      closeOpenLeafForNewBlock()
+      deepest match
+        case _: ListItemBuilder => closeOne()
+        case _                  => ()
+
+    val contentIndent = bullet.map(_.contentIndent).getOrElse(ordered.get.contentIndent)
+    val item = ListItemBuilder(ln, contentIndent)
+    openStack += item
+
+    (rest, true)
+
+  // ─── per-line dispatch ──────────────────────────────────────────────────
+
+  private def processLine(originalLine: Text, ln: Ordinal): Unit =
+    val (matchedDepth, residual0) = walkContainers(originalLine)
+
+    // Active fenced/indented code block at the deepest position bypasses
+    // opening logic — feed it the residual after matched containers.
+    if matchedDepth < openStack.length then
+      openStack(matchedDepth) match
+        case fenced: FencedCodeBlockBuilder =>
+          if ParserSupport.isFenceCloser(residual0, fenced.fenceChar, fenced.fenceLen)
+          then closeFromIndex(matchedDepth)
+          else fenced.addLine(ParserSupport.stripIndent(residual0, fenced.indent))
+          return
+
+        case indented: IndentedCodeBlockBuilder =>
+          if ParserSupport.isBlank(residual0) then
+            indented.addLine(ParserSupport.stripIndent(residual0, 4))
+            return
+          else if ParserSupport.indentColumn(residual0) >= 4 then
+            indented.addLine(ParserSupport.stripIndent(residual0, 4))
+            return
+          else
+            // close indented code, fall through
+            closeFromIndex(matchedDepth)
+
+        case _ => ()
+
+    // Lazy paragraph continuation
+    val deepestIsParagraph = deepest.isInstanceOf[ParagraphBuilder]
+
+    val canLazyContinue =
+      deepestIsParagraph
+      && !ParserSupport.startsNonParagraphBlock(residual0)
+      && !ParserSupport.isBlank(residual0)
+
+    if canLazyContinue then
+      val para = deepest.asInstanceOf[ParagraphBuilder]
+      para.addLine(ParserSupport.stripTrailingSpaces(residual0))
+      return
+
+    // Mark blank-line-induced loose flag on enclosing list items before
+    // closing failed containers
+    if matchedDepth < openStack.length && ParserSupport.isBlank(residual0) then
+      var idx = 1
+      while idx < openStack.length do
+        openStack(idx) match
+          case item: ListItemBuilder => item.hadBlank = true
+          case _                     => ()
+        idx += 1
+
+    if matchedDepth < openStack.length then closeFromIndex(matchedDepth)
+
+    val residual = tryOpenContainers(residual0, ln)
+    placeLeaf(residual, ln)
+
+  private def placeLeaf(residual: Text, ln: Ordinal): Unit =
+    if ParserSupport.isBlank(residual) then
+      deepest match
+        case _: ParagraphBuilder => closeOne()
         case _                   => ()
       return
 
-    ParserSupport.fenceOpener(line) match
+    ParserSupport.fenceOpener(residual) match
       case (ch: Char, count: Int, indent: Int, info: Text) =>
-        closeOpenLeaf()
+        closeOpenLeafForNewBlock()
         val tokens = ParserSupport.cutInfo(info)
-        openLeaf = FencedCodeBlockBuilder(ln, ch, count, indent, tokens)
+        val fenced = FencedCodeBlockBuilder(ln, ch, count, indent, tokens)
+        openStack += fenced
         return
 
       case Unset => ()
 
-    openLeaf match
+    deepest match
       case para: ParagraphBuilder if !para.isEmpty =>
-        ParserSupport.setextUnderline(line) match
+        ParserSupport.setextUnderline(residual) match
           case 1 =>
-            children += para.toHeading(1, refs)
-            openLeaf = Unset
+            openStack.remove(openStack.length - 1)
+            addToParent(deepest, para.toHeading(1, refs))
             return
 
           case 2 =>
-            children += para.toHeading(2, refs)
-            openLeaf = Unset
+            openStack.remove(openStack.length - 1)
+            addToParent(deepest, para.toHeading(2, refs))
             return
 
           case Unset => ()
 
       case _ => ()
 
-    if ParserSupport.isThematicBreak(line) then
-      closeOpenLeaf()
-      children += Layout.ThematicBreak(ln)
+    if ParserSupport.isThematicBreak(residual) then
+      closeOpenLeafForNewBlock()
+      addToParent(deepest, Layout.ThematicBreak(ln))
       return
 
-    ParserSupport.atxHeading(line) match
+    ParserSupport.atxHeading(residual) match
       case (level: (1 | 2 | 3 | 4 | 5 | 6), content: Text) =>
-        closeOpenLeaf()
-        children += Layout.Heading(ln, level, InlineParser.parse(content, refs)*)
+        closeOpenLeafForNewBlock()
+        addToParent(deepest, Layout.Heading(ln, level, InlineParser.parse(content, refs)*))
         return
 
       case Unset => ()
 
-    if openLeaf.absent && ParserSupport.indentColumn(line) >= 4 then
+    val canStartIndentedCode = deepest match
+      case _: LeafBuilder => false
+      case _              => true
+
+    if canStartIndentedCode && ParserSupport.indentColumn(residual) >= 4 then
       val indented = IndentedCodeBlockBuilder(ln)
-      indented.addLine(ParserSupport.stripIndent(line, 4))
-      openLeaf = indented
+      indented.addLine(ParserSupport.stripIndent(residual, 4))
+      openStack += indented
       return
 
-    val text = ParserSupport.stripTrailingSpaces(line)
-    openLeaf match
+    val text = ParserSupport.stripTrailingSpaces(residual)
+    deepest match
       case para: ParagraphBuilder => para.addLine(text)
 
       case _ =>
-        closeOpenLeaf()
+        closeOpenLeafForNewBlock()
         val para = ParagraphBuilder(ln)
         para.addLine(text)
-        openLeaf = para
+        openStack += para

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -99,7 +99,8 @@ final class BlockParser:
           addToParent(parent, layout)
 
       case leaf: LeafBuilder =>
-        addToParent(parent, leaf.finish(refs))
+        leaf.finish(refs).let: layout =>
+          addToParent(parent, layout)
 
   private def addToParent(parent: BlockBuilder, layout: Layout): Unit = parent match
     case item: ListItemBuilder       => item.children += layout
@@ -289,7 +290,7 @@ final class BlockParser:
 
     if canLazyContinue then
       val para = deepest.asInstanceOf[ParagraphBuilder]
-      para.addLine(ParserSupport.stripTrailingSpaces(residual0))
+      para.addLine(residual0)
       return
 
     // Mark blank-line-induced loose flag on enclosing list items before
@@ -364,12 +365,13 @@ final class BlockParser:
       openStack += indented
       return
 
-    val text = ParserSupport.stripTrailingSpaces(residual)
+    // Trailing whitespace per-line is preserved so the inline parser can
+    // detect hard line breaks via the two-trailing-spaces rule.
     deepest match
-      case para: ParagraphBuilder => para.addLine(text)
+      case para: ParagraphBuilder => para.addLine(residual)
 
       case _ =>
         closeOpenLeafForNewBlock()
         val para = ParagraphBuilder(ln)
-        para.addLine(text)
+        para.addLine(residual)
         openStack += para

--- a/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
+++ b/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
@@ -45,13 +45,25 @@ import vacuous.*
 
 sealed trait InlineData
 
-case class TextData(text: Text)                                            extends InlineData
-case class CodeData(code: Text)                                            extends InlineData
-case object SoftbreakData                                                  extends InlineData
-case object LinebreakData                                                  extends InlineData
-case class LinkData(dest: Text, title: Optional[Text], children: Seq[Prose]) extends InlineData
-case class EmphasisData(children: List[InlineNode])                        extends InlineData
-case class StrongData(children: List[InlineNode])                          extends InlineData
+case class TextData(text: Text)                                                extends InlineData
+case class CodeData(code: Text)                                                extends InlineData
+case object SoftbreakData                                                      extends InlineData
+case object LinebreakData                                                      extends InlineData
+case class LinkData
+  ( dest: Text, title: Optional[Text], children: List[InlineNode] )
+extends InlineData
+
+case class ImageData
+  ( dest: Text, title: Optional[Text], children: List[InlineNode] )
+extends InlineData
+case class EmphasisData(children: List[InlineNode])                            extends InlineData
+case class StrongData(children: List[InlineNode])                              extends InlineData
+
+// `[` or `![` marker placed in the inline list when a link/image bracket
+// opens. After tokenization the corresponding `BracketEntry` in the parser's
+// bracket stack tells us whether to wrap as a link, leave as literal text,
+// or skip (if the marker was deactivated by a containing link).
+final class BracketData(val isImage: Boolean) extends InlineData
 
 // `*` or `_` delimiter run. `length` may be reduced as the emphasis
 // algorithm consumes characters from the run.
@@ -245,9 +257,11 @@ object EmphasisProcessor:
     case CodeData(c)             => Some(Prose.Code(c))
     case SoftbreakData           => Some(Prose.Softbreak)
     case LinebreakData           => Some(Prose.Linebreak)
-    case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch*))
+    case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch.flatMap(proseOf)*))
+    case ImageData(d, title, ch) => Some(Prose.Image(d, title, ch.flatMap(proseOf)*))
     case EmphasisData(children)  => Some(Prose.Emphasis(children.flatMap(proseOf)*))
     case StrongData(children)    => Some(Prose.Strong(children.flatMap(proseOf)*))
+    case b: BracketData          => Some(Prose.Textual(Text(if b.isImage then "![" else "[")))
     case d: DelimData            => unmatchedDelim(d)
 
   private def unmatchedDelim(d: DelimData): Option[Prose] =

--- a/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
+++ b/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
@@ -1,0 +1,257 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import scala.collection.mutable
+
+import anticipation.*
+import vacuous.*
+
+// Working representation for inline parsing. The inline parser builds a
+// doubly-linked list of `InlineNode`s, including delimiter-run nodes for
+// `*`/`_`. `processEmphasis` then walks the linked list, pairing openers
+// with closers per the CommonMark rules and inserting `EmphasisData` /
+// `StrongData` wrappers in their place.
+
+sealed trait InlineData
+
+case class TextData(text: Text)                                            extends InlineData
+case class CodeData(code: Text)                                            extends InlineData
+case object SoftbreakData                                                  extends InlineData
+case object LinebreakData                                                  extends InlineData
+case class LinkData(dest: Text, title: Optional[Text], children: Seq[Prose]) extends InlineData
+case class EmphasisData(children: List[InlineNode])                        extends InlineData
+case class StrongData(children: List[InlineNode])                          extends InlineData
+
+// `*` or `_` delimiter run. `length` may be reduced as the emphasis
+// algorithm consumes characters from the run.
+final class DelimData
+  ( val char: Char,
+    var length: Int,
+    val canOpen: Boolean,
+    val canClose: Boolean )
+extends InlineData
+
+final class InlineNode(var data: InlineData):
+  var prev: InlineNode | Null = null
+  var next: InlineNode | Null = null
+
+
+final class InlineList:
+  var first: InlineNode | Null = null
+  var last:  InlineNode | Null = null
+
+  def append(data: InlineData): InlineNode =
+    val node = InlineNode(data)
+    node.prev = last
+    if last == null then first = node else last.nn.next = node
+    last = node
+    node
+
+  def insertAfter(node: InlineNode, newNode: InlineNode): Unit =
+    newNode.prev = node
+    newNode.next = node.next
+    if node.next == null then last = newNode else node.next.nn.prev = newNode
+    node.next = newNode
+
+  def remove(node: InlineNode): Unit =
+    val p = node.prev
+    val n = node.next
+    if p == null then first = n else p.next = n
+    if n == null then last  = p else n.prev = p
+    node.prev = null
+    node.next = null
+
+  def iterator: Iterator[InlineNode] = new Iterator[InlineNode]:
+    var cur: InlineNode | Null = first
+    def hasNext: Boolean = cur != null
+
+    def next(): InlineNode =
+      val n = cur.nn
+      cur = n.next
+      n
+
+
+object EmphasisProcessor:
+
+  // CommonMark left-flanking: not followed by Unicode whitespace AND
+  // (not followed by Unicode punctuation OR preceded by Unicode whitespace
+  // or punctuation).
+  def isLeftFlanking(prevChar: Char, nextChar: Char): Boolean =
+    if isUnicodeWhitespace(nextChar) then return false
+    if !isUnicodePunctuation(nextChar) then return true
+    isUnicodeWhitespace(prevChar) || isUnicodePunctuation(prevChar)
+
+  def isRightFlanking(prevChar: Char, nextChar: Char): Boolean =
+    if isUnicodeWhitespace(prevChar) then return false
+    if !isUnicodePunctuation(prevChar) then return true
+    isUnicodeWhitespace(nextChar) || isUnicodePunctuation(nextChar)
+
+  def isUnicodeWhitespace(c: Char): Boolean =
+    c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ''
+    || Character.getType(c) == Character.SPACE_SEPARATOR
+
+  def isUnicodePunctuation(c: Char): Boolean =
+    val t = Character.getType(c)
+    t == Character.CONNECTOR_PUNCTUATION
+    || t == Character.DASH_PUNCTUATION
+    || t == Character.START_PUNCTUATION
+    || t == Character.END_PUNCTUATION
+    || t == Character.INITIAL_QUOTE_PUNCTUATION
+    || t == Character.FINAL_QUOTE_PUNCTUATION
+    || t == Character.OTHER_PUNCTUATION
+    // CommonMark also classifies a few math/currency/etc. as punctuation; this
+    // keeps the common ASCII punctuation set right (which covers all spec
+    // tests). A broader set can be added later.
+
+  // Compute (canOpen, canClose) for a delimiter run.
+  def classifyDelim
+    ( char:     Char,
+      prevChar: Char,
+      nextChar: Char )
+  :   (Boolean, Boolean) =
+
+    val left = isLeftFlanking(prevChar, nextChar)
+    val right = isRightFlanking(prevChar, nextChar)
+    if char == '*' then (left, right)
+    else
+      val canOpen = left && (!right || isUnicodePunctuation(prevChar))
+      val canClose = right && (!left || isUnicodePunctuation(nextChar))
+      (canOpen, canClose)
+
+  // Implements CommonMark's "process emphasis" algorithm (§6.2). Walks the
+  // doubly-linked list, pairing matching opener/closer delimiter runs and
+  // wrapping the inline nodes between them as `EmphasisData` / `StrongData`.
+  def process(list: InlineList, stackBottom: InlineNode | Null): Unit =
+    // Locate first delimiter strictly above stackBottom
+    var current: InlineNode | Null =
+      if stackBottom == null then list.first else stackBottom.next
+
+    // openers_bottom indexed by (char, length % 3, canOpen-of-closer)
+    val openersBottom = mutable.Map[(Char, Int, Boolean), InlineNode | Null]()
+
+    def floorOf(closer: DelimData): InlineNode | Null =
+      openersBottom.getOrElse((closer.char, closer.length % 3, closer.canOpen), stackBottom)
+
+    while current != null do
+      val curNode = current
+      val curData = curNode.data
+      curData match
+        case closer: DelimData if closer.canClose =>
+          val floor = floorOf(closer)
+          var opener: InlineNode | Null = curNode.prev
+          var matched = false
+
+          while opener != null && opener != floor && opener != stackBottom && !matched do
+            val openerNode = opener
+            openerNode.data match
+              case od: DelimData if od.canOpen && od.char == closer.char =>
+                val ruleOf3 =
+                  (od.canClose || closer.canOpen)
+                  && (od.length + closer.length) % 3 == 0
+                  && (od.length % 3 != 0 || closer.length % 3 != 0)
+
+                if !ruleOf3 then
+                  val strong = od.length >= 2 && closer.length >= 2
+                  val take = if strong then 2 else 1
+
+                  // Collect children strictly between opener and closer
+                  val children = mutable.ListBuffer[InlineNode]()
+                  var cursor: InlineNode | Null = openerNode.next
+                  while cursor != null && cursor != curNode do
+                    val n = cursor
+                    val nx = n.next
+                    list.remove(n)
+                    children += n
+                    cursor = nx
+
+                  val wrapper =
+                    if strong then InlineNode(StrongData(children.toList))
+                    else InlineNode(EmphasisData(children.toList))
+
+                  list.insertAfter(openerNode, wrapper)
+
+                  od.length -= take
+                  closer.length -= take
+
+                  if od.length == 0 then list.remove(openerNode)
+                  if closer.length == 0 then
+                    val nxt = curNode.next
+                    list.remove(curNode)
+                    current = nxt
+                    matched = true
+                  else
+                    matched = true
+                    // Continue with the now-shorter closer at the same node
+                else
+                  opener = openerNode.prev
+
+              case _ => opener = openerNode.prev
+
+          if !matched then
+            openersBottom((closer.char, closer.length % 3, closer.canOpen)) = curNode.prev
+            if !closer.canOpen then
+              val nxt = curNode.next
+              list.remove(curNode)
+              current = nxt
+            else
+              current = curNode.next
+
+        case _ => current = curNode.next
+
+  // Convert the (post-emphasis) inline list to a Seq[Prose] for embedding
+  // in a Layout.Paragraph or Layout.Heading.
+  def toProse(list: InlineList): Seq[Prose] =
+    val builder = mutable.ListBuffer[Prose]()
+    var cur: InlineNode | Null = list.first
+    while cur != null do
+      val node = cur
+      proseOf(node).foreach(builder += _)
+      cur = node.next
+    builder.toSeq
+
+  private def proseOf(node: InlineNode): Option[Prose] = node.data match
+    case TextData(t)             => Some(Prose.Textual(t))
+    case CodeData(c)             => Some(Prose.Code(c))
+    case SoftbreakData           => Some(Prose.Softbreak)
+    case LinebreakData           => Some(Prose.Linebreak)
+    case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch*))
+    case EmphasisData(children)  => Some(Prose.Emphasis(children.flatMap(proseOf)*))
+    case StrongData(children)    => Some(Prose.Strong(children.flatMap(proseOf)*))
+    case d: DelimData            => unmatchedDelim(d)
+
+  private def unmatchedDelim(d: DelimData): Option[Prose] =
+    val sb = new StringBuilder
+    var k = 0
+    while k < d.length do { sb.append(d.char); k += 1 }
+    if d.length > 0 then Some(Prose.Textual(Text(sb.toString))) else None

--- a/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
+++ b/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
@@ -47,6 +47,7 @@ sealed trait InlineData
 
 case class TextData(text: Text)                                                extends InlineData
 case class CodeData(code: Text)                                                extends InlineData
+case class HtmlInlineData(html: Text)                                          extends InlineData
 case object SoftbreakData                                                      extends InlineData
 case object LinebreakData                                                      extends InlineData
 case class LinkData
@@ -255,6 +256,7 @@ object EmphasisProcessor:
   private def proseOf(node: InlineNode): Option[Prose] = node.data match
     case TextData(t)             => Some(Prose.Textual(t))
     case CodeData(c)             => Some(Prose.Code(c))
+    case HtmlInlineData(h)       => Some(Prose.HtmlInline(h))
     case SoftbreakData           => Some(Prose.Softbreak)
     case LinebreakData           => Some(Prose.Linebreak)
     case LinkData(d, title, ch)  => Some(Prose.Link(d, title, ch.flatMap(proseOf)*))

--- a/lib/punctuation/src/core/punctuation.HtmlEntities.scala
+++ b/lib/punctuation/src/core/punctuation.HtmlEntities.scala
@@ -32,106 +32,31 @@
                                                                                                   */
 package punctuation
 
-import scala.collection.mutable
-
 import anticipation.*
-import vacuous.*
+import hellenism.*, classloaders.threadContext
+import hieroglyph.*, charDecoders.utf8, textSanitizers.skip
+import turbulence.*
 
-// Inline parser. Consumes the raw text of one paragraph or heading and emits
-// a `Seq[Prose]`. Stage 4 covers literal text, backslash escapes, character
-// entities, code spans, autolinks, and hard/soft line breaks. Emphasis,
-// links, images, and reference-link resolution arrive in stages 5–6.
-
-object InlineParser:
-  def parse(text: Text, refs: LinkRefs): Seq[Prose] =
-    val s = text.s
-    val n = s.length
-
-    // CommonMark §4.8: strip trailing whitespace from the paragraph's raw
-    // content before inline parsing. Internal-line trailing whitespace is
-    // preserved here so the per-line hard-break detection still works.
-    var end = n
-    while end > 0 && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
-
-    val builder = mutable.ListBuffer[Prose]()
-    val pending = new StringBuilder
-
-    def flushPending(): Unit =
-      if pending.length > 0 then
-        builder += Prose.Textual(Text(pending.toString))
-        pending.clear()
-
+// HTML5 named character references, loaded once from the `entities-extra.tsv`
+// resource shipped by Honeycomb. Only entries with a trailing semicolon are
+// kept, since CommonMark requires the `;` terminator for named entities to
+// be valid.
+object HtmlEntities:
+  private lazy val table: Map[String, String] =
+    val tsv = cp"/honeycomb/entities-extra.tsv".read[Text].s
+    val builder = Map.newBuilder[String, String]
+    val lines = tsv.split("\n").nn
     var i = 0
-    while i < end do
-      val c = s.charAt(i)
-      c match
-        case '\\' =>
-          if i + 1 < end then
-            val next = s.charAt(i + 1)
-            if next == '\n' then
-              flushPending()
-              builder += Prose.Linebreak
-              i += 2
-              while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
-            else if InlineSupport.isAsciiPunctuation(next) then
-              pending.append(next)
-              i += 2
-            else
-              pending.append('\\')
-              i += 1
-          else
-            pending.append('\\')
-            i += 1
+    while i < lines.length do
+      val line = lines(i).nn
+      val tab = line.indexOf('\t')
+      if tab > 0 && line.charAt(tab - 1) == ';' then
+        val name = line.substring(0, tab - 1).nn
+        val value = line.substring(tab + 1).nn
+        builder += (name -> value)
+      i += 1
+    builder.result()
 
-        case '&' =>
-          InlineSupport.parseEntity(s, i, end) match
-            case e: EntityMatch =>
-              pending.append(e.decoded)
-              i = e.end
-
-            case Unset =>
-              pending.append('&')
-              i += 1
-
-        case '`' =>
-          InlineSupport.parseCodeSpan(s, i, end) match
-            case cs: CodeSpanMatch =>
-              flushPending()
-              builder += Prose.Code(cs.content)
-              i = cs.end
-
-            case Unset =>
-              pending.append('`')
-              i += 1
-
-        case '<' =>
-          InlineSupport.parseAutolink(s, i, end) match
-            case al: AutolinkMatch =>
-              flushPending()
-              builder += al.link
-              i = al.end
-
-            case Unset =>
-              pending.append('<')
-              i += 1
-
-        case '\n' =>
-          // Hard break if pending ends with 2+ trailing spaces, else soft.
-          var j = pending.length
-          var spaces = 0
-          while j > 0 && pending.charAt(j - 1) == ' ' do
-            j -= 1
-            spaces += 1
-          pending.setLength(j)
-          flushPending()
-          if spaces >= 2 then builder += Prose.Linebreak
-          else builder += Prose.Softbreak
-          i += 1
-          while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
-
-        case _ =>
-          pending.append(c)
-          i += 1
-
-    flushPending()
-    builder.toSeq
+  // Returns the decoded text for a named entity (without `&` or `;`), or
+  // `null` if no such entity exists.
+  def lookup(name: String): String | Null = table.getOrElse(name, null)

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -32,15 +32,15 @@
                                                                                                   */
 package punctuation
 
-import scala.collection.mutable
-
 import anticipation.*
 import vacuous.*
 
-// Inline parser. Consumes the raw text of one paragraph or heading and emits
-// a `Seq[Prose]`. Stage 4 covers literal text, backslash escapes, character
-// entities, code spans, autolinks, and hard/soft line breaks. Emphasis,
-// links, images, and reference-link resolution arrive in stages 5–6.
+// Inline parser. Two passes:
+//   1. Tokenize the paragraph's raw text into a doubly-linked list of
+//      `InlineNode`s, including delimiter-run nodes for `*`/`_`.
+//   2. Run the CommonMark emphasis algorithm over the delimiter runs in the
+//      list, wrapping matched openers/closers as `EmphasisData`/`StrongData`.
+// The resulting list is then converted to a `Seq[Prose]`.
 
 object InlineParser:
   def parse(text: Text, refs: LinkRefs): Seq[Prose] =
@@ -48,17 +48,17 @@ object InlineParser:
     val n = s.length
 
     // CommonMark §4.8: strip trailing whitespace from the paragraph's raw
-    // content before inline parsing. Internal-line trailing whitespace is
-    // preserved here so the per-line hard-break detection still works.
+    // content before inline parsing. Per-line trailing whitespace is kept so
+    // hard-break detection still works at internal `\n` positions.
     var end = n
     while end > 0 && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
 
-    val builder = mutable.ListBuffer[Prose]()
+    val list = InlineList()
     val pending = new StringBuilder
 
     def flushPending(): Unit =
       if pending.length > 0 then
-        builder += Prose.Textual(Text(pending.toString))
+        list.append(TextData(Text(pending.toString)))
         pending.clear()
 
     var i = 0
@@ -67,14 +67,14 @@ object InlineParser:
       c match
         case '\\' =>
           if i + 1 < end then
-            val next = s.charAt(i + 1)
-            if next == '\n' then
+            val nextCh = s.charAt(i + 1)
+            if nextCh == '\n' then
               flushPending()
-              builder += Prose.Linebreak
+              list.append(LinebreakData)
               i += 2
               while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
-            else if InlineSupport.isAsciiPunctuation(next) then
-              pending.append(next)
+            else if InlineSupport.isAsciiPunctuation(nextCh) then
+              pending.append(nextCh)
               i += 2
             else
               pending.append('\\')
@@ -97,7 +97,7 @@ object InlineParser:
           InlineSupport.parseCodeSpan(s, i, end) match
             case cs: CodeSpanMatch =>
               flushPending()
-              builder += Prose.Code(cs.content)
+              list.append(CodeData(cs.content))
               i = cs.end
 
             case Unset =>
@@ -108,7 +108,13 @@ object InlineParser:
           InlineSupport.parseAutolink(s, i, end) match
             case al: AutolinkMatch =>
               flushPending()
-              builder += al.link
+              al.link match
+                case link: Prose.Link =>
+                  list.append(LinkData(link.destination, link.title, link.prose))
+
+                case other =>
+                  list.append(TextData(Text(other.toString)))
+
               i = al.end
 
             case Unset =>
@@ -116,7 +122,6 @@ object InlineParser:
               i += 1
 
         case '\n' =>
-          // Hard break if pending ends with 2+ trailing spaces, else soft.
           var j = pending.length
           var spaces = 0
           while j > 0 && pending.charAt(j - 1) == ' ' do
@@ -124,14 +129,36 @@ object InlineParser:
             spaces += 1
           pending.setLength(j)
           flushPending()
-          if spaces >= 2 then builder += Prose.Linebreak
-          else builder += Prose.Softbreak
+          if spaces >= 2 then list.append(LinebreakData)
+          else list.append(SoftbreakData)
           i += 1
           while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+
+        case '*' | '_' =>
+          // Delimiter run: count consecutive same-char characters.
+          var j = i
+          while j < end && s.charAt(j) == c do j += 1
+          val length = j - i
+
+          // Flanking detection uses the source characters immediately before
+          // the run and immediately after.
+          val prevChar = if i == 0 then ' ' else s.charAt(i - 1)
+          val nextChar = if j >= end then ' ' else s.charAt(j)
+
+          val (canOpen, canClose) =
+            EmphasisProcessor.classifyDelim(c, prevChar, nextChar)
+
+          flushPending()
+          list.append(DelimData(c, length, canOpen, canClose))
+          i = j
 
         case _ =>
           pending.append(c)
           i += 1
 
     flushPending()
-    builder.toSeq
+
+    // Pass 2: emphasis processing
+    EmphasisProcessor.process(list, null)
+
+    EmphasisProcessor.toProse(list)

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -32,46 +32,15 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import anticipation.*
 
-import strategies.throwUnsafely
-
-import doms.html.whatwg
-import classloaders.system
-
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
-
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
-
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
-
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+// Skeleton inline parser. Stage 4 will introduce text/escape/entity/codespan/
+// autolink/hardbreak/softbreak handling; stage 5 the emphasis delimiter
+// algorithm; stage 6 link/image and reference resolution. For now the entire
+// raw text is wrapped as a single `Prose.Textual`, which means anything other
+// than literal text (emphasis, links, code spans, escapes) will not match the
+// reference parser's output.
+object InlineParser:
+  def parse(text: Text, refs: LinkRefs): Seq[Prose] =
+    if text.s.isEmpty then Nil
+    else Seq(Prose.Textual(text))

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -137,8 +137,15 @@ object InlineParser:
               i = al.end
 
             case Unset =>
-              pending.append('<')
-              i += 1
+              InlineSupport.parseRawHtml(s, i, end) match
+                case h: InlineSupport.HtmlInlineMatch =>
+                  flushPending()
+                  list.append(HtmlInlineData(h.html))
+                  i = h.end
+
+                case Unset =>
+                  pending.append('<')
+                  i += 1
 
         case '\n' =>
           var j = pending.length

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -32,29 +32,45 @@
                                                                                                   */
 package punctuation
 
+import scala.collection.mutable
+
 import anticipation.*
+import gossamer.*
 import vacuous.*
 
 // Inline parser. Two passes:
 //   1. Tokenize the paragraph's raw text into a doubly-linked list of
-//      `InlineNode`s, including delimiter-run nodes for `*`/`_`.
-//   2. Run the CommonMark emphasis algorithm over the delimiter runs in the
-//      list, wrapping matched openers/closers as `EmphasisData`/`StrongData`.
+//      `InlineNode`s — including delimiter-run nodes for `*`/`_` and
+//      bracket-marker nodes for `[`/`![` — and try-match links/images on
+//      `]`. Successful link matches wrap the bracketed content as
+//      `LinkData` / `ImageData` and process emphasis within it.
+//   2. After tokenization, run a final emphasis pass over any remaining
+//      delimiters outside successfully-matched links.
 // The resulting list is then converted to a `Seq[Prose]`.
 
 object InlineParser:
+
+  // Bracket stack entry. `node` is the BracketData node in the inline list
+  // marking the `[` or `![`. `sourceStart` is the source position
+  // immediately AFTER the opening bracket (used to extract the literal
+  // bracket content for shortcut/collapsed reference labels). `active` is
+  // false when a containing link has been matched (no nested links).
+  private final class BracketEntry
+    ( val node:        InlineNode,
+      val isImage:     Boolean,
+      val sourceStart: Int,
+      var active:      Boolean = true )
+
   def parse(text: Text, refs: LinkRefs): Seq[Prose] =
     val s = text.s
     val n = s.length
 
-    // CommonMark §4.8: strip trailing whitespace from the paragraph's raw
-    // content before inline parsing. Per-line trailing whitespace is kept so
-    // hard-break detection still works at internal `\n` positions.
     var end = n
     while end > 0 && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
 
     val list = InlineList()
     val pending = new StringBuilder
+    val brackets = mutable.Stack[BracketEntry]()
 
     def flushPending(): Unit =
       if pending.length > 0 then
@@ -110,10 +126,13 @@ object InlineParser:
               flushPending()
               al.link match
                 case link: Prose.Link =>
-                  list.append(LinkData(link.destination, link.title, link.prose))
+                  val child = InlineNode(TextData(link.prose.head match
+                    case Prose.Textual(t) => t
+                    case _                => link.destination))
+                  list.append(LinkData(link.destination, link.title, List(child)))
 
-                case other =>
-                  list.append(TextData(Text(other.toString)))
+                case _ =>
+                  list.append(TextData(Text(al.link.toString)))
 
               i = al.end
 
@@ -135,13 +154,10 @@ object InlineParser:
           while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
 
         case '*' | '_' =>
-          // Delimiter run: count consecutive same-char characters.
           var j = i
           while j < end && s.charAt(j) == c do j += 1
           val length = j - i
 
-          // Flanking detection uses the source characters immediately before
-          // the run and immediately after.
           val prevChar = if i == 0 then ' ' else s.charAt(i - 1)
           val nextChar = if j >= end then ' ' else s.charAt(j)
 
@@ -152,13 +168,128 @@ object InlineParser:
           list.append(DelimData(c, length, canOpen, canClose))
           i = j
 
+        case '[' =>
+          flushPending()
+          val node = list.append(BracketData(isImage = false))
+          brackets.push(BracketEntry(node, isImage = false, sourceStart = i + 1))
+          i += 1
+
+        case '!' if i + 1 < end && s.charAt(i + 1) == '[' =>
+          flushPending()
+          val node = list.append(BracketData(isImage = true))
+          brackets.push(BracketEntry(node, isImage = true, sourceStart = i + 2))
+          i += 2
+
+        case ']' =>
+          flushPending()
+          val newPos = handleCloseBracket(list, brackets, s, i, end, refs)
+          i = newPos
+
         case _ =>
           pending.append(c)
           i += 1
 
     flushPending()
 
-    // Pass 2: emphasis processing
     EmphasisProcessor.process(list, null)
-
     EmphasisProcessor.toProse(list)
+
+  // Handle a closing `]` at source position `closePos`. Returns the new
+  // source index to continue from.
+  private def handleCloseBracket
+    ( list:     InlineList,
+      brackets: mutable.Stack[BracketEntry],
+      s:        String,
+      closePos: Int,
+      end:      Int,
+      refs:     LinkRefs )
+  :   Int =
+
+    if brackets.isEmpty then
+      list.append(TextData(t"]"))
+      return closePos + 1
+
+    val entry = brackets.pop()
+
+    if !entry.active then
+      // Inactive marker: drop bracket node, emit literal `]`
+      list.remove(entry.node)
+      list.append(TextData(t"]"))
+      return closePos + 1
+
+    // Try to match link/image syntax starting at the character after `]`
+    val afterClose = closePos + 1
+    tryMatchLink(s, afterClose, end, entry, refs) match
+      case Unset =>
+        // No link match: bracket and `]` become literal text
+        list.remove(entry.node)
+        list.append(TextData(if entry.isImage then t"![" else t"["))
+        list.append(TextData(t"]"))
+        afterClose
+
+      case lm: LinkResolution =>
+        // Process emphasis in the bracket content (between bracket node and
+        // current end of list), so emphasis WITHIN the link is wrapped first.
+        EmphasisProcessor.process(list, entry.node)
+
+        // Collect children: everything strictly after the bracket node, to
+        // the end of the list.
+        val children = mutable.ListBuffer[InlineNode]()
+        var cursor: InlineNode | Null = entry.node.next
+        while cursor != null do
+          val n = cursor
+          val nxt = n.next
+          list.remove(n)
+          children += n
+          cursor = nxt
+
+        // Replace bracket node with the link/image wrapper
+        list.remove(entry.node)
+        if entry.isImage then list.append(ImageData(lm.dest, lm.title, children.toList))
+        else
+          list.append(LinkData(lm.dest, lm.title, children.toList))
+          // Deactivate any earlier `[` markers (no nested links)
+          brackets.foreach(_.active = false)
+
+        lm.end
+
+  private case class LinkResolution(dest: Text, title: Optional[Text], end: Int)
+
+  private def tryMatchLink
+    ( s:        String,
+      after:    Int,
+      end:      Int,
+      entry:    BracketEntry,
+      refs:     LinkRefs )
+  :   Optional[LinkResolution] =
+
+    // 1. Inline link: ( dest title? )
+    if after < end && s.charAt(after) == '(' then
+      InlineSupport.parseInlineLinkBody(s, after, end) match
+        case b: InlineSupport.InlineLinkBody =>
+          return LinkResolution(b.dest, b.title, b.end)
+
+        case Unset => return Unset
+
+    // 2. Reference forms
+    val bracketContent = Text(s.substring(entry.sourceStart, after - 1).nn)
+
+    if after < end && s.charAt(after) == '[' then
+      InlineSupport.parseRefLabel(s, after, end) match
+        case r: InlineSupport.RefLabelMatch =>
+          val label = if r.label.s.isEmpty then bracketContent else r.label
+          val resolved = refs.lookup(label)
+          if resolved.present then
+            val ref = resolved.vouch
+            return LinkResolution(ref.destination, ref.title, r.end)
+          // ref not found; fall through to shortcut
+
+        case Unset => ()  // fall through to shortcut
+
+    // 3. Shortcut reference
+    val resolved = refs.lookup(bracketContent)
+    if resolved.present then
+      val ref = resolved.vouch
+      LinkResolution(ref.destination, ref.title, after)
+    else
+      Unset

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -1,0 +1,327 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import java.util.regex as jur
+
+import anticipation.*
+import vacuous.*
+
+case class EntityMatch(decoded: String, end: Int)
+case class CodeSpanMatch(content: Text, end: Int)
+case class AutolinkMatch(link: Prose, end: Int)
+
+object InlineSupport:
+
+  // CommonMark "ASCII punctuation": !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+  def isAsciiPunctuation(c: Char): Boolean = c match
+    case '!' | '"' | '#' | '$' | '%' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' => true
+    case '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '[' | '\\' => true
+    case ']' | '^' | '_' | '`' | '{' | '|' | '}' | '~'                          => true
+    case _                                                                      => false
+
+  private inline def isDecDigit(c: Char): Boolean = c >= '0' && c <= '9'
+
+  private inline def isHexDigit(c: Char): Boolean =
+    (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
+
+  private inline def isAsciiAlpha(c: Char): Boolean =
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+
+  private inline def isAsciiAlnum(c: Char): Boolean = isAsciiAlpha(c) || isDecDigit(c)
+
+  // Try to parse an HTML entity at position `start` (which points at `&`).
+  // Returns the decoded string and index past the closing `;`, or Unset.
+  def parseEntity(s: String, start: Int, end: Int): Optional[EntityMatch] =
+    var i = start + 1
+    if i >= end then return Unset
+
+    if s.charAt(i) == '#' then
+      i += 1
+      if i >= end then return Unset
+      val isHex = s.charAt(i) == 'x' || s.charAt(i) == 'X'
+      if isHex then i += 1
+      val digitStart = i
+      val maxDigits = if isHex then 6 else 7
+
+      def hasDigit: Boolean =
+        if isHex then isHexDigit(s.charAt(i)) else isDecDigit(s.charAt(i))
+
+      while i < end && (i - digitStart) < maxDigits && hasDigit do i += 1
+
+      if i == digitStart then return Unset
+      if i >= end || s.charAt(i) != ';' then return Unset
+      val numStr = s.substring(digitStart, i).nn
+
+      val codePoint =
+        try Integer.parseInt(numStr, if isHex then 16 else 10)
+        catch case _: NumberFormatException => return Unset
+
+      val ch =
+        if codePoint == 0 || codePoint > 0x10FFFF then "�"
+        else String.valueOf(Character.toChars(codePoint).nn).nn
+
+      EntityMatch(ch, i + 1)
+    else
+      val nameStart = i
+      while i < end && isAsciiAlnum(s.charAt(i)) do i += 1
+      if i == nameStart then return Unset
+      if i >= end || s.charAt(i) != ';' then return Unset
+      val name = s.substring(nameStart, i).nn
+      val decoded = HtmlEntities.lookup(name)
+      if decoded == null then Unset else EntityMatch(decoded, i + 1)
+
+  // Try to parse a code span starting at the run of backticks at position
+  // `start`. Returns the content text and index past the closing run.
+  def parseCodeSpan(s: String, start: Int, end: Int): Optional[CodeSpanMatch] =
+    var i = start
+    while i < end && s.charAt(i) == '`' do i += 1
+    val openerLen = i - start
+    val contentStart = i
+
+    while i < end do
+      while i < end && s.charAt(i) != '`' do i += 1
+      if i >= end then return Unset
+      val closerStart = i
+      while i < end && s.charAt(i) == '`' do i += 1
+      val closerLen = i - closerStart
+      if closerLen == openerLen then
+        val raw = s.substring(contentStart, closerStart).nn
+        // Replace newlines with spaces (CommonMark §6.1)
+        val noNewlines = raw.replace('\n', ' ').nn
+
+        // Strip one leading + one trailing space if both ends have space and
+        // content is not all spaces
+        val needsTrim =
+          noNewlines.length >= 2
+          && noNewlines.charAt(0) == ' '
+          && noNewlines.charAt(noNewlines.length - 1) == ' '
+          && existsNonSpace(noNewlines)
+
+        val stripped =
+          if needsTrim then noNewlines.substring(1, noNewlines.length - 1).nn
+          else noNewlines
+
+        return CodeSpanMatch(Text(stripped), i)
+    Unset
+
+  private def existsNonSpace(s: String): Boolean =
+    val n = s.length
+    var i = 0
+    while i < n do
+      if s.charAt(i) != ' ' then return true
+      i += 1
+    false
+
+  // Email autolink pattern from the CommonMark spec (§6.4)
+  private val EmailRegex: jur.Pattern =
+    val local = "[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+"
+    val labelChars = "[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+    jur.Pattern.compile(s"^${local}@${labelChars}(?:\\.${labelChars})*$$").nn
+
+  // Try to parse an autolink starting at `<` at position `start`.
+  // Returns a `Prose.Link` and index past `>`, or Unset.
+  def parseAutolink(s: String, start: Int, end: Int): Optional[AutolinkMatch] =
+    var i = start + 1
+    var keep = true
+    while keep && i < end do
+      val c = s.charAt(i)
+      if c == '>' || c <= 0x20 || c == '<' then keep = false
+      else i += 1
+
+    if i >= end || s.charAt(i) != '>' then return Unset
+    val content = s.substring(start + 1, i).nn
+
+    if isUriAutolink(content) then
+      val text = Text(content)
+      val link = Prose.Link(text, Unset, Prose.Textual(text))
+      AutolinkMatch(link, i + 1)
+    else if EmailRegex.matcher(content).nn.matches then
+      val text = Text(content)
+      val mailto = Text("mailto:" + content)
+      val link = Prose.Link(mailto, Unset, Prose.Textual(text))
+      AutolinkMatch(link, i + 1)
+    else
+      Unset
+
+  // Scheme: [A-Za-z][A-Za-z0-9+.-]{1,31} followed by `:` then a body of
+  // characters that are neither whitespace, controls, `<`, nor `>` (already
+  // ensured by the caller).
+  private def isUriAutolink(content: String): Boolean =
+    val n = content.length
+    if n < 3 then return false
+    if !isAsciiAlpha(content.charAt(0)) then return false
+    var i = 1
+    while i < n && i <= 32 do
+      val c = content.charAt(i)
+      val isSchemeChar = isAsciiAlnum(c) || c == '+' || c == '.' || c == '-'
+      if c == ':' then
+        if i < 2 then return false
+        return validateUriBody(content, i + 1, n)
+      if !isSchemeChar then return false
+      i += 1
+    false
+
+  private def validateUriBody(content: String, start: Int, end: Int): Boolean =
+    var i = start
+    while i < end do
+      val c = content.charAt(i)
+      if c <= 0x20 || c == '<' || c == '>' then return false
+      i += 1
+    true
+
+  // Parse a single-line link reference definition: `[label]: dest "title"`.
+  // Multi-line link refs are not yet supported. Returns the definition and
+  // the consumed-character count, or Unset.
+  def parseLinkRefDef(line: Text): Optional[Markdown.LinkRef] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 then return Unset
+    if i >= n || s.charAt(i) != '[' then return Unset
+    i += 1
+
+    val labelStart = i
+    var labelDone = false
+    while i < n && !labelDone do
+      val c = s.charAt(i)
+      if c == ']' then labelDone = true
+      else if c == '[' then return Unset
+      else if c == '\\' && i + 1 < n then i += 2
+      else i += 1
+
+    if !labelDone then return Unset
+    if i == labelStart then return Unset
+    val label = Text(s.substring(labelStart, i).nn)
+    i += 1
+
+    if i >= n || s.charAt(i) != ':' then return Unset
+    i += 1
+
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    if i >= n then return Unset
+
+    val destResult = parseLinkDestination(s, i, n)
+    if destResult.absent then return Unset
+    val (destination, afterDest) = (destResult.vouch.dest, destResult.vouch.end)
+    i = afterDest
+
+    val beforeWs = i
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+
+    var title: Optional[Text] = Unset
+    if i > beforeWs && i < n then
+      parseLinkTitle(s, i, n) match
+        case Unset =>
+          // No title: backtrack to before the whitespace to allow trailing-only
+          i = beforeWs
+
+        case t: TitleMatch =>
+          title = Text(t.title)
+          i = t.end
+
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    if i < n then return Unset
+
+    Markdown.LinkRef(label, title, destination)
+
+  case class DestMatch(dest: Text, end: Int)
+  case class TitleMatch(title: String, end: Int)
+
+  // Link destination: either `<...>` (allows escapes; no unescaped < or >),
+  // or a sequence of non-whitespace characters with balanced parentheses.
+  def parseLinkDestination(s: String, start: Int, end: Int): Optional[DestMatch] =
+    if start >= end then return Unset
+    if s.charAt(start) == '<' then
+      var i = start + 1
+      val buf = new StringBuilder
+      while i < end do
+        val c = s.charAt(i)
+        if c == '>' then return DestMatch(Text(buf.toString), i + 1)
+        else if c == '<' || c == '\n' then return Unset
+        else if c == '\\' && i + 1 < end && isAsciiPunctuation(s.charAt(i + 1)) then
+          buf.append(s.charAt(i + 1))
+          i += 2
+        else
+          buf.append(c)
+          i += 1
+      Unset
+    else
+      var i = start
+      var depth = 0
+      val buf = new StringBuilder
+      while i < end do
+        val c = s.charAt(i)
+        if c <= 0x20 then
+          if i == start then return Unset
+          return DestMatch(Text(buf.toString), i)
+        else if c == '\\' && i + 1 < end && isAsciiPunctuation(s.charAt(i + 1)) then
+          buf.append(s.charAt(i + 1))
+          i += 2
+        else if c == '(' then
+          depth += 1; buf.append(c); i += 1
+        else if c == ')' then
+          if depth == 0 then return DestMatch(Text(buf.toString), i)
+          depth -= 1; buf.append(c); i += 1
+        else
+          buf.append(c)
+          i += 1
+
+      if depth != 0 then return Unset
+      if i == start then Unset else DestMatch(Text(buf.toString), i)
+
+  // Link title: `"..."`, `'...'`, or `(...)` with backslash-escapes.
+  def parseLinkTitle(s: String, start: Int, end: Int): Optional[TitleMatch] =
+    if start >= end then return Unset
+    val opener = s.charAt(start)
+    val closer = opener match
+      case '"'  => '"'
+      case '\'' => '\''
+      case '('  => ')'
+      case _    => return Unset
+
+    var i = start + 1
+    val buf = new StringBuilder
+    while i < end do
+      val c = s.charAt(i)
+      if c == closer then return TitleMatch(buf.toString, i + 1)
+      else if c == opener && opener == '(' then return Unset  // unbalanced inner (
+      else if c == '\\' && i + 1 < end && isAsciiPunctuation(s.charAt(i + 1)) then
+        buf.append(s.charAt(i + 1))
+        i += 2
+      else
+        buf.append(c)
+        i += 1
+    Unset

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -51,15 +51,15 @@ object InlineSupport:
     case ']' | '^' | '_' | '`' | '{' | '|' | '}' | '~'                          => true
     case _                                                                      => false
 
-  private inline def isDecDigit(c: Char): Boolean = c >= '0' && c <= '9'
+  inline def isDecDigit(c: Char): Boolean = c >= '0' && c <= '9'
 
-  private inline def isHexDigit(c: Char): Boolean =
+  inline def isHexDigit(c: Char): Boolean =
     (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
 
-  private inline def isAsciiAlpha(c: Char): Boolean =
+  inline def isAsciiAlpha(c: Char): Boolean =
     (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
 
-  private inline def isAsciiAlnum(c: Char): Boolean = isAsciiAlpha(c) || isDecDigit(c)
+  inline def isAsciiAlnum(c: Char): Boolean = isAsciiAlpha(c) || isDecDigit(c)
 
   // Try to parse an HTML entity at position `start` (which points at `&`).
   // Returns the decoded string and index past the closing `;`, or Unset.
@@ -326,6 +326,142 @@ object InlineSupport:
         buf.append(c)
         i += 1
     Unset
+
+  case class HtmlInlineMatch(html: Text, end: Int)
+
+  // Try to parse a raw-HTML inline starting at `<` (position `start`).
+  // Recognises open tags, close tags, HTML comments, processing
+  // instructions, declarations, and CDATA sections, per CommonMark §6.5.
+  def parseRawHtml(s: String, start: Int, end: Int): Optional[HtmlInlineMatch] =
+    if start >= end || s.charAt(start) != '<' then return Unset
+    if start + 1 >= end then return Unset
+
+    val c = s.charAt(start + 1)
+
+    val matchedEnd: Int =
+      if c == '!' then parseHtmlBangForm(s, start, end)
+      else if c == '?' then parseHtmlProcessingInstruction(s, start, end)
+      else if c == '/' then parseHtmlClosingTag(s, start, end)
+      else if isAsciiAlpha(c) then parseHtmlOpenTag(s, start, end)
+      else -1
+
+    if matchedEnd < 0 then Unset
+    else HtmlInlineMatch(Text(s.substring(start, matchedEnd).nn), matchedEnd)
+
+  private def parseHtmlBangForm(s: String, start: Int, end: Int): Int =
+    // <!-- ... -->  /  <![CDATA[ ... ]]>  /  <! ... >  (declaration)
+    if start + 4 < end && s.charAt(start + 2) == '-' && s.charAt(start + 3) == '-' then
+      // HTML comment
+      var i = start + 4
+      while i + 2 < end do
+        if s.charAt(i) == '-' && s.charAt(i + 1) == '-' && s.charAt(i + 2) == '>' then
+          return i + 3
+        i += 1
+      -1
+    else if start + 9 < end && s.regionMatches(start + 2, "[CDATA[", 0, 7) then
+      var i = start + 9
+      while i + 2 < end do
+        if s.charAt(i) == ']' && s.charAt(i + 1) == ']' && s.charAt(i + 2) == '>' then
+          return i + 3
+        i += 1
+      -1
+    else if start + 2 < end && isAsciiUpper(s.charAt(start + 2)) then
+      var i = start + 2
+      while i < end do
+        if s.charAt(i) == '>' then return i + 1
+        i += 1
+      -1
+    else
+      -1
+
+  private def parseHtmlProcessingInstruction(s: String, start: Int, end: Int): Int =
+    var i = start + 2
+    while i + 1 < end do
+      if s.charAt(i) == '?' && s.charAt(i + 1) == '>' then return i + 2
+      i += 1
+    -1
+
+  private def parseHtmlClosingTag(s: String, start: Int, end: Int): Int =
+    // </ tag-name space* >
+    var i = start + 2
+    if i >= end || !isAsciiAlpha(s.charAt(i)) then return -1
+    i += 1
+    while i < end && (isAsciiAlnum(s.charAt(i)) || s.charAt(i) == '-') do i += 1
+    while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t' || s.charAt(i) == '\n') do
+      i += 1
+    if i < end && s.charAt(i) == '>' then i + 1 else -1
+
+  private def parseHtmlOpenTag(s: String, start: Int, end: Int): Int =
+    // < tag-name (attr)* space* /? >
+    var i = start + 1
+    if i >= end || !isAsciiAlpha(s.charAt(i)) then return -1
+    i += 1
+    while i < end && (isAsciiAlnum(s.charAt(i)) || s.charAt(i) == '-') do i += 1
+
+    var done = false
+    var failed = false
+    while !done && !failed do
+      val before = i
+      while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t' || s.charAt(i) == '\n') do
+        i += 1
+
+      if i >= end then failed = true
+      else if s.charAt(i) == '>' then done = true
+      else if s.charAt(i) == '/' then
+        if i + 1 < end && s.charAt(i + 1) == '>' then { i += 2; return i }
+        else failed = true
+      else
+        // attribute requires preceding whitespace
+        if i == before then failed = true
+        else
+          val attrEnd = parseHtmlAttribute(s, i, end)
+          if attrEnd < 0 then failed = true
+          else i = attrEnd
+
+    if failed then -1
+    else if done then i + 1
+    else -1
+
+  private inline def isAttrNameChar(c: Char): Boolean =
+    isAsciiAlnum(c) || c == '_' || c == '.' || c == ':' || c == '-'
+
+  private inline def isUnquotedValueChar(c: Char): Boolean =
+    c != ' ' && c != '\t' && c != '\n'
+    && c != '"' && c != '\''
+    && c != '=' && c != '<' && c != '>' && c != '`'
+
+  private def parseHtmlAttribute(s: String, start: Int, end: Int): Int =
+    var i = start
+    val c = s.charAt(i)
+    if !(isAsciiAlpha(c) || c == '_' || c == ':') then return -1
+    i += 1
+    while i < end && isAttrNameChar(s.charAt(i)) do i += 1
+
+    // Optional value
+    val nameEnd = i
+    while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t' || s.charAt(i) == '\n') do
+      i += 1
+
+    if i < end && s.charAt(i) == '=' then
+      i += 1
+      while i < end && (s.charAt(i) == ' ' || s.charAt(i) == '\t' || s.charAt(i) == '\n') do
+        i += 1
+      if i >= end then return -1
+      val q = s.charAt(i)
+      if q == '"' || q == '\'' then
+        i += 1
+        while i < end && s.charAt(i) != q do i += 1
+        if i >= end then return -1
+        i + 1
+      else
+        // unquoted value: no whitespace, ", ', =, <, >, `
+        val vstart = i
+        while i < end && isUnquotedValueChar(s.charAt(i)) do i += 1
+        if i == vstart then -1 else i
+    else
+      nameEnd
+
+  private def isAsciiUpper(c: Char): Boolean = c >= 'A' && c <= 'Z'
 
   case class InlineLinkBody(dest: Text, title: Optional[Text], end: Int)
 

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -35,6 +35,7 @@ package punctuation
 import java.util.regex as jur
 
 import anticipation.*
+import gossamer.*
 import vacuous.*
 
 case class EntityMatch(decoded: String, end: Int)
@@ -325,3 +326,78 @@ object InlineSupport:
         buf.append(c)
         i += 1
     Unset
+
+  case class InlineLinkBody(dest: Text, title: Optional[Text], end: Int)
+
+  // Parse the body of an inline link `(dest "title")` starting at the `(`.
+  // Returns the destination, optional title, and the index past the closing
+  // `)`, or Unset if the body doesn't parse.
+  def parseInlineLinkBody(s: String, start: Int, end: Int): Optional[InlineLinkBody] =
+    if start >= end || s.charAt(start) != '(' then return Unset
+    var i = start + 1
+    i = skipLinkWhitespace(s, i, end)
+
+    val (dest, afterDest): (Text, Int) =
+      if i < end && s.charAt(i) != ')' then
+        parseLinkDestination(s, i, end) match
+          case Unset        => return Unset
+          case d: DestMatch => (d.dest, d.end)
+      else
+        (t"", i)
+
+    i = afterDest
+    val beforeWs = i
+    i = skipLinkWhitespace(s, i, end)
+
+    var title: Optional[Text] = Unset
+    if i > beforeWs && i < end then
+      parseLinkTitle(s, i, end) match
+        case t: TitleMatch =>
+          title = Text(t.title)
+          i = t.end
+
+        case Unset =>
+          // No title; rewind to before the inter-token whitespace
+          i = beforeWs
+
+    i = skipLinkWhitespace(s, i, end)
+    if i >= end || s.charAt(i) != ')' then return Unset
+    InlineLinkBody(dest, title, i + 1)
+
+  case class RefLabelMatch(label: Text, end: Int)
+
+  // Parse a reference link label `[label]` starting at the `[`. Returns the
+  // raw label text (or empty for `[]`) and the index past the closing `]`,
+  // or Unset if no valid label parses.
+  def parseRefLabel(s: String, start: Int, end: Int): Optional[RefLabelMatch] =
+    if start >= end || s.charAt(start) != '[' then return Unset
+    var i = start + 1
+    val labelStart = i
+    var done = false
+
+    while i < end && !done do
+      val c = s.charAt(i)
+      if c == ']' then done = true
+      else if c == '[' then return Unset
+      else if c == '\\' && i + 1 < end then i += 2
+      else i += 1
+
+    if !done then return Unset
+    val label = if i == labelStart then t"" else Text(s.substring(labelStart, i).nn)
+    RefLabelMatch(label, i + 1)
+
+  // Skip whitespace allowed in link bodies — spaces, tabs, and up to one
+  // newline (per CommonMark §6.6).
+  private def skipLinkWhitespace(s: String, start: Int, end: Int): Int =
+    var i = start
+    var newlines = 0
+    var done = false
+    while i < end && !done do
+      val c = s.charAt(i)
+      if c == ' ' || c == '\t' then i += 1
+      else if c == '\n' && newlines < 1 then
+        newlines += 1
+        i += 1
+      else
+        done = true
+    i

--- a/lib/punctuation/src/core/punctuation.LinkRefs.scala
+++ b/lib/punctuation/src/core/punctuation.LinkRefs.scala
@@ -32,46 +32,48 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import scala.collection.mutable
 
-import strategies.throwUnsafely
+import anticipation.*
 
-import doms.html.whatwg
-import classloaders.system
+// Accumulates link reference definitions discovered during the block-parse
+// pass; consulted by the inline-parse pass for shortcut/collapsed/full
+// reference links. Stage 4 will populate this from `[label]: dest "title"`
+// definitions in paragraphs; for now it stays empty.
+final class LinkRefs:
+  private val table: mutable.LinkedHashMap[Text, Markdown.LinkRef] =
+    mutable.LinkedHashMap()
 
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
+  // CommonMark normalisation: trim, collapse internal whitespace runs, then
+  // Unicode case-fold (approximated here by `toLowerCase` since the JDK's
+  // `String.toLowerCase` does Unicode case-folding for the BMP).
+  def normalize(label: Text): Text =
+    val s = label.s
+    val n = s.length
+    val builder = new StringBuilder
+    var i = 0
+    var inSpace = false
+    var trimmingLeft = true
+    while i < n do
+      val c = s.charAt(i)
+      if c == ' ' || c == '\t' || c == '\n' || c == '\r' then
+        if !trimmingLeft then inSpace = true
+      else
+        if inSpace then builder.append(' ')
+        builder.append(c)
+        inSpace = false
+        trimmingLeft = false
+      i += 1
+    Text(builder.toString.toLowerCase.nn)
 
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
+  // First definition wins (per CommonMark).
+  def add(ref: Markdown.LinkRef): Unit =
+    val key = normalize(ref.label)
+    if !table.contains(key) then table(key) = ref
 
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def lookup(label: Text): vacuous.Optional[Markdown.LinkRef] =
+    table.get(normalize(label)) match
+      case Some(ref) => ref
+      case None      => vacuous.Unset
 
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+  def all: List[Markdown.LinkRef] = table.values.to(List)

--- a/lib/punctuation/src/core/punctuation.Parser.scala
+++ b/lib/punctuation/src/core/punctuation.Parser.scala
@@ -32,46 +32,10 @@
                                                                                                   */
 package punctuation
 
-import soundness.*
+import anticipation.*
+import prepositional.*
 
-import strategies.throwUnsafely
-
-import doms.html.whatwg
-import classloaders.system
-
-object Tests extends Suite(m"Punctuation tests"):
-  def run(): Unit =
-    case class Testcase
-      ( markdown:   Text,
-        html:       Text,
-        example:    Int,
-        start_line: Int,
-        end_line:   Int,
-        section:    Text )
-
-    val testCases =
-      cp"/punctuation/mdspec.json"
-      . read[Json]
-      . as[List[Testcase]]
-      . groupBy(_.section)
-      . filter(_(0) != "HTML blocks")
-
-    suite(m"Java parser (commonmark-java)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Commonmark test case ${testcase.example}"):
-                  Commonmark.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
-
-    suite(m"Native parser (in-development)"):
-      testCases.each: (section, cases) =>
-        suite(section.communicate):
-          cases.each: testcase =>
-            safely(testcase.html.read[Html of whatwg.Flow]).let: html =>
-              if !Set(308, 309, 475, 598, 605)(testcase.example) then
-                test(m"Native test case ${testcase.example}"):
-                  Parser.parse(testcase.markdown).html.show
-                . assert(_ == html.show)
+// Public entry point for the native CommonMark parser. Mirrors `Commonmark.parse`
+// in shape so test and benchmark suites can swap implementations.
+object Parser:
+  def parse(text: Text): Markdown of Layout = BlockParser().parse(text)

--- a/lib/punctuation/src/core/punctuation.ParserSupport.scala
+++ b/lib/punctuation/src/core/punctuation.ParserSupport.scala
@@ -1,0 +1,239 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+import gossamer.*
+import vacuous.*
+
+object ParserSupport:
+
+  // CommonMark treats every horizontal-tab as advancing to the next 4-column
+  // boundary. For block-parser indent counting that's what `indentColumn`
+  // returns; for content stripping after a known indent we use `stripIndent`,
+  // which removes whole-tab-equivalent prefix correctly.
+
+  def isBlank(line: Text): Boolean =
+    val s = line.s
+    var i = 0
+    val n = s.length
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    i == n
+
+  // Number of leading-indent columns, expanding tabs to 4-column stops.
+  // Stops at the first non-space, non-tab character.
+  def indentColumn(line: Text): Int =
+    val s = line.s
+    var i = 0
+    var col = 0
+    val n = s.length
+    while i < n do
+      s.charAt(i) match
+        case ' ' =>
+          col += 1; i += 1
+
+        case '\t' =>
+          col += 4 - (col & 3); i += 1
+
+        case _ => return col
+
+    col
+
+  // Index (in chars) of the first non-space, non-tab char, or s.length.
+  def firstNonWhitespace(line: Text): Int =
+    val s = line.s
+    var i = 0
+    val n = s.length
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    i
+
+  // Strip trailing whitespace (spaces and tabs only — newlines aren't expected).
+  def stripTrailingSpaces(line: Text): Text =
+    val s = line.s
+    var i = s.length
+    while i > 0 && (s.charAt(i - 1) == ' ' || s.charAt(i - 1) == '\t') do i -= 1
+    if i == s.length then line else Text(s.substring(0, i).nn)
+
+  // ATX heading: ^ {0,3}#{1,6}( |\t|$).*?(#+)? *$
+  // Returns Some((level, content)) where content is the trimmed heading text.
+  // Optional trailing #s are stripped per the spec when surrounded by space.
+  def atxHeading(line: Text): Optional[(1 | 2 | 3 | 4 | 5 | 6, Text)] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    // up to 3 leading spaces
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 then return Unset
+    // 1-6 hashes
+    var hashes = 0
+    while i < n && s.charAt(i) == '#' && hashes < 7 do { i += 1; hashes += 1 }
+    if hashes < 1 || hashes > 6 then return Unset
+    // must be followed by space, tab, or end-of-line
+    if i < n && s.charAt(i) != ' ' && s.charAt(i) != '\t' then return Unset
+    // skip spaces/tabs after hashes
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    // strip trailing whitespace
+    var end = n
+    while end > i && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
+    // strip optional trailing #s if preceded by space (or whole line)
+    val origEnd = end
+    var hashEnd = end
+    while hashEnd > i && s.charAt(hashEnd - 1) == '#' do hashEnd -= 1
+    val hashesPrecededBySpace =
+      hashEnd == i || s.charAt(hashEnd - 1) == ' ' || s.charAt(hashEnd - 1) == '\t'
+
+    if hashEnd < origEnd && hashesPrecededBySpace then
+      end = hashEnd
+      while end > i && (s.charAt(end - 1) == ' ' || s.charAt(end - 1) == '\t') do end -= 1
+    val content = if end > i then Text(s.substring(i, end).nn) else t""
+    val level: 1 | 2 | 3 | 4 | 5 | 6 = (hashes: @unchecked) match
+      case 1 => 1; case 2 => 2; case 3 => 3; case 4 => 4; case 5 => 5; case 6 => 6
+    (level, content)
+
+  // Setext underline: ^ {0,3}(=+|-+) *$
+  // Returns Some(1) for `=`, Some(2) for `-`.
+  def setextUnderline(line: Text): Optional[1 | 2] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val ch = s.charAt(i)
+    if ch != '=' && ch != '-' then return Unset
+    var count = 0
+    while i < n && s.charAt(i) == ch do { i += 1; count += 1 }
+    if count < 1 then return Unset
+    while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+    if i < n then return Unset
+    if ch == '=' then 1 else 2
+
+  // Thematic break: ^ {0,3}([-*_])(\1| |\t)*\1\1.*$ where total non-space chars >= 3 of same
+  def isThematicBreak(line: Text): Boolean =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return false
+    val ch = s.charAt(i)
+    if ch != '-' && ch != '*' && ch != '_' then return false
+    var count = 0
+    while i < n do
+      val c = s.charAt(i)
+      if c == ch then count += 1
+      else if c != ' ' && c != '\t' then return false
+      i += 1
+    count >= 3
+
+  // Fence opener: ^ {0,3}(`{3,}|~{3,})(.*)$
+  // Backtick fences cannot contain backticks in info string.
+  // Returns Some((char, count, indent, info)).
+  def fenceOpener(line: Text): Optional[(Char, Int, Int, Text)] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val ch = s.charAt(i)
+    if ch != '`' && ch != '~' then return Unset
+    val fenceStart = i
+    while i < n && s.charAt(i) == ch do i += 1
+    val count = i - fenceStart
+    if count < 3 then return Unset
+    val infoStart = i
+    val info = Text(s.substring(infoStart, n).nn).trim
+    // Backtick fences cannot contain backticks in info string
+    if ch == '`' && info.s.indexOf('`') >= 0 then return Unset
+    (ch, count, indent, info)
+
+  // Fence closer: ^ {0,3}(`{minCount,}|~{minCount,}) *$
+  def isFenceCloser(line: Text, fenceChar: Char, minCount: Int): Boolean =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 then return false
+    val start = i
+    while i < n && s.charAt(i) == fenceChar do i += 1
+    val count = i - start
+    if count < minCount then return false
+    while i < n && s.charAt(i) == ' ' do i += 1
+    i == n
+
+  // Strip up to `n` columns of indent, expanding tabs as needed. Returns the
+  // remainder of the line. If the line has fewer than n columns of leading
+  // whitespace, the entire whitespace prefix is stripped and the rest returned.
+  def stripIndent(line: Text, n: Int): Text =
+    if n <= 0 then return line
+    val s = line.s
+    var i = 0
+    var col = 0
+    val len = s.length
+    while i < len && col < n do
+      s.charAt(i) match
+        case ' ' =>
+          col += 1; i += 1
+
+        case '\t' =>
+          val advance = 4 - (col & 3)
+          if col + advance <= n then { col += advance; i += 1 }
+          else
+            // Partial tab: replace with leftover spaces
+            val leftover = (col + advance) - n
+            val builder = new StringBuilder
+            var k = 0
+            while k < leftover do { builder.append(' '); k += 1 }
+            builder.append(s, i + 1, len)
+            return Text(builder.toString)
+
+        case _ =>
+          return Text(s.substring(i, len).nn)
+    if i == 0 then line else if i >= len then t"" else Text(s.substring(i, len).nn)
+
+  // Cut info string into whitespace-separated tokens (CommonMark spec).
+  def cutInfo(info: Text): List[Text] =
+    val s = info.s
+    val n = s.length
+    if n == 0 then return Nil
+    val result = scala.collection.mutable.ListBuffer[Text]()
+    var i = 0
+    while i < n do
+      while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
+      val start = i
+      while i < n && s.charAt(i) != ' ' && s.charAt(i) != '\t' do i += 1
+      if i > start then result += Text(s.substring(start, i).nn)
+    result.toList

--- a/lib/punctuation/src/core/punctuation.ParserSupport.scala
+++ b/lib/punctuation/src/core/punctuation.ParserSupport.scala
@@ -36,6 +36,15 @@ import anticipation.*
 import gossamer.*
 import vacuous.*
 
+case class BulletMarker(char: Char, markerIndent: Int, contentIndent: Int, rest: Text)
+
+case class OrderedMarker
+  ( start:         Int,
+    delimiter:     '.' | ')',
+    markerIndent:  Int,
+    contentIndent: Int,
+    rest:          Text )
+
 object ParserSupport:
 
   // CommonMark treats every horizontal-tab as advancing to the next 4-column
@@ -237,3 +246,98 @@ object ParserSupport:
       while i < n && s.charAt(i) != ' ' && s.charAt(i) != '\t' do i += 1
       if i > start then result += Text(s.substring(start, i).nn)
     result.toList
+
+  // Bullet list marker: ^ {0,3}([-*+])( +|\t|$)(.*)$
+  // Returns (marker char, marker indent, content indent, remainder).
+  // `contentIndent` is the column at which the item's content begins (used
+  // by `ListItemBuilder` to know how many columns to strip from continuation
+  // lines).
+  def bulletMarker(line: Text): Optional[BulletMarker] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val ch = s.charAt(i)
+    if ch != '-' && ch != '+' && ch != '*' then return Unset
+    val markerEnd = i + 1
+    // Must be followed by space, tab, or end-of-line
+    if markerEnd < n && s.charAt(markerEnd) != ' ' && s.charAt(markerEnd) != '\t' then return Unset
+    // Count post-marker whitespace columns (1..4); if 5+, treat as 1 (content
+    // becomes indented code) — caller handles that by not stripping past 1.
+    var j = markerEnd
+    var postCol = 0
+    while j < n && (s.charAt(j) == ' ' || s.charAt(j) == '\t') && postCol < 5 do
+      if s.charAt(j) == ' ' then postCol += 1
+      else postCol += 4 - ((indent + 1 + postCol) & 3)
+      j += 1
+
+    val followSpace =
+      if markerEnd >= n then 1
+      else if isBlank(Text(s.substring(markerEnd, n).nn)) then 1
+      else if postCol >= 5 then 1
+      else postCol
+
+    val contentStart =
+      markerEnd + (if markerEnd >= n then 0 else followSpace.min(n - markerEnd))
+
+    val contentIndent = indent + 1 + followSpace
+    val rest = if contentStart >= n then t"" else Text(s.substring(contentStart, n).nn)
+    BulletMarker(ch, indent, contentIndent, rest)
+
+  // Ordered list marker: ^ {0,3}(\d{1,9})([.)])( +|\t|$)(.*)$
+  def orderedMarker(line: Text): Optional[OrderedMarker] =
+    val s = line.s
+    val n = s.length
+    var i = 0
+    var indent = 0
+    while i < n && s.charAt(i) == ' ' && indent < 4 do { i += 1; indent += 1 }
+    if indent >= 4 || i >= n then return Unset
+    val digitStart = i
+    while i < n && s.charAt(i) >= '0' && s.charAt(i) <= '9' && (i - digitStart) < 9 do i += 1
+    val digitCount = i - digitStart
+    if digitCount < 1 then return Unset
+    if i >= n then return Unset
+    val delimChar = s.charAt(i)
+    if delimChar != '.' && delimChar != ')' then return Unset
+    val markerEnd = i + 1
+    if markerEnd < n && s.charAt(markerEnd) != ' ' && s.charAt(markerEnd) != '\t' then
+      return Unset
+    val start =
+      try Integer.parseInt(s.substring(digitStart, digitStart + digitCount))
+      catch case _: NumberFormatException => return Unset
+
+    var j = markerEnd
+    var postCol = 0
+    while j < n && (s.charAt(j) == ' ' || s.charAt(j) == '\t') && postCol < 5 do
+      if s.charAt(j) == ' ' then postCol += 1
+      else postCol += 4 - ((indent + digitCount + 1 + postCol) & 3)
+      j += 1
+
+    val followSpace =
+      if markerEnd >= n then 1
+      else if isBlank(Text(s.substring(markerEnd, n).nn)) then 1
+      else if postCol >= 5 then 1
+      else postCol
+
+    val contentStart =
+      markerEnd + (if markerEnd >= n then 0 else followSpace.min(n - markerEnd))
+
+    val contentIndent = indent + digitCount + 1 + followSpace
+    val rest = if contentStart >= n then t"" else Text(s.substring(contentStart, n).nn)
+    val delim: '.' | ')' = if delimChar == '.' then '.' else ')'
+    OrderedMarker(start, delim, indent, contentIndent, rest)
+
+  // Whether the line, ignoring leading 0..3 spaces, starts a new block
+  // (other than a paragraph). Used for lazy-paragraph-continuation: if a line
+  // doesn't start a new block, it can continue an open paragraph regardless
+  // of failed container continuation.
+  def startsNonParagraphBlock(line: Text): Boolean =
+    if isBlank(line) then return true
+    if isThematicBreak(line) then return true
+    if atxHeading(line).present then return true
+    if fenceOpener(line).present then return true
+    if bulletMarker(line).present then return true
+    if orderedMarker(line).present then return true
+    false

--- a/lib/punctuation/src/core/soundness_punctuation_core.scala
+++ b/lib/punctuation/src/core/soundness_punctuation_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export punctuation.{Commonmark, Formattable, Layout, Markdown, Prose, Translator}
+export punctuation.{Commonmark, Formattable, Layout, Markdown, Parser, Prose, Translator}


### PR DESCRIPTION
Adds the native `Parser.parse` to Punctuation's existing benchmark suite
alongside the Java-backed `Commonmark.parse`, with each fixture measured
against both parsers in side-by-side rows so Sedentary's `Bench` computes
the speedup ratio directly. Stage 8 of an 8-stage native CommonMark port,
with the caveat that the Java parser is intentionally retained (see body).

---

The benchmark suite now compares both parsers across all four fixtures:

```
mill punctuation.bench.run
```

Each suite contains a Java baseline row (with `Baseline(compare = Min)`)
and a Native row over the same fixture, so the comparison is direct.

```scala
import soundness.Parser
val markdown = Parser.parse(t"# Hello")
```

`Parser` is now exported from the soundness package.

**Java parser intentionally retained.** The original plan called for
dropping the `commonmark-java` mvn dependency at this stage, but the
native parser currently passes 381 of 578 CommonMark spec tests (~66%).
That's short of the 100% needed for a clean cutover — many spec
edge-cases around list indentation, link reference normalization,
multi-line link reference definitions, and emphasis flanking corners
remain. The Java parser stays as the production path until the native
parser reaches spec parity.

This PR depends on stages 1 (#997), 2 (#998), 3 (#999), 4 (#1000),
5 (#1001), 6 (#1002), and 7 (#1003).