### PR TITLE
Add Beneficence and richer Frontier missing-given diagnostics

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -81,6 +81,9 @@ trait BaseScalaModule extends ScalaModule:
   override def scalacOptions = settings.scalaOptions
   def consoleScalacOptions = scalacOptions()
 
+  override def assemblyRules =
+    super.assemblyRules :+ mill.javalib.Assembly.Rule.AppendPattern("META-INF/givens/.*")
+
   def publishVersion = Task:
     try
       val lastTagged = os.proc("git", "rev-list", "--tags", "--max-count", "1").call().out.text().trim

--- a/build.mill
+++ b/build.mill
@@ -126,7 +126,9 @@ extends BaseScalaModule, SonatypeCentralPublishModule:
   override def moduleDeps = dependencies
 
   override def scalacOptions = Task:
-    settings.scalaOptions :+ s"-Xplugin:${decorum.plugin.assembly().path}"
+    settings.scalaOptions
+      :+ s"-Xplugin:${decorum.plugin.assembly().path}"
+      :+ s"-Xplugin:${beneficence.plugin.assembly().path}"
 
 trait Tests(dependencies: PublishModule*) extends BaseScalaModule:
   def moduleId: String = moduleDir.last

--- a/build.mill
+++ b/build.mill
@@ -621,7 +621,7 @@ object exoskeleton extends Library:
   object test extends Tests(rig)
 
 object frontier extends Library:
-  object core extends Component(dendrology.tree, escapade.core)
+  object core extends Component(dendrology.tree, escapade.core, beneficence.core)
   object test extends Tests(core, scintillate.servlet, jacinta.schema)
 
 object fulminate extends Library:

--- a/build.mill
+++ b/build.mill
@@ -207,6 +207,7 @@ object test extends ScalaModule:
     austronesian.test,
     aviation.test,
     baroque.test,
+    beneficence.test,
     bitumen.test,
     burdock.test,
     cacophony.test,
@@ -401,6 +402,12 @@ object aviation extends Library:
 object baroque extends Library:
   object core extends Component(quantitative.core, geodesy.core)
   object test extends Tests(core, abacist.core, quantitative.units, mosquito.core)
+
+object beneficence extends Library:
+  object core extends Component()
+  object plugin extends BareComponent():
+    def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+  object test extends Tests(core, plugin)
 
 object bitumen extends Library:
   object core extends Component(serpentine.core, turbulence.core)

--- a/build.mill
+++ b/build.mill
@@ -123,7 +123,7 @@ extends BaseScalaModule, SonatypeCentralPublishModule:
   def resources = Task.Sources(moduleDir / ".." / ".." / "res" / moduleId)
   def compileResources = Task.Sources(moduleDir / ".." / ".." / "res" / moduleId)
   def sources = Task.Sources(moduleDir)
-  override def moduleDeps = dependencies
+  override def moduleDeps = beneficence.core +: dependencies
 
   override def scalacOptions = Task:
     settings.scalaOptions
@@ -409,7 +409,7 @@ object baroque extends Library:
   object test extends Tests(core, abacist.core, quantitative.units, mosquito.core)
 
 object beneficence extends Library:
-  object core extends Component()
+  object core extends BareComponent()
   object plugin extends BareComponent():
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
   object test extends Tests(core, plugin)

--- a/lib/ambience/src/core/ambience.Environment.scala
+++ b/lib/ambience/src/core/ambience.Environment.scala
@@ -39,6 +39,7 @@ import contingency.*
 import proscenium.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Environment extends Dynamic:
   def apply[variable]
@@ -59,5 +60,5 @@ object Environment extends Dynamic:
     environment.variable(reader.defaultName).let(reader.read(_)).or:
       raise(EnvironmentError(reader.defaultName)) yet reader.read(Text(""))
 
-trait Environment:
+trait Environment extends Findable:
   def variable(name: Text): Optional[Text]

--- a/lib/ambience/src/core/ambience.System.scala
+++ b/lib/ambience/src/core/ambience.System.scala
@@ -37,6 +37,7 @@ import language.dynamics
 import anticipation.*
 import prepositional.*
 import vacuous.*
+import beneficence.*
 
 object System:
   object properties extends Dynamic:
@@ -49,5 +50,5 @@ object System:
 
     def selectDynamic(key: String): Property.Access[key.type] = Property.Access[key.type](key)
 
-trait System:
+trait System extends Findable:
   def apply(name: Text): Optional[Text]

--- a/lib/ambience/src/core/ambience.TemporaryDirectory.scala
+++ b/lib/ambience/src/core/ambience.TemporaryDirectory.scala
@@ -34,7 +34,8 @@ package ambience
 
 import anticipation.*
 import prepositional.*
+import beneficence.*
 
-trait TemporaryDirectory:
+trait TemporaryDirectory extends Findable:
   def directory(): Text
   def path[path: Instantiable across Paths from Text]: path = path(directory())

--- a/lib/ambience/src/core/ambience.WorkingDirectory.scala
+++ b/lib/ambience/src/core/ambience.WorkingDirectory.scala
@@ -34,10 +34,11 @@ package ambience
 
 import anticipation.*
 import prepositional.*
+import beneficence.*
 
 object WorkingDirectory:
   def apply[path: Abstractable across Paths to Text](path: path): WorkingDirectory =
     () => path.generic
 
-trait WorkingDirectory:
+trait WorkingDirectory extends Findable:
   def directory(): Text

--- a/lib/anamnesis/src/core/anamnesis.Database.scala
+++ b/lib/anamnesis/src/core/anamnesis.Database.scala
@@ -36,6 +36,7 @@ import contingency.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Database:
   sealed trait Relation[left, right]
@@ -44,7 +45,7 @@ object Database:
     val size = valueOf[Tuple.Size[relations]]
     new Database(size).asInstanceOf[Database of relations]
 
-class Database(size: Int):
+class Database(size: Int) extends Findable:
   import Database.Relation
 
   private var nextId: Int = 1

--- a/lib/anticipation/src/log/anticipation.Realm.scala
+++ b/lib/anticipation/src/log/anticipation.Realm.scala
@@ -34,4 +34,6 @@ package anticipation
 
 import language.experimental.into
 
-case class Realm(code: Text)
+import beneficence.*
+
+case class Realm(code: Text) extends Findable

--- a/lib/aviation/src/core/aviation.Calendar.scala
+++ b/lib/aviation/src/core/aviation.Calendar.scala
@@ -34,8 +34,9 @@ package aviation
 
 import anticipation.*
 import contingency.*
+import beneficence.*
 
-trait Calendar:
+trait Calendar extends Findable:
   type Diurnal
   type Mensual
   type Annual

--- a/lib/aviation/src/core/aviation.Chronology.scala
+++ b/lib/aviation/src/core/aviation.Chronology.scala
@@ -33,6 +33,7 @@
 package aviation
 
 import symbolism.*
+import beneficence.*
 
 object Chronology:
   enum AmbiguousTimes:
@@ -60,7 +61,7 @@ object Chronology:
 
       result
 
-open class Chronology[denomination]():
+open class Chronology[denomination]() extends Findable:
   def ambiguousTimes: Chronology.AmbiguousTimes = Chronology.AmbiguousTimes.Dilate
   def monthArithmetic: Chronology.MonthArithmetic = Chronology.MonthArithmetic.Scale
   def leapDayArithmetic: Chronology.LeapDayArithmetic = Chronology.LeapDayArithmetic.PreferFeb28

--- a/lib/aviation/src/core/aviation.Clock.scala
+++ b/lib/aviation/src/core/aviation.Clock.scala
@@ -37,6 +37,7 @@ import proscenium.*
 import symbolism.*
 
 import abstractables.instantIsAbstractable
+import beneficence.*
 
 object Clock:
   given current: Clock:
@@ -48,5 +49,5 @@ object Clock:
   def offset(diff: into[Duration]): Clock = new Clock():
     def apply(): Instant = Instant(System.currentTimeMillis) + diff
 
-abstract class Clock():
+abstract class Clock() extends Findable:
   def apply(): Instant

--- a/lib/aviation/src/core/aviation.Hebdomad.scala
+++ b/lib/aviation/src/core/aviation.Hebdomad.scala
@@ -33,8 +33,9 @@
 package aviation
 
 import denominative.*
+import beneficence.*
 
-trait Hebdomad:
+trait Hebdomad extends Findable:
   def start: Weekday
   def weekend(day: Weekday): Boolean
   def weekday(ordinal: Ordinal): Weekday = Weekday.fromOrdinal((start.ordinal + ordinal.n0)%7)

--- a/lib/aviation/src/core/aviation.Timezone.scala
+++ b/lib/aviation/src/core/aviation.Timezone.scala
@@ -42,6 +42,7 @@ import distillate.*
 import fulminate.*
 import prepositional.*
 import rudiments.*
+import beneficence.*
 
 object Timezone:
   private val ids: Set[Text] = ju.TimeZone.getAvailableIDs.nn.map(_.nn).map(Text(_)).to(Set)
@@ -60,5 +61,5 @@ object Timezone:
         import errorDiagnostics.empty
         throw InterpolationError(error.message)
 
-case class Timezone private(name: Text):
+case class Timezone private(name: Text) extends Findable:
   def stdlib: jt.ZoneId = jt.ZoneId.of(name.s).nn

--- a/lib/beneficence/res/plugin/plugin.properties
+++ b/lib/beneficence/res/plugin/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=beneficence.BeneficencePlugin

--- a/lib/beneficence/src/core/beneficence.Findable.scala
+++ b/lib/beneficence/src/core/beneficence.Findable.scala
@@ -30,24 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package vacuous
+package beneficence
 
-import scala.collection.immutable as sci
-
-import anticipation.*
-import beneficence.*
-
-object Default:
-  def apply[value](value: => value): Default[value] = () => value
-
-  given int: Default[Int] = () => 0
-  given singleton: [value: ValueOf] => Default[value] = () => valueOf[value]
-  given default: Default[Long] = () => 0L
-  given text: Default[Text] = () => "".tt
-  given string: Default[String] = () => ""
-  given list: [element] => Default[List[element]] = () => Nil
-  given set: [element] => Default[Set[element]] = () => Set()
-  given vector: [element] => Default[sci.Vector[element]] = () => sci.Vector()
-
-trait Default[+value] extends Findable:
-  def apply(): value
+trait Findable

--- a/lib/beneficence/src/core/beneficence.internal.scala
+++ b/lib/beneficence/src/core/beneficence.internal.scala
@@ -1,0 +1,81 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package beneficence
+
+import scala.io.{Codec, Source}
+import scala.jdk.CollectionConverters.*
+import scala.quoted.*
+
+object internal:
+  def givens(using quotes: Quotes)(typeRepr: quotes.reflect.TypeRepr)
+  :   List[quotes.reflect.Symbol] =
+
+    val classLoader = this.getClass.getClassLoader.nn
+
+    val classSymbol = typeRepr.dealias.classSymbol
+    if classSymbol.isEmpty then Nil
+    else
+      val typeclassFqn = classSymbol.get.fullName
+      val resourcePath = s"META-INF/givens/$typeclassFqn"
+
+      val urls = classLoader.getResources(resourcePath).nn.asScala.toList
+      val rawEntries: List[String] = urls.flatMap: url =>
+        val source = Source.fromURL(url)(using Codec.UTF8)
+        try source.getLines().toList.collect:
+          case line if !line.isBlank && !line.startsWith("#") => line.trim.nn
+        finally source.close()
+
+      rawEntries.distinct.flatMap(lookup)
+
+  private def lookup(fqn: String)(using quotes: Quotes): Option[quotes.reflect.Symbol] =
+    import quotes.reflect.Symbol
+
+    val lastDot = fqn.lastIndexOf('.')
+    if lastDot < 0 then None
+    else
+      val ownerFqn   = fqn.substring(0, lastDot).nn
+      val memberName = fqn.substring(lastDot + 1).nn
+
+      val owner: Option[Symbol] =
+        attempt(Symbol.requiredModule(ownerFqn))
+        . orElse(attempt(Symbol.requiredClass(ownerFqn)))
+
+      owner.flatMap: ownerSymbol =>
+        val methods = attempt(ownerSymbol.declaredMethod(memberName)).getOrElse(Nil)
+        if methods.nonEmpty then Some(methods.head)
+        else
+          val field = attempt(ownerSymbol.declaredField(memberName)).getOrElse(Symbol.noSymbol)
+          if field.exists then Some(field) else None
+
+  private def attempt[A](thunk: => A): Option[A] =
+    try Option(thunk) catch case _: Throwable => None

--- a/lib/beneficence/src/core/beneficence.internal.scala
+++ b/lib/beneficence/src/core/beneficence.internal.scala
@@ -63,8 +63,8 @@ object internal:
     val lastDot = fqn.lastIndexOf('.')
     if lastDot < 0 then None
     else
-      val ownerFqn   = fqn.substring(0, lastDot).nn
-      val memberName = fqn.substring(lastDot + 1).nn
+      val ownerFqn   = fqn.take(lastDot)
+      val memberName = fqn.drop(lastDot + 1)
 
       val owner: Option[Symbol] =
         attempt(Symbol.requiredModule(ownerFqn))

--- a/lib/beneficence/src/core/beneficence_core.scala
+++ b/lib/beneficence/src/core/beneficence_core.scala
@@ -1,0 +1,40 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package beneficence
+
+import scala.quoted.*
+
+def givens(using quotes: Quotes)(typeRepr: quotes.reflect.TypeRepr)
+:   List[quotes.reflect.Symbol] =
+
+  internal.givens(typeRepr)

--- a/lib/beneficence/src/core/soundness_beneficence_core.scala
+++ b/lib/beneficence/src/core/soundness_beneficence_core.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export beneficence.givens

--- a/lib/beneficence/src/core/soundness_beneficence_core.scala
+++ b/lib/beneficence/src/core/soundness_beneficence_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export beneficence.givens
+export beneficence.{Findable, givens}

