### PR TITLE
Add tags index for all modules

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -1,0 +1,118 @@
+abacist: composite-units mixed-radix time-decomposition quantities
+acyclicity: graph dag directed-graph poset graphviz dot subgraph
+adversaria: annotations metadata reflection compile-time-reflection
+ambience: envvar system-properties configuration xdg directories environment
+anamnesis: database entity persistence storage data-access
+anthology: scala-compiler compilation programmatic-compiler diagnostics
+anticipation: integration typeclass-bridges abstract-typeclasses cross-module
+austronesian: pojo java-interop serialization classloader-isolation
+aviation: time date calendar timezone iso8601 rfc1123 holidays leap-seconds tzdb
+baroque: complex-numbers math imaginary algebra
+bitumen: tar archive pax tarball unix-permissions
+burdock: bootstrap installer self-installer
+cacophony: audio sound aiff wav playback recording stereo waveform
+caduceus: email smtp mime sender attachment envelope
+caesura: csv tsv dsv spreadsheet sheet delimited-values
+camouflage: cache lru-cache memoization
+capricious: random rng probability gaussian gamma distribution sampling seed
+cardinality: refinement-types numeric-range bounded-numbers ranges
+cataclysm: css stylesheet selectors keyframes media-queries fonts typesafe-css
+cellulose: codl config configuration-language declarative
+charisma: chemistry periodic-table chemical-equation molecule chemical-formula
+chiaroscuro: diff comparison contrast similarity test-assertions decomposition
+coaxial: socket tcp udp networking domain-socket bindable connection
+contextual: string-interpolation interpolator typesafe-interpolation custom-interpolators
+contingency: error-handling exceptions tactics recovery validation effects
+cosmopolite: i18n internationalization locale language polyglot l10n
+decorum: compiler-plugin code-style linting static-analysis
+dendrology: tree-diagram dag-diagram ascii-tree visualization tree-rendering
+denominative: ordinal indexing zero-based one-based interval
+digression: stacktrace codepoint fqcn introspection debugging
+dissonance: diff myers-diff text-diff edit-distance change-detection
+distillate: decoder encoder typeclass conversion extraction
+diuretic: java-interop adapters legacy-java compatibility java-types
+embarcadero: docker container container-runtime
+enigmatic: cryptography aes rsa hmac encryption signing pem public-key
+escapade: ansi-escape terminal-styling colors text-style hyperlink ribbon teletype
+escritoire: table tabulation grid box-drawing terminal-tables column-alignment
+ethereal: daemon ipc background-process service-installer client-server
+eucalyptus: logging logs realm logger structured-logging
+exegesis: lsp language-server-protocol ide-integration
+exoskeleton: cli command-line application-framework entrypoint shell-completion
+frontier: implicits given-search compile-time-reflection enumeration
+fulminate: error-messages diagnostics fail-fast structured-messages internationalization-messages
+galilei: filesystem io files directories symlinks volumes posix
+gastronomy: hashing digest sha256 md5 crc32 feistel checksum
+geodesy: geolocation compass coordinates directions geography cardinal-direction
+gesticulate: mime media-types multipart content-type assets
+gigantism: macros metaprogramming compile-time scala-compiler-internals
+gnossienne: reference foreign-key entity-reference resolvable
+gossamer: text strings text-utilities decimal-formatting bidi unicode joining
+guillotine: shell process subprocess command-execution posix sh
+hallucination: image png jpeg gif bmp raster image-io
+harlequin: syntax-highlighting source-code tokenization scala-parser
+hellenism: classpath classloader jvm resources jar
+hieroglyph: unicode encoding character-encoding utf8 grapheme text-encoding
+honeycomb: html html5 dom typesafe-html tags attributes
+hyperbole: tasty scala-compiler introspection ast macro-debugging
+hypotenuse: numeric overflow division integer-arithmetic ordered
+imperial: directory-layout home-directory base-directory filesystem-layout xdg
+inimitable: uuid identifier guid
+iridescence: color color-spaces rgb cielab hsl srgb palette theme colorimetry
+jacinta: json parser serialization json-pointer ndjson dynamic-access
+kaleidoscope: regex glob pattern-matching scanner regular-expressions
+larceny: compiler-plugin compile-error testing compile-time-testing
+legerdemain: forms widgets html-forms input fields
+mandible: bytecode jvm classfile class-file
+mercator: functor monad applicative typeclass functional-programming
+merino: json parser fast-parser json-ast
+metamorphose: permutations combinatorics factoradic lehmer
+monotonous: base64 base32 hex binary-encoding base-encoding serialization
+mosquito: matrix linear-algebra math vector
+nomenclature: name-validation type-level constraints refinement-types string-literal-types
+obligatory: rpc json-rpc sse server-sent-events framing length-prefix protocol
+octogenarian: git version-control git-repository commit ssh-url
+orthodoxy: oauth authentication authorization oauth2 scope
+panopticon: lens optics composable case-class accessor
+parasite: async threading concurrency tasks promise daemon supervision
+perihelion: websocket frame ws-protocol
+phoenicia: fonts typography ttf truetype font-metrics opentype
+plutocrat: currency money price finance luhn isin fixed-point
+polaris: binary-serialization buffer pack unpack byte-buffer
+polyvinyl: structural-types records anonymous-records type-providers
+prepositional: typeclass type-infrastructure refinement-types abstract-types
+probably: testing test-runner property-testing benchmark assertions
+profanity: terminal tui keyboard line-editor interactive console
+proscenium: re-exports stdlib utilities boilerplate-reduction
+punctuation: markdown commonmark prose text-formatting
+quantitative: units quantities dimensional-analysis si-units measurements physics
+revolution: jar-manifest semver versioning
+rudiments: utilities core-library bijection loops indexable
+satirical: wit webassembly-interface-types wasm interface-definitions
+savagery: svg vector-graphics 2d-graphics path shapes
+scintillate: http-server servlet web-framework http-routing
+sedentary: benchmarking performance-testing micro-benchmark
+serpentine: path filesystem-paths posix windows linux relative-path absolute-path
+spectacular: show pretty-printing display inspect
+stenography: typename qualified-names imports symbol-rendering scala-types
+superlunary: staging remote-execution multi-stage-programming distributed-computing
+surveillance: file-watcher filesystem file-events directory-monitoring nio
+symbolism: operators arithmetic typeclass operator-overloading algebra
+synesthesia: mcp model-context-protocol llm ai-protocol
+tarantula: webdriver browser-automation chrome firefox selenium
+telekinesis: http http-client cookies authentication rest-client web-requests
+turbulence: streams io stdio gzip compression streaming reactive
+typonym: type-level type-list type-map heterogeneous reflection
+ulysses: bloom-filter probabilistic-data-structures palimpsest
+umbrageous: compiler-plugin shading namespace-isolation
+urticose: hostname email-address ip-address mac-address port network-identifiers endpoint
+vacuous: optional null-safety option maybe nullable
+vexillology: bit-flags flags enumeration bitfield
+vicarious: catalog proxy type-indexed records
+villainy: json-schema schema-validation jsonschema
+wisteria: derivation product-types sum-types case-class typeclass-derivation magnolia
+xylophone: xml xml-schema typesafe-xml dynamic-xml
+yossarian: pty terminal-emulator ansi-escape screen-buffer vt100 cursor
+zephyrine: parser parsing cursor emitter sparse-format
+zeppelin: zip archive zip-file compression
+ziggurat: installer bootstrap deployment payload


### PR DESCRIPTION
A new file at doc/tags.md provides a quick reference listing each of the 118 Soundness modules together with searchable keywords describing its purpose and features. It is intended to make modules easier to discover for newcomers browsing the repo and for users searching for libraries by topic on GitHub.


# New tags index

A new file, `doc/tags.md`, lists every module in Soundness alongside a short list of tags. Each line takes the form:

    module-name: purpose tag-1 tag-2 tag-3 ...

The first tag is the module's definitive purpose, and the remaining tags are keywords typical of GitHub topics — features, algorithms, related concepts. Use this index to quickly locate, for example, the lens library (`panopticon`), the OAuth library (`orthodoxy`), or the PTY emulator (`yossarian`).