### PR TITLE
Add ziggurat/etc/launch bootstrap snippet

### DIFF
--- a/lib/ziggurat/etc/launch
+++ b/lib/ziggurat/etc/launch
@@ -1,0 +1,4 @@
+openssl base64 -d <<EOF | sh -s -- URL HASH
+Zj1gbWt0ZW1wYDtjdXJsIC1zTG8gJGYgJDF8fHdnZXQgLXFPICRmICQxO2Nhc2UgYG9wZW5z
+c2wgZGdzdCAtc2hhMjU2ICRmYCBpbiAqJDIpY2htb2QgK3ggJGY7ZXhlYyAkZjtlc2Fj
+EOF


### PR DESCRIPTION
Adds `lib/ziggurat/etc/launch`, a tiny POSIX shell snippet that downloads a URL with `curl` (falling back to `wget`), verifies the file's SHA-256 against a user-supplied hash using `openssl dgst`, and execs the binary on a match. It is delivered base64-encoded inside a heredoc so the whole thing can be embedded in a short installer one-liner without losing portability between Linux and macOS.


### Ziggurat: download-and-launch snippet

A new file, `ziggurat/etc/launch`, provides a minimal bootstrap suitable for embedding in installer commands. It downloads a URL, verifies its SHA-256 hash, and executes the resulting file:

```sh
openssl base64 -d <<EOF | sh -s -- URL HASH
Zj1gbWt0ZW1wYDtjdXJsIC1zTG8gJGYgJDF8fHdnZXQgLXFPICRmICQxO2Nhc2UgYG9wZW5z
c2wgZGdzdCAtc2hhMjU2ICRmYCBpbiAqJDIpY2htb2QgK3ggJGY7ZXhlYyAkZjtlc2Fj
EOF
```

Replace `URL` and `HASH` with the resource location and its expected SHA-256. The snippet works on Linux and macOS; it is not intended for Windows. It tries `curl -sL` first and falls back to `wget -q` if `curl` is unavailable or fails. If the SHA-256 of the downloaded bytes does not match the supplied hash, nothing is executed.