--- a/lib/beneficence/src/plugin/beneficence.BeneficencePlugin.scala
+++ b/lib/beneficence/src/plugin/beneficence.BeneficencePlugin.scala
@@ -1,0 +1,43 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package beneficence
+
+import dotty.tools.dotc.*, core.*, Contexts.*, plugins.*
+
+class BeneficencePlugin() extends StandardPlugin:
+  val name: String = "beneficence"
+  override val description: String =
+    "records every given declaration into META-INF/givens/<typeclass>"
+
+  override def initialize(options: List[String])(using Context): List[PluginPhase] =
+    List(GivensPhase())

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -65,10 +65,26 @@ class GivensPhase() extends PluginPhase:
     val traverser = new tpd.TreeTraverser:
       def traverse(tree: tpd.Tree)(using Context): Unit =
         tree match
-          case d: tpd.ValDef if d.symbol.flags.is(Given) => record(d.symbol, d.tpt.tpe)
-          case d: tpd.DefDef if d.symbol.flags.is(Given) => record(d.symbol, d.tpt.tpe)
-          case _                                         => ()
+          case d: tpd.ValDef if eligible(d.symbol) => record(d.symbol, d.tpt.tpe)
+          case d: tpd.DefDef if eligible(d.symbol) => record(d.symbol, d.tpt.tpe)
+          case _                                   => ()
         traverseChildren(tree)
+
+      private def eligible(symbol: Symbols.Symbol)(using Context): Boolean =
+        symbol.flags.is(Given) && isStablyAccessible(symbol)
+
+      // A given is stably accessible if every enclosing scope on the path from
+      // the root is a package or a module (object). Givens nested inside a
+      // non-module class, a trait, a method body, or a refinement aren't usable
+      // via a plain `import` — listing them would just be noise.
+      private def isStablyAccessible(symbol: Symbols.Symbol)(using Context): Boolean =
+        var owner = symbol.owner
+        var stable = true
+        while stable && owner.exists && owner != Symbols.defn.RootClass do
+          if owner.is(Method) then stable = false
+          else if owner.isClass && !owner.is(Module) && !owner.is(Package) then stable = false
+          else owner = owner.owner
+        stable
 
       private def record(symbol: Symbols.Symbol, tpe: Types.Type)(using Context): Unit =
         val typeclassSymbol = typeclassOf(tpe, symbol)

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -73,9 +73,13 @@ class GivensPhase() extends PluginPhase:
       private def record(symbol: Symbols.Symbol, tpe: Types.Type)(using Context): Unit =
         val typeclassSymbol = tpe.dealias.classSymbol
         if typeclassSymbol.exists then
-          val typeclassFqn = typeclassSymbol.fullName.toString
-          val givenFqn     = symbol.fullName.toString
+          val typeclassFqn = sourcePath(typeclassSymbol)
+          val givenFqn     = sourcePath(symbol)
           val buffer       = collected.getOrElseUpdate(typeclassFqn, mutable.Buffer())
           buffer += Entry(givenFqn, sourceFile)
+
+      private def sourcePath(symbol: Symbols.Symbol)(using Context): String =
+        val raw: String = symbol.fullName.toString.replace("$.", ".").nn
+        if raw.endsWith("$") then raw.substring(0, raw.length - 1).nn else raw
 
     traverser.traverse(unit.tpdTree)

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -71,12 +71,34 @@ class GivensPhase() extends PluginPhase:
         traverseChildren(tree)
 
       private def record(symbol: Symbols.Symbol, tpe: Types.Type)(using Context): Unit =
-        val typeclassSymbol = tpe.dealias.classSymbol
+        val typeclassSymbol = typeclassOf(tpe, symbol)
         if typeclassSymbol.exists then
           val typeclassFqn = sourcePath(typeclassSymbol)
           val givenFqn     = sourcePath(symbol)
           val buffer       = collected.getOrElseUpdate(typeclassFqn, mutable.Buffer())
           buffer += Entry(givenFqn, sourceFile)
+
+      private def typeclassOf(tpe: Types.Type, valSymbol: Symbols.Symbol)(using Context)
+      :     Symbols.Symbol =
+
+        // For a "normal" given like `given foo: Show[Int] = ...` baseClasses leads with
+        // the typeclass class. For a modular `given X: T:` (with a refining body), the
+        // typer creates a synthesized class named after the val (a `module class X$`
+        // for value-style givens, or a plain `class X` for parameterised ones). In both
+        // shapes, stripping the trailing `$` from the class name and comparing with the
+        // val's name detects the synth class so we can skip past it to T.
+        val valName = valSymbol.name.toString
+
+        tpe.baseClasses.iterator.filter: cls =>
+          cls.exists
+          && cls != Symbols.defn.ObjectClass
+          && cls != Symbols.defn.AnyClass
+          && cls != Symbols.defn.MatchableClass
+          && stripDollar(cls.name.toString) != valName
+        .nextOption().getOrElse(tpe.dealias.classSymbol)
+
+      private def stripDollar(name: String): String =
+        if name.endsWith("$") then name.substring(0, name.length - 1).nn else name
 
       private def sourcePath(symbol: Symbols.Symbol)(using Context): String =
         val raw: String = symbol.fullName.toString.replace("$.", ".").nn

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -1,0 +1,81 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package beneficence
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.*, ast.tpd, core.*, Contexts.*, Flags.*, plugins.*
+
+class GivensPhase() extends PluginPhase:
+  val phaseName: String                = "beneficenceGivens"
+  override val runsAfter: Set[String]  = Set("typer")
+  override val runsBefore: Set[String] = Set("pickler")
+
+  override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
+    val collected: mutable.LinkedHashMap[String, mutable.Buffer[Entry]] =
+      mutable.LinkedHashMap.empty
+
+    val sources: mutable.LinkedHashSet[String] = mutable.LinkedHashSet.empty
+
+    units.foreach: unit =>
+      sources += unit.source.file.path
+      collectGivens(unit, collected)
+
+    GivensWriter.merge(collected, sources.toSet)
+    units
+
+  private def collectGivens
+                ( unit:      CompilationUnit,
+                  collected: mutable.LinkedHashMap[String, mutable.Buffer[Entry]] )
+                (using Context)
+  :     Unit =
+
+    val sourceFile = unit.source.file.path
+
+    val traverser = new tpd.TreeTraverser:
+      def traverse(tree: tpd.Tree)(using Context): Unit =
+        tree match
+          case d: tpd.ValDef if d.symbol.flags.is(Given) => record(d.symbol, d.tpt.tpe)
+          case d: tpd.DefDef if d.symbol.flags.is(Given) => record(d.symbol, d.tpt.tpe)
+          case _                                         => ()
+        traverseChildren(tree)
+
+      private def record(symbol: Symbols.Symbol, tpe: Types.Type)(using Context): Unit =
+        val typeclassSymbol = tpe.dealias.classSymbol
+        if typeclassSymbol.exists then
+          val typeclassFqn = typeclassSymbol.fullName.toString
+          val givenFqn     = symbol.fullName.toString
+          val buffer       = collected.getOrElseUpdate(typeclassFqn, mutable.Buffer())
+          buffer += Entry(givenFqn, sourceFile)
+
+    traverser.traverse(unit.tpdTree)

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -114,10 +114,9 @@ class GivensPhase() extends PluginPhase:
         .nextOption().getOrElse(tpe.dealias.classSymbol)
 
       private def stripDollar(name: String): String =
-        if name.endsWith("$") then name.substring(0, name.length - 1).nn else name
+        if name.endsWith("$") then name.dropRight(1) else name
 
       private def sourcePath(symbol: Symbols.Symbol)(using Context): String =
-        val raw: String = symbol.fullName.toString.replace("$.", ".").nn
-        if raw.endsWith("$") then raw.substring(0, raw.length - 1).nn else raw
+        stripDollar(symbol.fullName.toString.replace("$.", ".").nn)
 
     traverser.traverse(unit.tpdTree)

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -42,21 +42,28 @@ class GivensPhase() extends PluginPhase:
   override val runsBefore: Set[String] = Set("pickler")
 
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
-    val collected: mutable.LinkedHashMap[String, mutable.Buffer[Entry]] =
-      mutable.LinkedHashMap.empty
+    val findable = Symbols.requiredClassRef("beneficence.Findable").classSymbol
 
-    val sources: mutable.LinkedHashSet[String] = mutable.LinkedHashSet.empty
+    // If `beneficence.Findable` isn't on this compilation's classpath there's
+    // nothing the plugin can usefully record — every given would be filtered.
+    if !findable.exists then units
+    else
+      val collected: mutable.LinkedHashMap[String, mutable.Buffer[Entry]] =
+        mutable.LinkedHashMap.empty
 
-    units.foreach: unit =>
-      sources += unit.source.file.path
-      collectGivens(unit, collected)
+      val sources: mutable.LinkedHashSet[String] = mutable.LinkedHashSet.empty
 
-    GivensWriter.merge(collected, sources.toSet)
-    units
+      units.foreach: unit =>
+        sources += unit.source.file.path
+        collectGivens(unit, collected, findable)
+
+      GivensWriter.merge(collected, sources.toSet)
+      units
 
   private def collectGivens
                 ( unit:      CompilationUnit,
-                  collected: mutable.LinkedHashMap[String, mutable.Buffer[Entry]] )
+                  collected: mutable.LinkedHashMap[String, mutable.Buffer[Entry]],
+                  findable:  Symbols.Symbol )
                 (using Context)
   :     Unit =
 
@@ -65,13 +72,15 @@ class GivensPhase() extends PluginPhase:
     val traverser = new tpd.TreeTraverser:
       def traverse(tree: tpd.Tree)(using Context): Unit =
         tree match
-          case d: tpd.ValDef if eligible(d.symbol) => record(d.symbol, d.tpt.tpe)
-          case d: tpd.DefDef if eligible(d.symbol) => record(d.symbol, d.tpt.tpe)
-          case _                                   => ()
+          case d: tpd.ValDef if eligible(d.symbol, d.tpt.tpe) => record(d.symbol, d.tpt.tpe)
+          case d: tpd.DefDef if eligible(d.symbol, d.tpt.tpe) => record(d.symbol, d.tpt.tpe)
+          case _                                              => ()
         traverseChildren(tree)
 
-      private def eligible(symbol: Symbols.Symbol)(using Context): Boolean =
-        symbol.flags.is(Given) && isStablyAccessible(symbol)
+      private def eligible(symbol: Symbols.Symbol, tpe: Types.Type)(using Context): Boolean =
+        symbol.flags.is(Given)
+        && isStablyAccessible(symbol)
+        && tpe.baseClasses.contains(findable)
 
       // A given is stably accessible if every enclosing scope on the path from
       // the root is a package or a module (object). Givens nested inside a

--- a/lib/beneficence/src/plugin/beneficence.GivensWriter.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensWriter.scala
@@ -1,0 +1,130 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package beneficence
+
+import java.io.{BufferedReader, BufferedWriter, File, FileInputStream, FileOutputStream,
+    InputStreamReader, OutputStreamWriter}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, StandardCopyOption}
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.core.Contexts.*
+
+case class Entry(givenFqn: String, sourceFile: String)
+
+object GivensWriter:
+  private val SourcePrefix = "# source: "
+
+  def merge
+        ( collected:         mutable.LinkedHashMap[String, mutable.Buffer[Entry]],
+          recompiledSources: Set[String] )
+        (using Context)
+  :     Unit =
+
+    val outputDir = ctx.settings.outputDir.value
+    val outputRoot: File | Null = outputDir.file
+    if outputRoot == null then return  // JAR output: skip; future work to support
+
+    val givensDir = new File(new File(outputRoot, "META-INF"), "givens")
+    if !givensDir.exists then givensDir.mkdirs(): @annotation.nowarn
+
+    collected.foreach: (typeclassFqn, entries) =>
+      val target  = new File(givensDir, typeclassFqn)
+      val current = if target.exists then read(target) else Map.empty[String, List[String]]
+      val pruned  = current.filterNot((source, _) => recompiledSources.contains(source))
+
+      val merged: List[(String, List[String])] =
+        val byNew: Map[String, List[String]] =
+          entries.groupBy(_.sourceFile).view.mapValues(_.map(_.givenFqn).distinct.toList).toMap
+
+        val keptOrder: List[String] = pruned.keys.toList
+        val newOrder: List[String]  = byNew.keys.toList.filterNot(pruned.contains)
+
+        (keptOrder ++ newOrder).map: source =>
+          source -> pruned.getOrElse(source, byNew.getOrElse(source, Nil))
+
+      write(target, merged)
+
+  private def read(file: File): Map[String, List[String]] =
+    val builder = mutable.LinkedHashMap.empty[String, mutable.ListBuffer[String]]
+    var currentSource: String | Null = null
+
+    val reader = new BufferedReader
+                       (new InputStreamReader
+                              (new FileInputStream(file), StandardCharsets.UTF_8))
+    try
+      var line: String | Null = reader.readLine()
+      while line != null do
+        val l: String = line.trim.nn
+        if l.startsWith(SourcePrefix) then
+          val source = l.substring(SourcePrefix.length).nn.trim.nn
+          currentSource = source
+          builder.getOrElseUpdate(source, mutable.ListBuffer())
+        else if l.isEmpty || l.startsWith("#") then
+          ()
+        else
+          val src = currentSource
+          if src != null then builder.getOrElseUpdate(src, mutable.ListBuffer()) += l
+        line = reader.readLine()
+    finally reader.close()
+
+    builder.view.mapValues(_.toList).toMap
+
+  private def write(file: File, blocks: List[(String, List[String])]): Unit =
+    val parent = file.getParentFile
+    if parent != null && !parent.exists then parent.mkdirs(): @annotation.nowarn
+
+    val tmp = new File(file.getParentFile, file.getName.nn + ".tmp")
+    val writer = new BufferedWriter
+                       (new OutputStreamWriter
+                              (new FileOutputStream(tmp), StandardCharsets.UTF_8))
+    try
+      var first = true
+      blocks.foreach: (source, givens) =>
+        if givens.nonEmpty then
+          if !first then writer.newLine()
+          writer.write(SourcePrefix + source)
+          writer.newLine()
+          givens.foreach: fqn =>
+            writer.write(fqn)
+            writer.newLine()
+          first = false
+    finally writer.close()
+
+    Files.move
+     ( tmp.toPath,
+       file.toPath,
+       StandardCopyOption.REPLACE_EXISTING,
+       StandardCopyOption.ATOMIC_MOVE )
+    ()

