### PR TITLE
Use frontier.Every for Formattable code-block interpreters

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -841,7 +841,7 @@ object profanity extends Library:
   object test extends Tests(core)
 
 object punctuation extends Library:
-  object core extends Component(honeycomb.core)
+  object core extends Component(honeycomb.core, frontier.core)
   object html extends Component(core)
   object ansi extends Component(core, harlequin.core)
   object test extends Tests(core, html, ansi, jacinta.core, telekinesis.core, sedentary.core, quantitative.units)

--- a/lib/punctuation/src/core/punctuation.Formattable.scala
+++ b/lib/punctuation/src/core/punctuation.Formattable.scala
@@ -35,18 +35,9 @@ package punctuation
 import anticipation.*
 import honeycomb.*
 import prepositional.*
-import proscenium.*
 import vacuous.*
-import wisteria.*
 
 import doms.html.whatwg, whatwg.*
-
-object Formattable extends ProductDerivable[Formattable]:
-  inline def conjunction[derivation <: Product: ProductReflection]: derivation is Formattable =
-    (language, content) =>
-      contexts: [field] => (context: field is Formattable) => context
-      . foldLeft(Unset: Optional[Html of Flow]): (acc, next) =>
-        acc.or(next.format(language, content))
 
 trait Formattable:
   type Self

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -34,6 +34,7 @@ package punctuation
 
 import anticipation.*
 import denominative.*
+import frontier.*
 import gossamer.*
 import honeycomb.*
 import prepositional.*
@@ -106,13 +107,10 @@ object Markdown:
     def render(markdown: Markdown of Prose): Html of Phrasing =
       Fragment(markdown.children.map(phrasing(_))*)
 
-  given layout: (Markdown of Layout) is Renderable in doms.html.whatwg.Flow = markdown =>
-    layout2[EmptyTuple].render(markdown.asInstanceOf[Markdown of Layout across EmptyTuple])
-
-  given layout2: [domains: Formattable] => (Markdown of Layout across domains) is Renderable:
+  given layout: Every[Formattable] => (Markdown of Layout) is Renderable:
     type Form = doms.html.whatwg.Flow
 
-    def render(markdown: Markdown of Layout across domains): Html of whatwg.Flow =
+    def render(markdown: Markdown of Layout): Html of whatwg.Flow =
       import doms.html.whatwg.*
 
       def tightItem(node: Layout): Html of Flow = node match
@@ -183,7 +181,10 @@ object Markdown:
             case 6 => H6(content.map(phrasing(_))*)
 
         case Layout.CodeBlock(line, info, code) =>
-          domains.format(info, code).or:
+          val formatted = summon[Every[Formattable]].values.foldLeft(Unset: Optional[Html of Flow]):
+            (acc, formattable) => acc.or(formattable.format(info, code))
+
+          formatted.or:
             Pre(info.prim.lay(Code(code)) { info => Code(`class` = t"language-$info")(code) })
 
       Fragment(markdown.children.map { node => Fragment(layout(node), "\n") }*)


### PR DESCRIPTION
Punctuation now picks up every `Formattable` given in scope automatically when
rendering Markdown to HTML, so adding support for a new fenced code language
(e.g. Scala, Java, …) is just an `import` of the relevant given — no tuple to
construct, no `across` infix to thread through `Markdown`'s `Domain`.

Adding a fenced-code interpreter to a Markdown rendering used to look like:

```scala
import punctuation.formattables.{scala, java}

type MyDomains = (scala.type, java.type)
val html = (markdown: Markdown of Layout across MyDomains).html
```

You can now drop the tuple type and the `across` cast entirely:

```scala
import punctuation.formattables.{scala, java}

val html = markdown.html
```

Internally, the layout renderer now takes a single `Every[Formattable]` context
parameter (from `frontier`) and folds every in-scope `Formattable` until one
returns a non-`Unset` rendering. The empty-list case continues to fall back to
plain `<pre><code>…</code></pre>` output, so existing renderings without any
formatter givens are unchanged. The Wisteria-based `ProductDerivable[Formattable]`
companion has been removed.