### PR TITLE
Make LineEditor and SelectMenu rendering width-aware

### DIFF
--- a/lib/profanity/src/core/profanity.Interaction.scala
+++ b/lib/profanity/src/core/profanity.Interaction.scala
@@ -37,36 +37,55 @@ import gossamer.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
-import symbolism.*
 import turbulence.*
 import vacuous.*
 
 object Interaction:
-  given selectMenu: [item: Showable] => Stdio => Interaction[item, SelectMenu[item]]:
+  given selectMenu: [item: Showable] => (terminal: Terminal) => Interaction[item, SelectMenu[item]]:
+    given Stdio = terminal.stdio
     override def before(): Unit = Out.print(t"\e[?25l")
     override def after(): Unit = Out.print(t"\e[J\e[?25h")
 
     def render(old: Optional[SelectMenu[item]], menu: SelectMenu[item]) =
-      menu.options.each: option =>
-        Out.print((if option == menu.current then t" > $option" else t"   $option")+t"\e[K\n")
-      Out.print(t"\e[${menu.options.length}A")
+      val cols = terminal.knownColumns.max(1)
+      Out.print:
+        Text.build:
+          append(t"\e[J")
+          var totalRows = 0
+          menu.options.each: option =>
+            val full = (if option == menu.current then t" > $option" else t"   $option")
+            append(full)
+            append(t"\e[E")
+            totalRows += (full.length - 1)/cols + 1
+          if totalRows > 0 then append(t"\e[${totalRows}F")
 
     def result(state: SelectMenu[item]): item = state.current
 
-  given lineEditor: Stdio => Interaction[Text, LineEditor]:
+  given lineEditor: (terminal: Terminal) => Interaction[Text, LineEditor]:
+    given Stdio = terminal.stdio
     override def after(): Unit = Out.println()
 
-    def render(editor: Optional[LineEditor], editor2: LineEditor): Unit = Out.print:
-      Text.build:
-        editor.let { editor => if editor.position > 0 then append(t"\e[${editor.position}D") }
-        append(t"\e[K")
+    def render(old: Optional[LineEditor], editor: LineEditor): Unit =
+      val cols = terminal.knownColumns.max(1)
+      val len = editor.value.length
+      val curRow = editor.position/cols
+      val curCol = editor.position%cols
 
-        val line =
-          t"${editor2.value}${t" "*(editor.or(editor2).value.length - editor2.value.length)}"
+      Out.print:
+        Text.build:
+          old.let: o =>
+            val oldRow = o.position/cols
+            if oldRow > 0 then append(t"\e[${oldRow}F") else append(t"\r")
 
-        append(line)
-        if line.length > 0 then append(t"\e[${line.length}D")
-        if editor2.position > 0 then append(t"\e[${editor2.position}C")
+          append(t"\e[J")
+          append(editor.value)
+
+          if len > 0 then
+            val printedRows = (len - 1)/cols
+            if printedRows > 0 then append(t"\e[${printedRows}F") else append(t"\r")
+
+          if curRow > 0 then append(t"\e[${curRow}B")
+          if curCol > 0 then append(t"\e[${curCol + 1}G")
 
     def result(editor: LineEditor): Text = editor.value
 

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -84,11 +84,32 @@ object Tests extends Suite(m"Profanity Tests"):
                       Out.println(t"RESULT:$result")
                     Exit.Ok
 
+              case Argument("line-editor-sized") :: Argument(w) :: Argument(h) :: Nil =>
+                execute:
+                  interactive: terminal ?=>
+                    terminal.columns = w.decode[Int]
+                    terminal.rows = h.decode[Int]
+                    Out.println(t"READY")
+                    LineEditor().ask: result =>
+                      Out.println(t"RESULT:$result")
+                    Exit.Ok
+
               case Argument("select-menu") :: Nil =>
                 execute:
                   interactive: terminal ?=>
                     Out.println(t"READY")
                     SelectMenu(List(t"alpha", t"beta", t"gamma"), t"alpha").ask: result =>
+                      Out.println(t"RESULT:$result")
+                    Exit.Ok
+
+              case Argument("select-menu-long-sized") :: Argument(w) :: Argument(h) :: Nil =>
+                execute:
+                  interactive: terminal ?=>
+                    terminal.columns = w.decode[Int]
+                    terminal.rows = h.decode[Int]
+                    Out.println(t"READY")
+                    val opts = List(t"first", t"averyverylongoptionnamethatwraps", t"third")
+                    SelectMenu(opts, t"first").ask: result =>
                       Out.println(t"RESULT:$result")
                     Exit.Ok
 
@@ -159,32 +180,29 @@ object Tests extends Suite(m"Profanity Tests"):
             Tmux.enter('\r')
         . aspire(_.contains(t"RESULT:hello"))
 