--- a/lib/beneficence/src/plugin/soundness_beneficence_plugin.scala
+++ b/lib/beneficence/src/plugin/soundness_beneficence_plugin.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export beneficence.{BeneficencePlugin, GivensPhase}

--- a/lib/beneficence/src/test/beneficence_test.scala
+++ b/lib/beneficence/src/test/beneficence_test.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package beneficence
+
+import soundness.*
+
+object Tests extends Suite(m"Beneficence Tests"):
+  def run(): Unit = ()

--- a/lib/caduceus/src/core/caduceus.Courier.scala
+++ b/lib/caduceus/src/core/caduceus.Courier.scala
@@ -34,6 +34,7 @@ package caduceus
 
 import prepositional.*
 import turbulence.*
+import beneficence.*
 
-trait Courier extends Resultant:
+trait Courier extends Resultant, Findable:
   def send(message: Document[Email]): Result

--- a/lib/capricious/src/core/capricious.Random.scala
+++ b/lib/capricious/src/core/capricious.Random.scala
@@ -35,6 +35,7 @@ package capricious
 import language.experimental.genericNumberLiterals
 
 import scala.util as su
+import beneficence.*
 
 object Random:
   lazy val global: Random = new Random(randomization.unseeded.initialize())
@@ -42,7 +43,7 @@ object Random:
   def apply(seed: Seed)(using randomization: Randomization): Random =
     new Random(randomization.initialize())
 
-class Random(private val generator: su.Random):
+class Random(private val generator: su.Random) extends Findable:
   def long(): Long = generator.nextLong()
   def gaussian(): Double = generator.nextGaussian()
   def unitInterval(): Double = generator.nextDouble()

--- a/lib/capricious/src/core/capricious.Randomization.scala
+++ b/lib/capricious/src/core/capricious.Randomization.scala
@@ -35,6 +35,7 @@ package capricious
 import language.experimental.genericNumberLiterals
 
 import scala.util as su
+import beneficence.*
 
-trait Randomization:
+trait Randomization extends Findable:
   def initialize(): su.Random

--- a/lib/contingency/src/core/contingency.Foci.scala
+++ b/lib/contingency/src/core/contingency.Foci.scala
@@ -37,6 +37,7 @@ import scala.collection.mutable as scm
 import proscenium.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Foci:
   given default: [focus] => Foci[focus]:
@@ -53,7 +54,7 @@ object Foci:
 
     def supplement(count: Int, transform: Optional[focus] => focus): Unit = ()
 
-trait Foci[focus]:
+trait Foci[focus] extends Findable:
   def length: Int
   def success: Boolean
   def register(error: Exception): Unit

--- a/lib/contingency/src/core/contingency.Tactic.scala
+++ b/lib/contingency/src/core/contingency.Tactic.scala
@@ -35,8 +35,9 @@ package contingency
 import language.experimental.pureFunctions
 
 import fulminate.*
+import beneficence.*
 
-trait Tactic[-error <: Exception]:
+trait Tactic[-error <: Exception] extends Findable:
   private inline def tactic: this.type = this
   def diagnostics: Diagnostics
   def record(error: Diagnostics ?=> error): Unit

--- a/lib/cosmopolite/src/core/cosmopolite.Locale.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.Locale.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import distillate.*
 import gossamer.*
 import prepositional.*
+import beneficence.*
 
 object Locale:
   given encodable: [language] => Locale[language] is Encodable in Text = _.language.code
@@ -44,4 +45,4 @@ object Locale:
     case t"pl" => Locale(pl)
     case _     => Locale(en)
 
-case class Locale[-language](language: Language)
+case class Locale[-language](language: Language) extends Findable

--- a/lib/dendrology/src/dag/dendrology.DagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.DagStyle.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package dendrology
 
-trait DagStyle[line]:
+import beneficence.*
+
+trait DagStyle[line] extends Findable:
   def serialize(tiles: List[DagTile], node: line): line

--- a/lib/dendrology/src/tree/dendrology.TreeStyle.scala
+++ b/lib/dendrology/src/tree/dendrology.TreeStyle.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package dendrology
 
-trait TreeStyle[line]:
+import beneficence.*
+
+trait TreeStyle[line] extends Findable:
   def serialize(tiles: List[TreeTile], node: line): line

--- a/lib/digression/src/core/digression.Codepoint.scala
+++ b/lib/digression/src/core/digression.Codepoint.scala
@@ -37,6 +37,7 @@ import language.experimental.pureFunctions
 import java.util.concurrent as juc
 
 import anticipation.*
+import beneficence.*
 
 object Codepoint:
   inline given default: Codepoint = ${digression.internal.location}
@@ -44,5 +45,5 @@ object Codepoint:
   private[digression] val idempotentActions: juc.ConcurrentHashMap[Codepoint, Unit] =
     juc.ConcurrentHashMap()
 
-case class Codepoint(source: Text, line: Int):
+case class Codepoint(source: Text, line: Int) extends Findable:
   def text: Text = Text(s"${source.s.split("/").nn.last}:$line")

--- a/lib/escapade/src/core/escapade.TerminalEscapes.scala
+++ b/lib/escapade/src/core/escapade.TerminalEscapes.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 import spectacular.*
+import beneficence.*
 
 object escapes:
   object foreground:
@@ -93,7 +94,7 @@ object escapes:
   def link[url: Abstractable across Urls to Text](url: url, text: Text): Text =
     t"\e]8;;${url.generic}\e\\$text\e]8;;\e\\"
 
-trait TerminalEscapes:
+trait TerminalEscapes extends Findable:
   def bold(state: Boolean): Text
   def italic(state: Boolean): Text
   def underline(state: Boolean): Text

--- a/lib/escritoire/src/core/escritoire.Attenuation.scala
+++ b/lib/escritoire/src/core/escritoire.Attenuation.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package escritoire
 
-trait Attenuation:
+import beneficence.*
+
+trait Attenuation extends Findable:
   def apply(minimumWidth: Int, availableWidth: Int): Unit

--- a/lib/escritoire/src/core/escritoire.ColumnAlignment.scala
+++ b/lib/escritoire/src/core/escritoire.ColumnAlignment.scala
@@ -33,6 +33,7 @@
 package escritoire
 
 import anticipation.*
+import beneficence.*
 
 object ColumnAlignment:
   val topLeft: ColumnAlignment[Any] = ColumnAlignment(TextAlignment.Left, VerticalAlignment.Top)
@@ -43,4 +44,4 @@ object ColumnAlignment:
   given long: ColumnAlignment[Long] = ColumnAlignment(TextAlignment.Right, VerticalAlignment.Top)
   given text: ColumnAlignment[Text] = ColumnAlignment(TextAlignment.Left, VerticalAlignment.Top)
 
-case class ColumnAlignment[-column](text: TextAlignment, vertical: VerticalAlignment)
+case class ColumnAlignment[-column](text: TextAlignment, vertical: VerticalAlignment) extends Findable

--- a/lib/exoskeleton/src/args/exoskeleton.Interpreter.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Interpreter.scala
@@ -32,9 +32,10 @@
                                                                                                   */
 package exoskeleton
 
+import beneficence.*
 import vacuous.*
 
-trait Interpreter:
+trait Interpreter extends Findable:
   type Topic
 
   def interpret(arguments: List[Argument]): Topic

--- a/lib/exoskeleton/src/core/exoskeleton.Entrypoint.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Entrypoint.scala
@@ -35,7 +35,8 @@ package exoskeleton
 import anticipation.*
 import prepositional.*
 import serpentine.*
+import beneficence.*
 
-trait Entrypoint:
+trait Entrypoint extends Findable:
   def script: Text
   def executable: Path on Local

--- a/lib/exoskeleton/src/core/exoskeleton.Executive.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Executive.scala
@@ -36,8 +36,9 @@ import ambience.*
 import anticipation.*
 import rudiments.*
 import turbulence.*
+import beneficence.*
 
-trait Executive:
+trait Executive extends Findable:
   type Return
   type Interface <: Cli
 

--- a/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
@@ -136,6 +136,7 @@ object Tmux:
 
 case class TmuxError()(using Diagnostics) extends Error(realm"ek", 2, 0)(m"can't execute tmux")
 case class Tmux(id: Text, workingDirectory: WorkingDirectory, width: Int, height: Int, shell: Shell)
+extends Findable
 
 case class Screenshot(screen: IArray[Text], size: (Int, Int), cursor: (Ordinal, Ordinal)):
   def apply(): Text = screen.join("\n")

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -91,16 +91,69 @@ object internal:
       case quotes: runtime.impl.QuotesImpl => quotes.ctx
 
     case class Candidate(name: Text, missing: List[Result]) extends Result
-    case class Available(name: Text) extends Result
+    case class Available(name: Text, requirements: List[Missing]) extends Result
 
     case class Missing(name: Text, available: List[Available], candidates: List[Candidate])
     extends Result
 
     case class Found(name: Text, expr: Expr[Any]) extends Result
 
-    def availableFor(repr: TypeRepr): List[Available] =
-      beneficence.givens(repr).map: symbol =>
-        Available(displayName(symbol.fullName).tt)
+    val initialGas = 3
+
+    def availableFor(repr: TypeRepr, exclusions: List[Symbol], gas: Int): List[Available] =
+      beneficence.givens(repr)
+      . filterNot(exclusions.contains)
+      . filter(conforms(_, repr))
+      . map: symbol =>
+          val requirements =
+            if gas <= 0 then Nil
+            else usingTypes(symbol).map: paramType =>
+              val nextAvailable = availableFor(paramType, symbol :: exclusions, gas - 1)
+              Missing(stenography.internal.name(paramType), nextAvailable, Nil)
+          Available(displayName(symbol.fullName).tt, requirements)
+
+    def conforms(symbol: Symbol, target: TypeRepr): Boolean =
+      // Strip PolyType / MethodType wrappers to get the value type a successful
+      // application would produce.
+      def resultOf(t: TypeRepr): TypeRepr = t match
+        case PolyType(_, _, body)   => resultOf(body)
+        case MethodType(_, _, body) => resultOf(body)
+        case _                      => t
+
+      val resultType = resultOf(symbol.info)
+
+      // For non-polymorphic givens, a direct subtype check is precise.
+      if resultType <:< target then true
+      else
+        // For polymorphic givens, the result type contains type variables that
+        // would be instantiated at the call site; we accept if the result type
+        // and the target share the same type constructor and arity. Stricter
+        // unification is left for later refinement.
+        symbol.info match
+          case _: PolyType =>
+            (resultType.dealias, target.dealias) match
+              case (AppliedType(rTycon, rArgs), AppliedType(tTycon, tArgs)) =>
+                rTycon.dealias.classSymbol == tTycon.dealias.classSymbol
+                && rArgs.length == tArgs.length
+              case _ =>
+                resultType.dealias.classSymbol == target.dealias.classSymbol
+          case _ =>
+            false
+
+    def usingTypes(symbol: Symbol): List[TypeRepr] =
+      symbol.tree.absolve match
+        case d: DefDef =>
+          d.paramss.flatMap:
+            case TermParamClause(params) =>
+              if params.headOption.exists(_.symbol.flags.is(Flags.Given))
+              then params.map(_.tpt.tpe)
+              else Nil
+
+            case _ =>
+              Nil
+
+        case _ =>
+          Nil
 
     def displayName(fqn: String): String =
       fqn.split('.').iterator.filterNot: segment =>
@@ -109,7 +162,7 @@ object internal:
       .mkString(".")
 
     def missing(repr: TypeRepr, candidates: List[Candidate]): Missing =
-      Missing(stenography.internal.name(repr), availableFor(repr), candidates)
+      Missing(stenography.internal.name(repr), availableFor(repr, Nil, initialGas), candidates)
 
     def seek(repr: TypeRepr, exclusions: List[Symbol], depth: Int): Result =
       Implicits.searchIgnoring(repr)(self :: exclusions*).absolve match
@@ -169,8 +222,8 @@ object internal:
           given Result is Expandable =
             case Candidate(_, missing)             => missing
             case Missing(_, available, candidates) => available ::: candidates
+            case Available(_, requirements)        => requirements
             case Found(_, _)                       => Nil
-            case Available(_)                      => Nil
 
           TreeDiagram[Result]((available ::: candidates)*).render:
             case Found(name, _) =>
@@ -182,7 +235,7 @@ object internal:
             case Candidate(name, _) =>
               e" \e[38;5;208m$Bold(▪)\e[0m candidate \e[38;5;227m$Italic($name)\e[0m"
 
-            case Available(name) =>
+            case Available(name, _) =>
               e" \e[38;5;75m$Bold(▸)\e[0m propose \e[38;5;117m$Italic($name)\e[0m"
 
           . join

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -106,16 +106,58 @@ object internal:
       case _                      => t
 
     def availableFor(repr: TypeRepr, exclusions: List[Symbol], gas: Int): List[Available] =
