### PR TITLE
Increase the heap size

### DIFF
--- a/.mill-jvm-opts
+++ b/.mill-jvm-opts
@@ -1,2 +1,2 @@
 -Xss2m
--Xmx3g
+-Xmx6g


### PR DESCRIPTION
Increases Mill's heap size given to Java.

Hopefully this will eliminate the out-of-memory errors.