-        // Bug reproducer: when input wraps onto a second visual row in the terminal and
-        // the user then deletes back across the wrap boundary, the renderer in
-        // profanity.Interaction.lineEditor uses single-line ANSI cursor moves and never
-        // erases the wrapped row. The logical state is still correct (so RESULT: is
-        // right), but the screen retains the original wrapped characters.
+        // Wrap-aware redraw: typing past the terminal width and then backspacing back
+        // across the wrap boundary must clear the wrapped row and reposition the cursor.
 
         test(m"submits correct text after wrap and backspace"):
           Bash.tmux(width = 20, height = 10):
             val tool = summon[Enclave.Tool].command
-            Tmux.enter(tool, ' ', t"line-editor")
+            Tmux.enter(tool, ' ', t"line-editor-sized 20 10")
             Tmux.enter('\r')
             if !waitFor(t"READY") then panic(m"profanity fixture did not become ready")
-            Tmux.enter(t"a"*25)
+            Tmux.enter(t"X"*25)
             Tmux.enter('', '', '', '', '')
             Tmux.enter('\r')
             waitFor(t"RESULT:")
             Tmux.screenshot().screen.toList.join
-        . assert(_.contains(t"RESULT:${t"a"*20}"))
+        . assert(_.contains(t"RESULT:${t"X"*20}"))
 
         test(m"backspace clears characters wrapped onto the next visual line"):
           Bash.tmux(width = 20, height = 10):
             val tool = summon[Enclave.Tool].command
-            Tmux.enter(tool, ' ', t"line-editor")
+            Tmux.enter(tool, ' ', t"line-editor-sized 20 10")
             Tmux.enter('\r')
             if !waitFor(t"READY") then panic(m"profanity fixture did not become ready")
-            Tmux.attend(Tmux.enter(t"a"*25))
+            Tmux.attend(Tmux.enter(t"X"*25))
             delay(0.1*Second)
             Tmux.attend:
               Tmux.enter('', '', '', '', '')
@@ -192,8 +210,29 @@ object Tests extends Suite(m"Profanity Tests"):
             val mid = Tmux.screenshot()
             Tmux.enter('\r')
             waitFor(t"RESULT:")
-            mid.screen.toList.map(_.count(_ == 'a')).sum
-        . aspire(_ == 20)
+            mid.screen.toList.map(_.count(_ == 'X')).sum
+        . assert(_ == 20)
+
+        // SelectMenu wrap-aware redraw: an option longer than the terminal width must
+        // occupy the right number of visual rows when computing the move-back-to-anchor.
+        // Capture the menu immediately after it appears (before any arrow-key navigation,
+        // which is flaky under daemon-mode ESC timing) and confirm the wrapped option's
+        // tail appears exactly once on screen.
+        test(m"select-menu draws a wrapping option without ghost rows"):
+          Bash.tmux(width = 20, height = 12):
+            val tool = summon[Enclave.Tool].command
+            Tmux.enter(tool, ' ', t"select-menu-long-sized 20 12")
+            Tmux.enter('\r')
+            if !waitFor(t"READY") then panic(m"profanity fixture did not become ready")
+            delay(0.3*Second)
+            val mid = Tmux.screenshot()
+            Tmux.enter('\r')
+            waitFor(t"RESULT:")
+            // The third option ("third") must appear exactly once. If the renderer
+            // miscounts visual rows for the wrapped second option, the menu drifts
+            // on subsequent re-renders and stale copies of "third" pile up.
+            mid.screen.toList.count(_.contains(t"third"))
+        . assert(_ == 1)
 
     // Pure state-transition tests, bypassing terminal IO. These exercise the
     // Iterator[TerminalEvent] -> recur path with synthetic events and a no-op


### PR DESCRIPTION
The Profanity widgets used to issue single-line ANSI cursor moves regardless of terminal width, so as soon as a `LineEditor` value wrapped past the pane width or a `SelectMenu` option exceeded the column count, the renderer left ghost characters on prior visual rows and mispositioned the cursor on subsequent re-renders. The state model was always correct — the corruption was purely visual.

### Width-aware rendering

The `lineEditor` and `selectMenu` `Interaction` givens now require a `Terminal` rather than a `Stdio`, so the renderers can read `terminal.knownColumns` at render time. Each render performs a multi-row clear-and-redraw:

* move from the previous cursor back to the editor's anchor row using `\e[<n>F` (CPL);
* clear from the anchor to end of screen with `\e[J`, removing any wrapped overflow;
* print the value, letting the terminal auto-wrap;
* compute the new logical cursor's visual row/column and reposition with `\e[<n>B` and `\e[<col>G`.

`SelectMenu` accumulates the visual rows used per option (`ceil((prefix + option).length / cols)`) so the move-back-to-anchor at the end of each render is right even when an option spans multiple visual rows.

### Tests

The previously aspirational `backspace clears characters wrapped onto the next visual line` is now a regular `.assert`, and a new `select-menu draws a wrapping option without ghost rows` test confirms the analogous fix for `SelectMenu`. Two new fixture variants — `line-editor-sized <w> <h>` and `select-menu-long-sized <w> <h>` — let the test set `terminal.columns`/`terminal.rows` directly, avoiding `TerminalSizeDetection` (which the existing fixture disables to keep the size-response sequence from racing through the keyboard parser).