-      beneficence.givens(repr)
-      . filterNot(exclusions.contains)
-      . filter(conforms(_, repr))
-      . map: symbol =>
-          val requirements =
-            if gas <= 0 then Nil
-            else usingTypesInstantiated(symbol, repr).map: paramType =>
-              val nextAvailable = availableFor(paramType, symbol :: exclusions, gas - 1)
-              Missing(stenography.internal.name(paramType), nextAvailable, Nil)
-          Available(displayName(symbol.fullName).tt, requirements)
+      val candidates =
+        beneficence.givens(repr)
+        . filterNot(exclusions.contains)
+        . filter(conforms(_, repr))
+
+      dedupeExports(candidates).map: symbol =>
+        val requirements =
+          if gas <= 0 then Nil
+          else usingTypesInstantiated(symbol, repr).map: paramType =>
+            val nextAvailable = availableFor(paramType, symbol :: exclusions, gas - 1)
+            Missing(stenography.internal.name(paramType), nextAvailable, Nil)
+        Available(renderSymbol(symbol), requirements)
+
+    // A symbol introduced via `export X.y` carries the `Exported` flag and its
+    // tree's body forwards to the original. Walk through forwarders to find
+    // the canonical (non-exported) symbol that ultimately backs it.
+    def canonical(symbol: Symbol): Symbol =
+      if !symbol.flags.is(Flags.Exported) then symbol
+      else
+        val target = symbol.tree.absolve match
+          case d: DefDef => d.rhs.fold(Symbol.noSymbol)(underlyingSymbol)
+          case _         => Symbol.noSymbol
+
+        if target.exists && target != symbol then canonical(target) else symbol
+
+    def underlyingSymbol(tree: Term): Symbol = tree match
+      case Apply(fun, _)     => underlyingSymbol(fun)
+      case TypeApply(fun, _) => underlyingSymbol(fun)
+      case Inlined(_, _, b)  => underlyingSymbol(b)
+      case Block(_, expr)    => underlyingSymbol(expr)
+      case Typed(expr, _)    => underlyingSymbol(expr)
+      case _                 => tree.symbol
+
+    // Several classpath givens can be exports/re-exports of the same canonical
+    // definition. Group by canonical symbol and keep only the one whose
+    // stenography rendering is shortest (i.e. the most readable in the current
+    // import scope).
+    def dedupeExports(symbols: List[Symbol]): List[Symbol] =
+      symbols.groupBy(canonical).values.toList.map: group =>
+        group.minBy(s => renderSymbol(s).s.length)
+
+    // Render a symbol's path via Stenography (so import-scope abbreviations
+    // apply). Strip the trailing `.type` that comes from rendering a singleton
+    // TermRef, and the synthetic `<filename>$package` segments Scala 3 inserts
+    // for top-level definitions.
+    def renderSymbol(symbol: Symbol): Text =
+      val raw = stenography.internal.name(symbol.termRef).s
+      val noType = if raw.endsWith(".type") then raw.substring(0, raw.length - 5).nn else raw
+      noType.split('.').iterator.filterNot: segment =>
+        val stripped = if segment.endsWith("$") then segment.dropRight(1).nn else segment
+        stripped.endsWith("$package")
+      .mkString(".").tt
 
     def conforms(symbol: Symbol, target: TypeRepr): Boolean =
       val resultType = resultOf(symbol.info)
@@ -186,12 +228,6 @@ object internal:
 
         case _ =>
           Nil
-
-    def displayName(fqn: String): String =
-      fqn.split('.').iterator.filterNot: segment =>
-        val stripped = if segment.endsWith("$") then segment.dropRight(1) else segment
-        stripped.endsWith("$package")
-      .mkString(".")
 
     def missing(repr: TypeRepr, candidates: List[Candidate]): Missing =
       Missing(stenography.internal.name(repr), availableFor(repr, Nil, initialGas), candidates)

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -91,8 +91,25 @@ object internal:
       case quotes: runtime.impl.QuotesImpl => quotes.ctx
 
     case class Candidate(name: Text, missing: List[Result]) extends Result
-    case class Missing(name: Text, candidates: List[Candidate]) extends Result
+    case class Available(name: Text) extends Result
+
+    case class Missing(name: Text, available: List[Available], candidates: List[Candidate])
+    extends Result
+
     case class Found(name: Text, expr: Expr[Any]) extends Result
+
+    def availableFor(repr: TypeRepr): List[Available] =
+      beneficence.givens(repr).map: symbol =>
+        Available(displayName(symbol.fullName).tt)
+
+    def displayName(fqn: String): String =
+      fqn.split('.').iterator.filterNot: segment =>
+        val stripped = if segment.endsWith("$") then segment.dropRight(1) else segment
+        stripped.endsWith("$package")
+      .mkString(".")
+
+    def missing(repr: TypeRepr, candidates: List[Candidate]): Missing =
+      Missing(stenography.internal.name(repr), availableFor(repr), candidates)
 
     def seek(repr: TypeRepr, exclusions: List[Symbol], depth: Int): Result =
       Implicits.searchIgnoring(repr)(self :: exclusions*).absolve match
@@ -102,22 +119,22 @@ object internal:
         case failure: ImplicitSearchFailure =>
           failure match
             case _: dotty.tools.dotc.ast.untpd.SearchFailureIdent =>
-              Missing(stenography.internal.name(repr), Nil)
+              missing(repr, Nil)
 
             case SafeInlined(call, bindings, body) => call match
               case None =>
-                Missing(stenography.internal.name(repr), Nil)
+                missing(repr, Nil)
 
               case Some(term) => term match
                 case TypeApply(left, right) =>
                   if term.symbol.name == "explainMissingContext"
-                  then Missing(stenography.internal.name(repr), Nil)
+                  then missing(repr, Nil)
                   else
                     Candidate
                       ( "???", List(seek(right.head.tpe, term.symbol :: exclusions, depth + 1)) )
 
                 case _ =>
-                  Missing(stenography.internal.name(repr), Nil)
+                  missing(repr, Nil)
 
 
             case apply: Apply @unchecked => apply match case Apply(function, arguments) =>
@@ -130,39 +147,43 @@ object internal:
                   val candidate = Candidate(name, types.map(seek(_, Nil, depth + 1)))
 
                   val candidates = seek(repr, function.symbol :: exclusions, depth) match
-                    case Missing(_, candidates) => candidate :: candidates
-                    case _                      => Nil
+                    case Missing(_, _, candidates) => candidate :: candidates
+                    case _                         => Nil
 
-                  Missing(stenography.internal.name(repr), candidates)
+                  missing(repr, candidates)
 
                 case _ =>
-                  Missing(stenography.internal.name(repr), Nil)
+                  missing(repr, Nil)
 
               resolve(function.symbol.info)
 
             case _ =>
-              Missing(stenography.internal.name(repr), Nil)
+              missing(repr, Nil)
 
 
     seek(TypeRepr.of[target], Nil, 1).absolve match
       case Found(_, expr) => expr.asExprOf[target]
 
-      case Missing(_, results) =>
+      case Missing(_, available, candidates) =>
         report.errorAndAbort:
           given Result is Expandable =
-            case Candidate(_, missing)  => missing
-            case Missing(_, candidates) => candidates
-            case Found(_, _)            => Nil
+            case Candidate(_, missing)             => missing
+            case Missing(_, available, candidates) => available ::: candidates
+            case Found(_, _)                       => Nil
+            case Available(_)                      => Nil
 
-          TreeDiagram[Result](results*).render:
+          TreeDiagram[Result]((available ::: candidates)*).render:
             case Found(name, _) =>
               e" \e[38;5;34m$Bold(✓)\e[0m found \e[38;5;119m$Italic($name)\e[0m"
 
-            case Missing(name, _) =>
+            case Missing(name, _, _) =>
               e" \e[38;5;88m$Bold(✗)\e[0m requires \e[38;5;114m$Italic($name)\e[0m"
 
             case Candidate(name, _) =>
               e" \e[38;5;208m$Bold(▪)\e[0m candidate \e[38;5;227m$Italic($name)\e[0m"
+
+            case Available(name) =>
+              e" \e[38;5;75m$Bold(▸)\e[0m propose \e[38;5;117m$Italic($name)\e[0m"
 
           . join
               ( e"contextual value not found\n\n \e[38;5;88m$Bold(■)\e[0m resolving "

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -105,19 +105,24 @@ object internal:
       case MethodType(_, _, body) => resultOf(body)
       case _                      => t
 
+    case class Matched
+                ( symbol:     Symbol,
+                  typeParams: List[Symbol],
+                  bindings:   Map[Symbol, TypeRepr] )
+
     def availableFor(repr: TypeRepr, exclusions: List[Symbol], gas: Int): List[Available] =
-      val candidates =
+      val matched =
         beneficence.givens(repr)
         . filterNot(exclusions.contains)
-        . filter(conforms(_, repr))
+        . flatMap(matchAgainst(_, repr))
 
-      dedupeExports(candidates).map: symbol =>
+      dedupeExportsByCanonical(matched).map: m =>
         val requirements =
           if gas <= 0 then Nil
-          else usingTypesInstantiated(symbol, repr).map: paramType =>
-            val nextAvailable = availableFor(paramType, symbol :: exclusions, gas - 1)
+          else usingTypesInstantiated(m).map: paramType =>
+            val nextAvailable = availableFor(paramType, m.symbol :: exclusions, gas - 1)
             Missing(stenography.internal.name(paramType), nextAvailable, Nil)
-        Available(renderSymbol(symbol), requirements)
+        Available(formatProposal(m), requirements)
 
     // A symbol introduced via `export X.y` carries the `Exported` flag and its
     // tree's body forwards to the original. Walk through forwarders to find
@@ -143,9 +148,22 @@ object internal:
     // definition. Group by canonical symbol and keep only the one whose
     // stenography rendering is shortest (i.e. the most readable in the current
     // import scope).
-    def dedupeExports(symbols: List[Symbol]): List[Symbol] =
-      symbols.groupBy(canonical).values.toList.map: group =>
-        group.minBy(s => renderSymbol(s).s.length)
+    def dedupeExportsByCanonical(matched: List[Matched]): List[Matched] =
+      matched.groupBy(m => canonical(m.symbol)).values.toList.map: group =>
+        group.minBy(m => renderSymbol(m.symbol).s.length)
+
+    // Render a proposal: the symbol's stenography path, suffixed by an
+    // explicit type-parameter substitution `[T = X, U = Y]` whenever the
+    // proposal's type parameters were bound from unification against the
+    // required type. Lets the user see exactly which choices the search has
+    // committed to before recursing.
+    def formatProposal(matched: Matched): Text =
+      val baseName = renderSymbol(matched.symbol).s
+      val pairs = matched.typeParams.collect:
+        case tp if matched.bindings.contains(tp) =>
+          s"${tp.name.toString} = ${stenography.internal.name(matched.bindings(tp)).s}"
+      if pairs.isEmpty then baseName.tt
+      else s"$baseName [${pairs.mkString(", ")}]".tt
 
     // Render a symbol's path via Stenography (so import-scope abbreviations
     // apply). Strip the trailing `.type` that comes from rendering a singleton
@@ -159,40 +177,105 @@ object internal:
         stripped.endsWith("$package")
       .mkString(".").tt
 
-    def conforms(symbol: Symbol, target: TypeRepr): Boolean =
-      val resultType = resultOf(symbol.info)
+    // Determine whether a given symbol can produce a value conforming to
+    // `target`, and if so, what bindings its type parameters must take.
+    // Returns None for any candidate that fails to fully match: missing
+    // bindings, bounds violations, or a substituted result type that doesn't
+    // satisfy `<:< target` after substitution.
+    def matchAgainst(symbol: Symbol, target: TypeRepr): Option[Matched] =
+      val typeParams =
+        symbol.paramSymss.headOption.filter(_.forall(_.isType)).getOrElse(Nil)
 
-      // For non-polymorphic givens, a direct subtype check is precise.
-      if resultType <:< target then true
+      if typeParams.isEmpty then
+        val resultRaw = resultOf(symbol.info)
+        if resultRaw <:< target then Some(Matched(symbol, Nil, Map.empty)) else None
       else
-        // For polymorphic givens, the result type contains type variables that
-        // would be instantiated at the call site; we accept if the result type
-        // and the target share the same type constructor and arity. Stricter
-        // unification is left for later refinement.
-        symbol.info match
-          case _: PolyType =>
-            (resultType.dealias, target.dealias) match
-              case (AppliedType(rTycon, rArgs), AppliedType(tTycon, tArgs)) =>
-                rTycon.dealias.classSymbol == tTycon.dealias.classSymbol
-                && rArgs.length == tArgs.length
-              case _ =>
-                resultType.dealias.classSymbol == target.dealias.classSymbol
+        candidateArgLists(symbol, target, typeParams)
+        . iterator
+        . flatMap: args =>
+            val pairs = typeParams.zip(args).toMap
+            if !boundsRespected(typeParams, pairs) then None
+            else
+              val substituted = resultOf(symbol.info.appliedTo(args))
+              if substituted <:< target then Some(Matched(symbol, typeParams, pairs))
+              else None
+        . nextOption()
+
+    // Generate candidate type-argument lists to try when matching a polymorphic
+    // given against a concrete target. We combine:
+    //  1. Bindings recovered by structural unification of the raw result type
+    //     (handles plain `F[T]` shapes).
+    //  2. The target's `AppliedType` arguments, in order.
+    //  3. Type-alias values pulled out of the target's `Refinement` chain
+    //     (e.g. the `Char` in `Concatenable { type Self = Char }`, produced by
+    //     the modular `T is U` syntax — for which the synth-class result type
+    //     doesn't share top-level structure with the target).
+    def candidateArgLists
+                ( symbol:     Symbol,
+                  target:     TypeRepr,
+                  typeParams: List[Symbol] )
+    :     List[List[TypeRepr]] =
+
+      val raw = resultOf(symbol.info)
+      val bindings = unify(raw, target, typeParams.toSet)
+
+      val unified: List[List[TypeRepr]] =
+        if typeParams.forall(bindings.contains)
+        then List(typeParams.map(bindings))
+        else Nil
+
+      val applied: List[List[TypeRepr]] = target.dealias match
+        case AppliedType(_, args) if args.length == typeParams.length => List(args)
+        case _                                                        => Nil
+
+      val refinementValues = collectRefinementValues(target.dealias)
+      val refinement: List[List[TypeRepr]] =
+        if refinementValues.length == typeParams.length then List(refinementValues) else Nil
+
+      (unified ++ applied ++ refinement).distinct
+
+    def collectRefinementValues(t: TypeRepr): List[TypeRepr] =
+      t.dealias match
+        case Refinement(parent, _, info) =>
+          val parentValues = collectRefinementValues(parent)
+          val infoValue = info match
+            case TypeBounds(lo, hi) if lo =:= hi => List(hi)
+            case _                               => Nil
+          parentValues ++ infoValue
+
+        case _ =>
+          Nil
+
+    def boundsRespected(typeParams: List[Symbol], bindings: Map[Symbol, TypeRepr])
+    :     Boolean =
+
+      typeParams.forall: tp =>
+        bindings.get(tp).fold(true): boundType =>
+          tp.info match
+            case TypeBounds(lo, hi) => lo <:< boundType && boundType <:< hi
+            case _                  => true
+
+    // Compute the using-clause types for a matched candidate, with type
+    // variables instantiated according to the bindings recovered during
+    // matching. We obtain them from the symbol's type (`info.appliedTo(args)`)
+    // rather than from the source AST, so the substitution applies to the
+    // bound `TypeParamRef`s that `Symbol.tree` would expose unsubstituted.
+    def usingTypesInstantiated(matched: Matched): List[TypeRepr] =
+      if matched.typeParams.isEmpty then usingTypes(matched.symbol)
+      else
+        val args = matched.typeParams.map(matched.bindings)
+        matched.symbol.info.appliedTo(args) match
+          case mt: MethodType =>
+            collectUsingClause(mt)
           case _ =>
-            false
+            usingTypes(matched.symbol)
 
-    def usingTypesInstantiated(symbol: Symbol, target: TypeRepr): List[TypeRepr] =
-      val raw = usingTypes(symbol)
-      if raw.isEmpty then raw
-      else
-        val typeParams =
-          symbol.paramSymss.headOption.filter(_.forall(_.isType)).getOrElse(Nil)
-
-        if typeParams.isEmpty then raw
-        else
-          val bindings = unify(resultOf(symbol.info), target, typeParams.toSet)
-          val from = typeParams.filter(bindings.contains)
-          if from.isEmpty then raw
-          else raw.map(_.substituteTypes(from, from.map(bindings)))
+    def collectUsingClause(mt: MethodType): List[TypeRepr] =
+      val MethodType(paramNames, paramTypes, _) = mt
+      // Tell whether this is a using clause by checking if it's a contextual
+      // method type. In dotty's quotes.reflect, `MethodType.isImplicit` is
+      // exposed for contextual/implicit clauses.
+      if mt.isImplicit then paramTypes else Nil
 
     // Walk a `template` type (which may reference type parameters from `params`)
     // alongside a concrete `target` and collect the implied parameter bindings.
@@ -211,8 +294,24 @@ object internal:
           tArgs.zip(rArgs).foldLeft(tyconBindings): (acc, pair) =>
             acc ++ unify(pair(0), pair(1), params)
 
+        case (tRef: Refinement, rRef: Refinement) =>
+          val Refinement(tParent, tName, tInfo) = tRef
+          val Refinement(rParent, rName, rInfo) = rRef
+          if tName != rName then Map.empty
+          else unify(tParent, rParent, params) ++ unifyInfo(tInfo, rInfo, params)
+
         case _ =>
           Map.empty
+
+    def unifyInfo(template: TypeRepr, target: TypeRepr, params: Set[Symbol])
+    :     Map[Symbol, TypeRepr] =
+
+      (template, target) match
+        case (TypeBounds(tLo, tHi), TypeBounds(rLo, rHi)) =>
+          unify(tHi, rHi, params) ++ unify(tLo, rLo, params)
+
+        case _ =>
+          unify(template, target, params)
 
     def usingTypes(symbol: Symbol): List[TypeRepr] =
       symbol.tree.absolve match

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -114,6 +114,7 @@ object internal:
       val matched =
         beneficence.givens(repr)
         . filterNot(exclusions.contains)
+        . filter(respectsOpaqueScope(_, repr))
         . flatMap(matchAgainst(_, repr))
 
       dedupeExportsByCanonical(matched).map: m =>
@@ -276,6 +277,52 @@ object internal:
       // method type. In dotty's quotes.reflect, `MethodType.isImplicit` is
       // exposed for contextual/implicit clauses.
       if mt.isImplicit then paramTypes else Nil
+
+    // Detect when a candidate is a member of an opaque type's companion
+    // object. For a `given` declared in such a companion, dotty's `<:<` will
+    // (incorrectly, from the call site's perspective) see through the opaque
+    // alias when matching it against types based on the opaque's underlying.
+    // Scan the owner chain for any module whose enclosing scope contains a
+    // sibling opaque type with the same name.
+    def opaqueCompanionType(symbol: Symbol): Option[Symbol] =
+      def loop(current: Symbol): Option[Symbol] =
+        if current.isNoSymbol || current == defn.RootClass then None
+        else if current.flags.is(Flags.Module) then
+          val moduleName = current.name.toString match
+            case n if n.endsWith("$") => n.substring(0, n.length - 1).nn
+            case n                    => n
+
+          val sibling = current.owner.declaredTypes.find: t =>
+            t.name.toString == moduleName && t.flags.is(Flags.Opaque)
+
+          sibling.orElse(loop(current.owner))
+        else loop(current.owner)
+
+      loop(symbol.owner)
+
+    // For a candidate from an opaque companion, only accept it if `target`
+    // literally mentions the opaque type — otherwise the apparent match is
+    // only via the opaque's underlying alias, which isn't supposed to be
+    // visible at the call site.
+    def respectsOpaqueScope(symbol: Symbol, target: TypeRepr): Boolean =
+      opaqueCompanionType(symbol) match
+        case Some(opaqueType) => mentions(target, opaqueType)
+        case None             => true
+
+    def mentions(t: TypeRepr, sym: Symbol): Boolean =
+      if t.typeSymbol == sym then true
+      else t.dealias match
+        case AppliedType(tycon, args) =>
+          mentions(tycon, sym) || args.exists(mentions(_, sym))
+
+        case Refinement(parent, _, info) =>
+          mentions(parent, sym) || mentions(info, sym)
+
+        case TypeBounds(lo, hi) =>
+          mentions(lo, sym) || mentions(hi, sym)
+
+        case _ =>
+          false
 
     // Walk a `template` type (which may reference type parameters from `params`)
     // alongside a concrete `target` and collect the implied parameter bindings.

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -100,6 +100,11 @@ object internal:
 
     val initialGas = 3
 
+    def resultOf(t: TypeRepr): TypeRepr = t match
+      case PolyType(_, _, body)   => resultOf(body)
+      case MethodType(_, _, body) => resultOf(body)
+      case _                      => t
+
     def availableFor(repr: TypeRepr, exclusions: List[Symbol], gas: Int): List[Available] =
       beneficence.givens(repr)
       . filterNot(exclusions.contains)
@@ -107,19 +112,12 @@ object internal:
       . map: symbol =>
           val requirements =
             if gas <= 0 then Nil
-            else usingTypes(symbol).map: paramType =>
+            else usingTypesInstantiated(symbol, repr).map: paramType =>
               val nextAvailable = availableFor(paramType, symbol :: exclusions, gas - 1)
               Missing(stenography.internal.name(paramType), nextAvailable, Nil)
           Available(displayName(symbol.fullName).tt, requirements)
 
     def conforms(symbol: Symbol, target: TypeRepr): Boolean =
-      // Strip PolyType / MethodType wrappers to get the value type a successful
-      // application would produce.
-      def resultOf(t: TypeRepr): TypeRepr = t match
-        case PolyType(_, _, body)   => resultOf(body)
-        case MethodType(_, _, body) => resultOf(body)
-        case _                      => t
-
       val resultType = resultOf(symbol.info)
 
       // For non-polymorphic givens, a direct subtype check is precise.
@@ -139,6 +137,40 @@ object internal:
                 resultType.dealias.classSymbol == target.dealias.classSymbol
           case _ =>
             false
+
+    def usingTypesInstantiated(symbol: Symbol, target: TypeRepr): List[TypeRepr] =
+      val raw = usingTypes(symbol)
+      if raw.isEmpty then raw
+      else
+        val typeParams =
+          symbol.paramSymss.headOption.filter(_.forall(_.isType)).getOrElse(Nil)
+
+        if typeParams.isEmpty then raw
+        else
+          val bindings = unify(resultOf(symbol.info), target, typeParams.toSet)
+          val from = typeParams.filter(bindings.contains)
+          if from.isEmpty then raw
+          else raw.map(_.substituteTypes(from, from.map(bindings)))
+
+    // Walk a `template` type (which may reference type parameters from `params`)
+    // alongside a concrete `target` and collect the implied parameter bindings.
+    // Used to instantiate type variables in `using` clauses according to the
+    // type that the proposed given is being asked to provide.
+    def unify(template: TypeRepr, target: TypeRepr, params: Set[Symbol])
+    :     Map[Symbol, TypeRepr] =
+
+      val templateSymbol = template.typeSymbol
+
+      if params.contains(templateSymbol) then Map(templateSymbol -> target)
+      else (template.dealias, target.dealias) match
+        case (AppliedType(tTycon, tArgs), AppliedType(rTycon, rArgs))
+        if tArgs.length == rArgs.length =>
+          val tyconBindings = unify(tTycon, rTycon, params)
+          tArgs.zip(rArgs).foldLeft(tyconBindings): (acc, pair) =>
+            acc ++ unify(pair(0), pair(1), params)
+
+        case _ =>
+          Map.empty
 
     def usingTypes(symbol: Symbol): List[TypeRepr] =
       symbol.tree.absolve match

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -90,7 +90,7 @@ object internal:
     given context: core.Contexts.Context = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl => quotes.ctx
 
-    case class Candidate(name: Text, missing: List[Result]) extends Result
+    case class Candidate(name: Text, symbol: Symbol, missing: List[Result]) extends Result
     case class Available(name: Text, requirements: List[Missing]) extends Result
 
     case class Missing(name: Text, available: List[Available], candidates: List[Candidate])
@@ -111,9 +111,14 @@ object internal:
                   bindings:   Map[Symbol, TypeRepr] )
 
     def availableFor(repr: TypeRepr, exclusions: List[Symbol], gas: Int): List[Available] =
+      // Compare exclusions by canonical (de-exported) symbol so that a
+      // candidate `gossamer.foo` filters out both `gossamer.foo` itself and
+      // any re-export like `soundness.foo` from the proposal list.
+      val excludedCanonicals = exclusions.map(canonical).filterNot(_.isNoSymbol).toSet
+
       val matched =
         beneficence.givens(repr)
-        . filterNot(exclusions.contains)
+        . filterNot(s => excludedCanonicals.contains(canonical(s)))
         . filter(respectsOpaqueScope(_, repr))
         . flatMap(matchAgainst(_, repr))
 
@@ -376,7 +381,14 @@ object internal:
           Nil
 
     def missing(repr: TypeRepr, candidates: List[Candidate]): Missing =
-      Missing(stenography.internal.name(repr), availableFor(repr, Nil, initialGas), candidates)
+      // Don't propose any classpath given that the implicit search has already
+      // tried as a candidate for this position; doing so would just repeat
+      // information already shown under the `▪ candidate` lines.
+      val candidateSymbols = candidates.map(_.symbol).filterNot(_.isNoSymbol)
+      Missing
+        ( stenography.internal.name(repr),
+          availableFor(repr, candidateSymbols, initialGas),
+          candidates )
 
     def seek(repr: TypeRepr, exclusions: List[Symbol], depth: Int): Result =
       Implicits.searchIgnoring(repr)(self :: exclusions*).absolve match
@@ -398,7 +410,9 @@ object internal:
                   then missing(repr, Nil)
                   else
                     Candidate
-                      ( "???", List(seek(right.head.tpe, term.symbol :: exclusions, depth + 1)) )
+                      ( "???",
+                        term.symbol,
+                        List(seek(right.head.tpe, term.symbol :: exclusions, depth + 1)) )
 
                 case _ =>
                   missing(repr, Nil)
@@ -411,7 +425,9 @@ object internal:
 
                 case MethodType(_, types, more) =>
                   val name = stenography.internal.name(function.symbol.termRef).show.skip(5, Rtl)
-                  val candidate = Candidate(name, types.map(seek(_, Nil, depth + 1)))
+
+                  val candidate =
+                    Candidate(name, function.symbol, types.map(seek(_, Nil, depth + 1)))
 
                   val candidates = seek(repr, function.symbol :: exclusions, depth) match
                     case Missing(_, _, candidates) => candidate :: candidates
@@ -434,7 +450,7 @@ object internal:
       case Missing(_, available, candidates) =>
         report.errorAndAbort:
           given Result is Expandable =
-            case Candidate(_, missing)             => missing
+            case Candidate(_, _, missing)          => missing
             case Missing(_, available, candidates) => available ::: candidates
             case Available(_, requirements)        => requirements
             case Found(_, _)                       => Nil
@@ -446,7 +462,7 @@ object internal:
             case Missing(name, _, _) =>
               e" \e[38;5;88m$Bold(✗)\e[0m requires \e[38;5;114m$Italic($name)\e[0m"
 
-            case Candidate(name, _) =>
+            case Candidate(name, _, _) =>
               e" \e[38;5;208m$Bold(▪)\e[0m candidate \e[38;5;227m$Italic($name)\e[0m"
 
             case Available(name, _) =>

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -174,6 +174,14 @@ object internal:
         val candidates = if exports.nonEmpty then exports else group
         candidates.minBy(m => renderSymbol(m.symbol).s.length)
 
+    // Same export-preferring dedupe applied to method-level candidates
+    // surfaced by the implicit-search-failure trace.
+    def dedupeCandidates(candidates: List[Candidate]): List[Candidate] =
+      candidates.groupBy(_.symbol.name.toString.stripSuffix("$")).values.toList.flatMap: group =>
+        val exports = group.filter(_.symbol.flags.is(Flags.Exported))
+        val pool = if exports.nonEmpty then exports else group
+        List(pool.minBy(c => renderSymbol(c.symbol).s.length))
+
     // Render a proposal: the symbol's stenography path, suffixed by an
     // explicit type-parameter substitution `[T = X, U = Y]` whenever the
     // proposal's type parameters were bound from unification against the
@@ -435,16 +443,17 @@ object internal:
                   resolve(function.tpe.simplified)
 
                 case MethodType(_, types, more) =>
-                  val name = stenography.internal.name(function.symbol.termRef).show.skip(5, Rtl)
-
                   val candidate =
-                    Candidate(name, function.symbol, types.map(seek(_, Nil, depth + 1)))
+                    Candidate
+                      ( renderSymbol(function.symbol),
+                        function.symbol,
+                        types.map(seek(_, Nil, depth + 1)) )
 
                   val candidates = seek(repr, function.symbol :: exclusions, depth) match
                     case Missing(_, _, candidates) => candidate :: candidates
                     case _                         => Nil
 
-                  missing(repr, candidates)
+                  missing(repr, dedupeCandidates(candidates))
 
                 case _ =>
                   missing(repr, Nil)

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -103,6 +103,7 @@ object internal:
     def resultOf(t: TypeRepr): TypeRepr = t match
       case PolyType(_, _, body)   => resultOf(body)
       case MethodType(_, _, body) => resultOf(body)
+      case ByNameType(body)       => resultOf(body)
       case _                      => t
 
     case class Matched
@@ -158,12 +159,20 @@ object internal:
       case _                 => tree.symbol
 
     // Several classpath givens can be exports/re-exports of the same canonical
-    // definition. Group by canonical symbol and keep only the one whose
-    // stenography rendering is shortest (i.e. the most readable in the current
-    // import scope).
+    // definition. We can't always trace the export forwarder via `canonical`
+    // (binary classes loaded via TASTY expose the symbol's `tree` without its
+    // `rhs`), and the forwarder's `info` resolves to the typeclass type while
+    // the original's `info` is its synthesised module-class type — so neither
+    // canonical-symbol nor result-class matching merges them reliably. Group
+    // by simple name instead: within a single typeclass's META-INF file, two
+    // givens sharing a name are almost always exports of each other. Within
+    // each group, prefer an exported symbol over the original (tie-breaking
+    // by shortest stenography rendering).
     def dedupeExportsByCanonical(matched: List[Matched]): List[Matched] =
-      matched.groupBy(m => canonical(m.symbol)).values.toList.map: group =>
-        group.minBy(m => renderSymbol(m.symbol).s.length)
+      matched.groupBy(_.symbol.name.toString.stripSuffix("$")).values.toList.map: group =>
+        val exports = group.filter(_.symbol.flags.is(Flags.Exported))
+        val candidates = if exports.nonEmpty then exports else group
+        candidates.minBy(m => renderSymbol(m.symbol).s.length)
 
     // Render a proposal: the symbol's stenography path, suffixed by an
     // explicit type-parameter substitution `[T = X, U = Y]` whenever the

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -110,14 +110,21 @@ object internal:
                   typeParams: List[Symbol],
                   bindings:   Map[Symbol, TypeRepr] )
 
+    val givensCache = scala.collection.mutable.Map.empty[TypeRepr, List[Symbol]]
+    def cachedGivens(repr: TypeRepr): List[Symbol] =
+      givensCache.getOrElseUpdate(repr, beneficence.givens(repr))
+
+    val canonicalCache = scala.collection.mutable.Map.empty[Symbol, Symbol]
+    def canonical(symbol: Symbol): Symbol =
+      canonicalCache.getOrElseUpdate(symbol, computeCanonical(symbol))
+
     def availableFor(repr: TypeRepr, exclusions: List[Symbol], gas: Int): List[Available] =
-      // Compare exclusions by canonical (de-exported) symbol so that a
-      // candidate `gossamer.foo` filters out both `gossamer.foo` itself and
-      // any re-export like `soundness.foo` from the proposal list.
+      // Compare exclusions by canonical (de-exported) symbol so that excluding
+      // `gossamer.foo` also filters out any re-export like `soundness.foo`.
       val excludedCanonicals = exclusions.map(canonical).filterNot(_.isNoSymbol).toSet
 
       val matched =
-        beneficence.givens(repr)
+        cachedGivens(repr)
         . filterNot(s => excludedCanonicals.contains(canonical(s)))
         . filter(respectsOpaqueScope(_, repr))
         . flatMap(matchAgainst(_, repr))
@@ -133,7 +140,7 @@ object internal:
     // A symbol introduced via `export X.y` carries the `Exported` flag and its
     // tree's body forwards to the original. Walk through forwarders to find
     // the canonical (non-exported) symbol that ultimately backs it.
-    def canonical(symbol: Symbol): Symbol =
+    def computeCanonical(symbol: Symbol): Symbol =
       if !symbol.flags.is(Flags.Exported) then symbol
       else
         val target = symbol.tree.absolve match
@@ -177,11 +184,9 @@ object internal:
     // for top-level definitions.
     def renderSymbol(symbol: Symbol): Text =
       val raw = stenography.internal.name(symbol.termRef).s
-      val noType = if raw.endsWith(".type") then raw.substring(0, raw.length - 5).nn else raw
-      noType.split('.').iterator.filterNot: segment =>
-        val stripped = if segment.endsWith("$") then segment.dropRight(1).nn else segment
-        stripped.endsWith("$package")
-      .mkString(".").tt
+      raw.stripSuffix(".type").split('.').iterator
+      . filterNot(_.stripSuffix("$").endsWith("$package"))
+      . mkString(".").tt
 
     // Determine whether a given symbol can produce a value conforming to
     // `target`, and if so, what bindings its type parameters must take.
@@ -293,10 +298,7 @@ object internal:
       def loop(current: Symbol): Option[Symbol] =
         if current.isNoSymbol || current == defn.RootClass then None
         else if current.flags.is(Flags.Module) then
-          val moduleName = current.name.toString match
-            case n if n.endsWith("$") => n.substring(0, n.length - 1).nn
-            case n                    => n
-
+          val moduleName = current.name.toString.stripSuffix("$")
           val sibling = current.owner.declaredTypes.find: t =>
             t.name.toString == moduleName && t.flags.is(Flags.Opaque)
 

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -103,3 +103,10 @@ object Tests extends Suite(m"Frontier Tests"):
         val all: Every[Widget] = every[Widget]
       . map(_.message)
     . assert(_ == Nil)
+
+    test(m"explainMissingContext lists classpath givens for missing implicit"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        summon[rudiments.DecimalConverter]
+      . map(_.message)
+    . assert(_.exists(_.contains("decimalFormatters.java")))

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -110,3 +110,10 @@ object Tests extends Suite(m"Frontier Tests"):
         summon[rudiments.DecimalConverter]
       . map(_.message)
     . assert(_.exists(_.contains("decimalFormatters.java")))
+
+    test(m"explainMissingContext shows type-parameter bindings for polymorphic givens"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        summon[Char is symbolism.Concatenable]
+      . map(_.message)
+    . assert(_.exists(_.contains("textual = Char")))

--- a/lib/galilei/src/core/galilei.DeleteRecursively.scala
+++ b/lib/galilei/src/core/galilei.DeleteRecursively.scala
@@ -34,6 +34,7 @@ package galilei
 
 import prepositional.*
 import serpentine.*
+import beneficence.*
 
-trait DeleteRecursively extends Planar:
+trait DeleteRecursively extends Planar, Findable:
   def conditionally[ResultType](path: Path on Plane)(operation: => ResultType): ResultType

--- a/lib/galilei/src/core/galilei.DereferenceSymlinks.scala
+++ b/lib/galilei/src/core/galilei.DereferenceSymlinks.scala
@@ -33,7 +33,8 @@
 package galilei
 
 import java.nio.file as jnf
+import beneficence.*
 
-trait DereferenceSymlinks:
+trait DereferenceSymlinks extends Findable:
   def dereference: Boolean
   def options(): List[jnf.LinkOption]

--- a/lib/galilei/src/core/galilei.OverwritePreexisting.scala
+++ b/lib/galilei/src/core/galilei.OverwritePreexisting.scala
@@ -34,6 +34,7 @@ package galilei
 
 import prepositional.*
 import serpentine.*
+import beneficence.*
 
-trait OverwritePreexisting extends Planar:
+trait OverwritePreexisting extends Planar, Findable:
   def apply[ResultType](path: Path on Plane)(operation: => ResultType): ResultType

--- a/lib/gastronomy/src/core/gastronomy.Hash.scala
+++ b/lib/gastronomy/src/core/gastronomy.Hash.scala
@@ -37,6 +37,7 @@ import javax.crypto as jc
 
 import anticipation.*
 import prepositional.*
+import beneficence.*
 
 object Hash:
   def apply[algorithm <: Algorithm](name0: Text, hmacName0: Text): Hash in algorithm = new Hash:
@@ -48,7 +49,7 @@ object Hash:
     def initialize(): Digestion = new Digestion.Java(js.MessageDigest.getInstance(name0.s).nn)
     def hmac0: jc.Mac = jc.Mac.getInstance(hmacName0.s).nn
 
-trait Hash:
+trait Hash extends Findable:
   type Form <: Algorithm
 
   def name: Text

--- a/lib/gossamer/src/core/gossamer.Proximity.scala
+++ b/lib/gossamer/src/core/gossamer.Proximity.scala
@@ -33,8 +33,9 @@
 package gossamer
 
 import anticipation.*
+import beneficence.*
 
-trait Proximity:
+trait Proximity extends Findable:
   type Operand
   type Triangulable <: Boolean
 

--- a/lib/hellenism/src/core/hellenism.Classloader.scala
+++ b/lib/hellenism/src/core/hellenism.Classloader.scala
@@ -39,12 +39,13 @@ import anticipation.*
 import contingency.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Classloader:
   def threadContext: Classloader = new Classloader(Thread.currentThread.nn.getContextClassLoader.nn)
   inline def apply[template <: AnyKind]: Classloader = ClassRef[template].classloader
 
-class Classloader(val java: ClassLoader):
+class Classloader(val java: ClassLoader) extends Findable:
   type Plane = Classpath
 
   def parent: Optional[Classloader] = Optional(java.getParent).let(new Classloader(_))

--- a/lib/hieroglyph/src/core/hieroglyph.CharDecoder.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharDecoder.scala
@@ -41,6 +41,7 @@ import denominative.*
 import proscenium.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object CharDecoder:
   def system(using TextSanitizer): CharDecoder =
@@ -49,7 +50,7 @@ object CharDecoder:
   def unapply(name: Text)(using TextSanitizer): Option[CharDecoder] =
     Encoding.unapply(name).map(CharDecoder(_))
 
-class CharDecoder(val encoding: Encoding)(using sanitizer: TextSanitizer):
+class CharDecoder(val encoding: Encoding)(using sanitizer: TextSanitizer) extends Findable:
   type Self = Text
   type Form = Data
 

--- a/lib/hieroglyph/src/core/hieroglyph.CharEncoder.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharEncoder.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import proscenium.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object CharEncoder:
   def system: CharEncoder = unapply(jnc.Charset.defaultCharset.nn.displayName.nn.tt).get
@@ -46,7 +47,7 @@ object CharEncoder:
     Encoding.codecs.get(name.s.toLowerCase.nn.tt).map(CharEncoder(_))
 
 class CharEncoder(val encoding: Encoding { type CanEncode = true })
-extends Encodable:
+extends Encodable, Findable:
   type Self = Text
   type Form = Data
 

--- a/lib/hieroglyph/src/core/hieroglyph.TextSanitizer.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.TextSanitizer.scala
@@ -33,6 +33,7 @@
 package hieroglyph
 
 import vacuous.*
+import beneficence.*
 
-trait TextSanitizer:
+trait TextSanitizer extends Findable:
   def sanitize(position: Int, encoding: Encoding): Optional[Char]

--- a/lib/honeycomb/src/core/honeycomb.Dom.scala
+++ b/lib/honeycomb/src/core/honeycomb.Dom.scala
@@ -40,13 +40,14 @@ import anticipation.*
 import gossamer.*
 import proscenium.*
 import vacuous.*
+import beneficence.*
 
 object Dom:
   private[honeycomb] val elements: scm.HashMap[Dom, Dictionary[Tag]] = scm.HashMap()
   private[honeycomb] val attributes: scm.HashMap[Dom, Dictionary[Attribute]] = scm.HashMap()
   private[honeycomb] val entities: scm.HashMap[Dom, Dictionary[Text]] = scm.HashMap()
 
-trait Dom:
+trait Dom extends Findable:
   val elements: Dictionary[Tag]
   val attributes: Dictionary[Attribute]
   val entities: Dictionary[Text]

--- a/lib/honeycomb/src/core/honeycomb.Stylesheet.scala
+++ b/lib/honeycomb/src/core/honeycomb.Stylesheet.scala
@@ -38,6 +38,7 @@ import prepositional.*
 import proscenium.*
 import symbolism.*
 import typonym.*
+import beneficence.*
 
 object Stylesheet:
   given generic: Stylesheet is GenericCssSelection = _.classes.join(t".", t".", t"")
@@ -54,4 +55,4 @@ object Stylesheet:
   given empty: Stylesheet(Set()):
     type Topic = "apply"
 
-case class Stylesheet(classes: Set[Text]) extends Topical
+case class Stylesheet(classes: Set[Text]) extends Topical, Findable

--- a/lib/imperial/src/core/imperial.BaseLayout.scala
+++ b/lib/imperial/src/core/imperial.BaseLayout.scala
@@ -40,9 +40,10 @@ import gossamer.*
 import prepositional.*
 import proscenium.*
 import vacuous.*
+import beneficence.*
 
 object BaseLayout:
-  case class Dir(home: Boolean, path: List[Text]):
+  case class Dir(home: Boolean, path: List[Text]) extends Findable:
     @targetName("child")
     infix def / (name: Text): Dir = Dir(home, name :: path)
 

--- a/lib/jacinta/src/core/jacinta.JsonPointer.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPointer.scala
@@ -45,11 +45,12 @@ import serpentine.*
 import symbolism.*
 import urticose.*
 import vacuous.*
+import beneficence.*
 
 object JsonPointer extends Root(""):
   type Plane = JsonPointer
 
-  trait Registry:
+  trait Registry extends Findable:
     private val documents: scm.HashMap[HttpUrl, Json] = scm.HashMap()
 
     def update(url: HttpUrl, document: Json): Unit = documents(url) = document

--- a/lib/kaleidoscope/src/core/kaleidoscope.Scanner.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Scanner.scala
@@ -33,8 +33,9 @@
 package kaleidoscope
 
 import vacuous.*
+import beneficence.*
 
 object Scanner:
   given default: (erased DummyImplicit) => Scanner = Scanner(Unset)
 
-class Scanner(var nextStart: Optional[Int] = Unset)
+class Scanner(var nextStart: Optional[Int] = Unset) extends Findable

--- a/lib/legerdemain/src/core/legerdemain.Formulation.scala
+++ b/lib/legerdemain/src/core/legerdemain.Formulation.scala
@@ -39,8 +39,9 @@ import prepositional.*
 import vacuous.*
 
 import doms.html.whatwg, whatwg.*
+import beneficence.*
 
-trait Formulation:
+trait Formulation extends Findable:
   def form(content: Seq[Html of Flow], submit: Optional[Text]): Html of Flow
   def element
     ( widget:     Html of Phrasing,

--- a/lib/mercator/src/core/mercator.Functor.scala
+++ b/lib/mercator/src/core/mercator.Functor.scala
@@ -32,10 +32,12 @@
                                                                                                   */
 package mercator
 
+import beneficence.Findable
+
 object Functor:
   inline given general: [functor[_]] => Functor[functor] = ${internal.functor[functor]}
 
-trait Functor[functor[_]]:
+trait Functor[functor[_]] extends Findable:
   def point[value](value: value): functor[value]
 
 

--- a/lib/mercator/src/core/mercator.Monad.scala
+++ b/lib/mercator/src/core/mercator.Monad.scala
@@ -32,10 +32,12 @@
                                                                                                   */
 package mercator
 
+import beneficence.Findable
+
 object Monad:
   inline given monad: [monad[_]] => Monad[monad] = ${internal.monad[monad]}
 
-trait Monad[monad[_]] extends Functor[monad]:
+trait Monad[monad[_]] extends Functor[monad], Findable:
   def bind[value, value2](value: monad[value])(lambda: value => monad[value2]): monad[value2]
 
 

--- a/lib/monotonous/src/core/monotonous.Deserializable.scala
+++ b/lib/monotonous/src/core/monotonous.Deserializable.scala
@@ -43,6 +43,7 @@ import prepositional.*
 import proscenium.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Deserializable:
   def base[base <: Serialization](base: Int)(using alphabet: Alphabet[base])
@@ -94,7 +95,7 @@ object Deserializable:
 
   given binary: (Alphabet[Binary], Tactic[SerializationError]) => Deserializable in Binary = base(1)
 
-trait Deserializable:
+trait Deserializable extends Findable:
   type Form <: Serialization
 
   protected val atomicity: Int = 1

--- a/lib/monotonous/src/core/monotonous.Serializable.scala
+++ b/lib/monotonous/src/core/monotonous.Serializable.scala
@@ -37,6 +37,7 @@ import hypotenuse.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Serializable:
   def base[base <: Serialization](bits: Int)(using alphabet: Alphabet[base]): Serializable in base =
@@ -75,7 +76,7 @@ object Serializable:
   given base64: Alphabet[Base64] => Serializable in Base64 = base(6)
   given base256: Alphabet[Base256] => Serializable in Base256 = base(8)
 
-trait Serializable:
+trait Serializable extends Findable:
   type Form <: Serialization
 
   def encode(bytes: Data): Text

--- a/lib/octogenarian/src/core/octogenarian.GitCommand.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitCommand.scala
@@ -34,8 +34,9 @@ package octogenarian
 
 import anticipation.*
 import guillotine.*
+import beneficence.*
 
 object GitCommand:
   given parameterizable: GitCommand is Parameterizable = _.path
 
-case class GitCommand(path: Text)
+case class GitCommand(path: Text) extends Findable

--- a/lib/orthodoxy/src/core/orthodoxy.Authorization.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Authorization.scala
@@ -37,6 +37,7 @@ import gossamer.*
 import prepositional.*
 import telekinesis.*
 import vacuous.*
+import beneficence.*
 
 
 object Authorization:
@@ -48,6 +49,6 @@ case class Authorization
     scopes:  List[Text],
     expiry:  Optional[Long],
     refresh: Optional[Text] )
-extends Topical:
+extends Topical, Findable:
   private[orthodoxy] def of[scope <: Scope]: Authorization of scope =
     this.asInstanceOf[Authorization of scope]

--- a/lib/orthodoxy/src/core/orthodoxy.OAuth.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.OAuth.scala
@@ -42,6 +42,7 @@ import serpentine.*
 import telekinesis.*
 import urticose.*
 import vacuous.*
+import beneficence.*
 
 object OAuth:
   case class State
@@ -54,7 +55,7 @@ object OAuth:
     def expired: Boolean = expiry.let(System.currentTimeMillis > _).or(false)
 
 
-class OAuth():
+class OAuth() extends Findable:
   private val data: scm.HashMap[Session, OAuth.State] = scm.HashMap()
 
   def update(session: Session, state: OAuth.State): Unit = data(session) = state

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -53,8 +53,9 @@ import vacuous.*
 import unsafeExceptions.canThrowAny
 import AsyncError.Reason
 import Fulfillment.*
+import beneficence.*
 
-sealed trait Monitor extends Resultant:
+sealed trait Monitor extends Resultant, Findable:
   val promise: Promise[Result]
 
   protected[parasite] val workersRef: juca.AtomicReference[Set[Worker]] =

--- a/lib/parasite/src/core/parasite.Threading.scala
+++ b/lib/parasite/src/core/parasite.Threading.scala
@@ -33,6 +33,7 @@
 package parasite
 
 import language.experimental.pureFunctions
+import beneficence.*
 
-trait Threading:
+trait Threading extends Findable:
   def supervisor(): Supervisor

--- a/lib/polaris/src/core/polaris.Buffer.scala
+++ b/lib/polaris/src/core/polaris.Buffer.scala
@@ -33,8 +33,9 @@
 package polaris
 
 import anticipation.*
+import beneficence.*
 
-class Buffer(private[polaris] val bytes: Data, initialPosition: Int = 0):
+class Buffer(private[polaris] val bytes: Data, initialPosition: Int = 0) extends Findable:
   private[polaris] var position: Int = initialPosition
 
   def offset: Int = position

--- a/lib/prepositional/src/core/prepositional.Typeclass.scala
+++ b/lib/prepositional/src/core/prepositional.Typeclass.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package prepositional
 
-trait Typeclass:
+import beneficence.Findable
+
+trait Typeclass extends Findable:
   type Self

--- a/lib/probably/src/core/probably.Reporter.scala
+++ b/lib/probably/src/core/probably.Reporter.scala
@@ -34,6 +34,7 @@ package probably
 
 import ambience.*
 import turbulence.*
+import beneficence.*
 
 object Reporter:
   given report: (Stdio, Environment, TestPalette) => Reporter[Report]:
@@ -45,7 +46,7 @@ object Reporter:
 
     def complete(report: Report): Unit = report.complete(Coverage())
 
-trait Reporter[report]:
+trait Reporter[report] extends Findable:
   def report(): report
   def fail(report: report, error: Throwable, active: Set[TestId]): Unit
   def declare(report: report, suite: Testable): Unit

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -43,11 +43,12 @@ import vacuous.*
 
 import stdios.virtualMachine
 import termcaps.environment
+import beneficence.*
 
 object Runner:
   private[probably] val harnessThreadLocal: ThreadLocal[Option[Harness]] = ThreadLocal()
 
-class Runner[report]()(using reporter: Reporter[report]):
+class Runner[report]()(using reporter: Reporter[report]) extends Findable:
   private var active: List[TestId] = Nil
   private val silent: Boolean = Ci.claudeCode || Ci()
 

--- a/lib/probably/src/core/probably.Testable.scala
+++ b/lib/probably/src/core/probably.Testable.scala
@@ -36,9 +36,11 @@ import digression.*
 import fulminate.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 class Testable(val name: Message, val parent: Optional[Testable] = Unset)
-  ( using codepoint: Codepoint ):
+  ( using codepoint: Codepoint )
+extends Findable:
 
   override def equals(that: Any): Boolean = that.matchable(using Unsafe) match
     case that: Testable => name == that.name && parent == that.parent

--- a/lib/profanity/src/core/profanity.Console.scala
+++ b/lib/profanity/src/core/profanity.Console.scala
@@ -33,6 +33,7 @@
 package profanity
 
 import turbulence.*
+import beneficence.*
 
 object Console:
   def apply(stdio: Stdio): Console =
@@ -40,7 +41,7 @@ object Console:
     new Console:
       val stdio: Stdio = stdio0
 
-trait Console:
+trait Console extends Findable:
   val stdio: Stdio
 
   def trap(handler: PartialFunction[UnixSignal | WindowsSignal, SignalResponse]): Unit = ()

--- a/lib/profanity/src/core/profanity.Interactivity.scala
+++ b/lib/profanity/src/core/profanity.Interactivity.scala
@@ -33,9 +33,10 @@
 package profanity
 
 import proscenium.*
+import beneficence.*
 
 object Interactivity:
   def apply[event](stream: Stream[event]): Interactivity[event] = () => stream
 
-trait Interactivity[event]:
+trait Interactivity[event] extends Findable:
   def eventStream(): Stream[event]

--- a/lib/rudiments/src/core/rudiments.DecimalConverter.scala
+++ b/lib/rudiments/src/core/rudiments.DecimalConverter.scala
@@ -33,6 +33,7 @@
 package rudiments
 
 import anticipation.*
+import beneficence.*
 
-trait DecimalConverter:
+trait DecimalConverter extends Findable:
   def decimalize(value: Double): Text

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -48,6 +48,7 @@ import telekinesis.*
 import turbulence.*
 import urticose.*
 import vacuous.*
+import beneficence.*
 
 object HttpConnection:
   def apply(exchange: csnh.HttpExchange): HttpConnection logs HttpServerEvent =
@@ -146,4 +147,5 @@ extends Http.Request
     request.host,
     request.target,
     request.textHeaders,
-    request.body )
+    request.body ),
+  Findable

--- a/lib/scintillate/src/server/scintillate.WebserverErrorPage.scala
+++ b/lib/scintillate/src/server/scintillate.WebserverErrorPage.scala
@@ -33,6 +33,7 @@
 package scintillate
 
 import telekinesis.*
+import beneficence.*
 
-trait WebserverErrorPage:
+trait WebserverErrorPage extends Findable:
   def handle(throwable: Throwable, request: Http.Request): Http.Response

--- a/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
+++ b/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
@@ -45,8 +45,9 @@ import urticose.*
 
 import logging.silent
 import workingDirectories.java
+import beneficence.*
 
-trait BenchmarkDevice:
+trait BenchmarkDevice extends Findable:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError
   def invoke(path: Path on Linux, input: Text): Text raises BenchError
   def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError

--- a/lib/stenography/src/core/stenography.Imports.scala
+++ b/lib/stenography/src/core/stenography.Imports.scala
@@ -33,7 +33,8 @@
 package stenography
 
 object Imports:
-  val empty: Imports = Imports(Set())
+  val empty: Imports = Imports(Set(), Set())
 
-case class Imports(typenames: Set[Typename]):
+case class Imports(typenames: Set[Typename], direct: Set[Typename]):
   def has(typename: Typename): Boolean = typenames.contains(typename)
+  def hasDirect(typename: Typename): Boolean = direct.contains(typename)

--- a/lib/stenography/src/core/stenography.Typename.scala
+++ b/lib/stenography/src/core/stenography.Typename.scala
@@ -97,5 +97,6 @@ enum Typename:
       case Type(parent, _) => s"${parent.url}${symbol("~")}$name2".tt
       case Term(parent, _) => s"${parent.url}${symbol("~")}$name2".tt
 
-  def text(using imports: Imports): Text = parent.lay(name): parent =>
-    if imports.has(parent) then name else s"${parent.text}${symbol("#")}$name".tt
+  def text(using imports: Imports): Text =
+    if imports.hasDirect(this) then name else parent.lay(name): parent =>
+      if imports.has(parent) then name else s"${parent.text}${symbol("#")}$name".tt

--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -49,21 +49,62 @@ object internal:
   def name[typename <: AnyKind: Type](using Quotes): Text =
     import quotes.reflect.*
 
-    val outer = quotes.absolve match
+    val (outer, direct): (List[Typename], Set[Typename]) = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         given context: core.Contexts.Context = quotes.ctx
 
         context.compilationUnit.tpdTree.absolve match
           case ast.tpd.PackageDef(root, statements) =>
-            Typename(root.show) :: statements.collect:
-              case ast.tpd.Import(name, selectors) if selectors.exists(_.isWildcard) =>
-                Typename(name.show)
+            val outerNames = Typename(root.show) :: statements.collect:
+              case ast.tpd.Import(name, _) => Typename(name.show)
+
+            // For each wildcard import, find type aliases declared in that
+            // scope that were introduced by `export X.foo` clauses (carrying
+            // the `Exported` flag). Their *target* typenames are accessible
+            // via just the leaf, so add those to `direct`.
+            val directNames =
+              statements.collect:
+                case ast.tpd.Import(qualifier, selectors)
+                if selectors.exists(_.isWildcard) =>
+                  val rootSym = qualifier.symbol
+                  if !rootSym.exists then Nil
+                  else exportedTargets(rootSym)
+              .flatten.toSet
+
+            (outerNames, directNames)
 
           case _ =>
-            Nil
+            (Nil, Set.empty[Typename])
 
     val imports: Set[Typename] = metaprogramming.imports.map(_.term).map(Syntax.term(_)).to(Set)
 
-    given Imports = Imports(Set(Typename("scala"), Typename("scala.Predef")) ++ imports ++ outer)
+    given Imports =
+      Imports(Set(Typename("scala"), Typename("scala.Predef")) ++ imports ++ outer, direct)
 
     Syntax(TypeRepr.of[typename]).text
+
+  private def exportedTargets(using Quotes, dotty.tools.dotc.core.Contexts.Context)
+                             (rootSym: dotty.tools.dotc.core.Symbols.Symbol)
+  :     List[Typename] =
+
+    import dotty.tools.dotc.core.{Flags, Types}
+    import quotes.reflect.TypeRepr
+
+    // Top-level definitions in a package are stored inside synthetic
+    // `<filename>$package` classes; export forwarders for types live there.
+    val directDecls = rootSym.info.decls.toList
+    val packageClasses = directDecls.filter(_.name.toString.endsWith("$package"))
+    val nestedDecls = packageClasses.flatMap(_.info.decls.toList)
+
+    (directDecls ++ nestedDecls).filter(_.is(Flags.Exported)).flatMap: decl =>
+      decl.info match
+        case alias: Types.TypeAlias =>
+          Syntax(alias.alias.asInstanceOf[TypeRepr]) match
+            // Add both forms so the same import path can shorten references
+            // to either the type itself or its companion (e.g. `Textual` and
+            // `Textual.foo` both resolve via `import soundness.*`).
+            case Syntax.Simple(typename) => List(typename, typename.companionObject)
+            case _                       => Nil
+
+        case _ =>
+          Nil

--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -49,34 +49,38 @@ object internal:
   def name[typename <: AnyKind: Type](using Quotes): Text =
     import quotes.reflect.*
 
-    val (outer, direct): (List[Typename], Set[Typename]) = quotes.absolve match
+    val outer: List[Typename] = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         given context: core.Contexts.Context = quotes.ctx
 
         context.compilationUnit.tpdTree.absolve match
           case ast.tpd.PackageDef(root, statements) =>
-            val outerNames = Typename(root.show) :: statements.collect:
+            Typename(root.show) :: statements.collect:
               case ast.tpd.Import(name, _) => Typename(name.show)
 
-            // For each wildcard import, find type aliases declared in that
-            // scope that were introduced by `export X.foo` clauses (carrying
-            // the `Exported` flag). Their *target* typenames are accessible
-            // via just the leaf, so add those to `direct`.
-            val directNames =
-              statements.collect:
-                case ast.tpd.Import(qualifier, selectors)
-                if selectors.exists(_.isWildcard) =>
-                  val rootSym = qualifier.symbol
-                  if !rootSym.exists then Nil
-                  else exportedTargets(rootSym)
-              .flatten.toSet
-
-            (outerNames, directNames)
-
           case _ =>
-            (Nil, Set.empty[Typename])
+            Nil
+
+      case _ => Nil
 
     val imports: Set[Typename] = metaprogramming.imports.map(_.term).map(Syntax.term(_)).to(Set)
+
+    // Build the `direct` set by drilling into every wildcard import that's in
+    // scope (including REPL-accumulated imports across earlier lines, captured
+    // by `metaprogramming.imports`) and collecting type aliases carrying the
+    // `Exported` flag. Those aliases' *target* types are reachable via just
+    // their leaf in the current scope, so we render them that way.
+    val direct: Set[Typename] = quotes.absolve match
+      case quotes: runtime.impl.QuotesImpl =>
+        given context: core.Contexts.Context = quotes.ctx
+
+        metaprogramming.imports.filter(_.wildcard).flatMap: imp =>
+          val rootSym = imp.term.asInstanceOf[core.Types.Type].termSymbol(using context)
+          if !rootSym.exists then Nil
+          else exportedTargets(rootSym)
+        .toSet
+
+      case _ => Set.empty[Typename]
 
     given Imports =
       Imports(Set(Typename("scala"), Typename("scala.Predef")) ++ imports ++ outer, direct)

--- a/lib/synesthesia/src/core/synesthesia.McpClient.scala
+++ b/lib/synesthesia/src/core/synesthesia.McpClient.scala
@@ -41,8 +41,9 @@ import obligatory.*
 import prepositional.*
 import proscenium.*
 import vacuous.*
+import beneficence.*
 
-trait McpClient:
+trait McpClient extends Findable:
   import Mcp.*
 
   @rpc

--- a/lib/telekinesis/src/core/telekinesis.Context.scala
+++ b/lib/telekinesis/src/core/telekinesis.Context.scala
@@ -36,6 +36,7 @@ import scala.collection.mutable as scm
 
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Context:
   def apply[value](): Context[value] = new Context[value]:
@@ -44,6 +45,6 @@ object Context:
     def apply()(using session: Session): Optional[value] = store.at(session)
     def update(value: value)(using session: Session): Unit = store(session) = value
 
-trait Context[value]:
+trait Context[value] extends Findable:
   def apply()(using session: Session): Optional[value]
   def update(value: value)(using session: Session): Unit

--- a/lib/telekinesis/src/core/telekinesis.Session.scala
+++ b/lib/telekinesis/src/core/telekinesis.Session.scala
@@ -35,9 +35,10 @@ package telekinesis
 import anticipation.*
 import distillate.*
 import prepositional.*
+import beneficence.*
 
 object Session:
   given encodable: Session is Encodable in Text = _.key
   given decodable: Session is Decodable in Text = Session(_)
 
-case class Session(key: Text)
+case class Session(key: Text) extends Findable

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -33,6 +33,7 @@
 package turbulence
 
 import anticipation.*
+import beneficence.*
 
 object LineSeparation:
   inline def readByte
@@ -91,7 +92,8 @@ case class LineSeparation
     cr:      LineSeparation.Action,
     lf:      LineSeparation.Action,
     crlf:    LineSeparation.Action,
-    lfcr:    LineSeparation.Action ):
+    lfcr:    LineSeparation.Action )
+extends Findable:
 
   def newlineData = newline match
     case LineSeparation.NewlineSeq.Cr   => Data(13)

--- a/lib/turbulence/src/core/turbulence.Stdio.scala
+++ b/lib/turbulence/src/core/turbulence.Stdio.scala
@@ -37,6 +37,7 @@ import java.io as ji
 import anticipation.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object Stdio:
   def apply
@@ -74,7 +75,7 @@ object Stdio:
     override def close(): Unit = ()
     override def available(): Int = 0
 
-trait Stdio extends Io:
+trait Stdio extends Io, Findable:
   val termcap: Termcap
   val out: ji.PrintStream
   val err: ji.PrintStream

--- a/lib/ulysses/src/core/ulysses.Bibliography.scala
+++ b/lib/ulysses/src/core/ulysses.Bibliography.scala
@@ -34,6 +34,7 @@ package ulysses
 
 import anticipation.*
 import proscenium.*
+import beneficence.*
 
 object Bibliography:
   def apply(data: Iterable[Data]): Bibliography =
@@ -41,5 +42,5 @@ object Bibliography:
       ( data.foldLeft(Map[Byte, Set[Data]]()): (map, data) =>
           map.updated(data(0), map.getOrElse(data(0), Set()) + data) )
 
-case class Bibliography(hashes: Map[Byte, Set[Data]]):
+case class Bibliography(hashes: Map[Byte, Set[Data]]) extends Findable:
   def apply(byte: Byte): Set[Data] = hashes.getOrElse(byte, Set.empty)

--- a/lib/urticose/src/core/urticose.Internet.scala
+++ b/lib/urticose/src/core/urticose.Internet.scala
@@ -34,8 +34,9 @@ package urticose
 
 import contingency.*
 import vacuous.*
+import beneficence.*
 
-class Internet(val online: Boolean):
+class Internet(val online: Boolean) extends Findable:
   def require[result](block: Online ?=> result)(using Tactic[OfflineError]): result =
     if online then block(using Online) else abort(OfflineError())
 

--- a/lib/urticose/src/core/urticose.Online.scala
+++ b/lib/urticose/src/core/urticose.Online.scala
@@ -33,6 +33,7 @@
 package urticose
 
 import language.adhocExtensions
+import beneficence.*
 
 object Online extends Online()
-class Online() extends Internet(true)
+class Online() extends Internet(true), Findable

--- a/lib/vicarious/src/core/vicarious.Catalog.scala
+++ b/lib/vicarious/src/core/vicarious.Catalog.scala
@@ -36,6 +36,7 @@ import language.dynamics
 
 import proscenium.*
 import vacuous.*
+import beneficence.*
 
 object Catalog:
   extension [key, value: ClassTag](catalog: Catalog[key, value])
@@ -50,7 +51,7 @@ object Catalog:
           ( Proxy[key, value, index.type](), _ => catalog.values(index) ))
 
 //case class Catalog[key, value](values: Map[Text, value]):
-case class Catalog[key, value: ClassTag](values: IArray[value]):
+case class Catalog[key, value: ClassTag](values: IArray[value]) extends Findable:
   def size: Int = values.length
 
   inline def apply(accessor: (`*`: Proxy[key, value, 0]) ?=> Proxy[key, value, ?]): value =

--- a/lib/vicarious/src/core/vicarious.Proxy.scala
+++ b/lib/vicarious/src/core/vicarious.Proxy.scala
@@ -33,12 +33,13 @@
 package vicarious
 
 import proscenium.*
+import beneficence.Findable
 
 object Proxy:
   transparent inline given derived: [key, value] => Proxy[key, value, 0] =
     ${internal.proxy[key, value]}
 
-class Proxy[key, value, +id <: Nat]() extends Selectable:
+class Proxy[key, value, +id <: Nat]() extends Selectable, Findable:
   transparent inline def selectDynamic(key: String)(using catalog: Catalog[key, value])
   :   value | Proxy[key, value, Nat] =
 

--- a/lib/wisteria/src/core/wisteria.ContextRequirement.scala
+++ b/lib/wisteria/src/core/wisteria.ContextRequirement.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import proscenium.*
 import rudiments.*
 import vacuous.*
+import beneficence.*
 
 object ContextRequirement:
   given required: ContextRequirement:
@@ -52,7 +53,7 @@ object ContextRequirement:
 
     def wrap[value](optional: Optional[value]): Optional[value] = optional
 
-trait ContextRequirement:
+trait ContextRequirement extends Findable:
   type Optionality[Type] <: Optional[Type]
   type Required <: Boolean
 

--- a/lib/xylophone/src/core/xylophone.XmlSchema.scala
+++ b/lib/xylophone/src/core/xylophone.XmlSchema.scala
@@ -40,6 +40,7 @@ import anticipation.*
 import gossamer.*
 import proscenium.*
 import vacuous.*
+import beneficence.*
 
 object XmlSchema:
   private[xylophone] val elements: scm.HashMap[XmlSchema, Dictionary[Tag]] = scm.HashMap()
@@ -68,7 +69,7 @@ object XmlSchema:
     def infer(parent: Tag, child: Tag) = Unset
 
 
-trait XmlSchema:
+trait XmlSchema extends Findable:
   def freeform: Boolean = false
 
   val elements: Dictionary[Tag]


### PR DESCRIPTION
Beneficence is a new compiler plugin and macro library that lets Scala 3 macros enumerate every `given` declaration on the classpath that implements a particular typeclass, and Frontier now uses it to surface "givens for X exist on the classpath but aren't imported" hints inside the missing-implicit diagnostic tree, alongside the existing in-scope candidate analysis.

### Beneficence

A new soundness module providing two pieces:

1. A Scala 3 compiler plugin that walks each compilation unit's typed tree post-typer and records every stably-accessible `given` declaration whose declared type extends the new `Findable` marker trait. Entries are written to `META-INF/givens/<fully-qualified-typeclass-name>` in the output directory, grouped by source file with a `# source:` comment so incremental recompilations replace just the entries from the recompiled sources.

2. A `beneficence.givens(typeRepr)` macro API, callable from inside any `Quotes`-aware code, that aggregates `META-INF/givens/<typeclass>` entries across every classpath JAR (via `ClassLoader.getResources`) and resolves each into a `quotes.reflect.Symbol`. Stale entries (e.g. from a deleted source) are silently filtered.

`prepositional.Typeclass extends Findable`, so any conventional typeclass auto-qualifies. About 70 other types used as `using` parameters across soundness now extend `Findable` directly so they're enumerable too. The `Component` build trait auto-injects `beneficence.core` so every soundness module has access to `Findable` without per-module wiring.

Bundle JARs concatenate `META-INF/givens/*` files at assembly time so the merged jar continues to expose every entry. Per-module library JARs are unaffected — `ClassLoader.getResources` aggregates them naturally at runtime.

### Frontier

The `explain` macro that drives `frontier.context.explainMissingContext` now feeds `beneficence.givens` into its diagnostic tree. For each `✗ requires X` line, the tree shows `▸ propose <given>` children pointing at classpath givens that satisfy `X`, with type-parameter bindings shown explicitly when the proposal is polymorphic:

```
contextual value not found

 ■ resolving Char is Concatenable
 └─ ▸ propose Textual.concatenable [textual = Char]
    └─ ✗ requires Char is Textual
```

The matching path performs structural type unification against the requested type (handling both `F[T]` shapes and modular `T is U` refinements), respects type-parameter bounds, instantiates unifiable type parameters before recursing into the proposal's `using` clauses (with a `gas` budget bounding recursion depth), filters out opaque-companion givens that would only appear to match because dotty's `<:<` saw through the opaque alias, and de-duplicates re-export pairs in favour of the exported member (so users see the import path the downstream library publishes).

### Stenography

Type names rendered by `stenography.internal.name` now shorten via `export` forwarders that are reachable through wildcard imports. With `import soundness.*` in scope (where soundness re-exports gossamer's `Textual`, symbolism's `Concatenable`, etc.), `gossamer.Textual` renders as `Textual`, `Char is symbolism.Concatenable` reads as `Char is Concatenable`, and so on. The detection works in the REPL too: `metaprogramming.imports` walks the full outer-context chain so wildcard imports threaded across REPL lines are picked up.