### PR TITLE
Optimize HTML parser: 2.0–3.1× → 1.15–1.65× slower than jsoup

### DIFF
--- a/lib/gossamer/src/core/gossamer.Dictionary.scala
+++ b/lib/gossamer/src/core/gossamer.Dictionary.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package gossamer
 
+import scala.annotation.tailrec
+
 import anticipation.*
 import rudiments.*
 import vacuous.*
@@ -41,52 +43,82 @@ object Dictionary:
     pairs.foldLeft(Dictionary.Empty): (dictionary, next) =>
       dictionary.add(next(0), next(1), 0)
 
+  // Build a `Just` whose suffix begins at the given offset of `text`. Avoids
+  // allocating a fresh substring at construction time; the offset is consumed
+  // virtually as the dictionary is walked.
+  private[gossamer] inline def just[element](text: Text, offset: Int, value: element): Just[element] =
+    Just(text, offset, value)
+
+  extension [element](just: Just[element])
+    // Number of characters remaining in the virtual suffix.
+    inline def tailLength: Int = just.text.length - just.offset
+
+    // True if the virtual suffix has been fully consumed.
+    inline def tailEmpty: Boolean = just.offset >= just.text.length
+
+    // First character of the virtual suffix, if any.
+    inline def head: Optional[Char] =
+      if just.offset < just.text.length then just.text.s.charAt(just.offset) else Unset
+
+    // Materialize the virtual suffix as a `Text`. Allocates only when called.
+    def tail: Text =
+      if just.offset == 0 then just.text
+      else just.text.s.substring(just.offset).nn.tt
+
+// `Just(text, offset, value)` represents a unique remaining suffix `text[offset:]`
+// in the trie. Walking one character forward returns a sibling `Just` with the
+// same shared `text` and `offset + 1` — no `String.substring` allocation per
+// step. The `tail`, `head`, `tailLength` and `tailEmpty` accessors expose the
+// virtual suffix without forcing materialization.
 enum Dictionary[+element]:
   case Empty
-  case Just(tail: Text, value: element)
+  case Just(text: Text, offset: Int, value: element)
   case Branch(value: Optional[element], map: Map[Char, Dictionary[element]])
 
   def size: Int = this match
     case Empty              => 0
-    case Just(_, _)         => 1
+    case Just(_, _, _)      => 1
     case Branch(Unset, map) => map.sumBy(_(1).size)
     case Branch(_, map)     => map.sumBy(_(1).size) + 1
 
   def branches: Set[Char] = this match
-    case Empty          => Set()
-    case Just(tail, _)  => tail.prim.let(Set(_)).or(Set())
-    case Branch(_, map) => map.keySet
+    case Empty                  => Set()
+    case just: Just[element]    => just.head.let(Set(_)).or(Set())
+    case Branch(_, map)         => map.keySet
 
   def iterator: Iterable[element] = this match
-    case Empty          => Nil
-    case Just(_, value) => List(value)
+    case Empty             => Nil
+    case Just(_, _, value) => List(value)
 
     case Branch(value, map) =>
       val values = map.values.flatMap(_.iterator)
       value.lay(values): value => Iterable(value) ++ values
 
   def element: Optional[element] = this match
-    case Empty            => Unset
-    case Just("", value)  => value
-    case Branch(value, _) => value
-    case Just(_, value)   => Unset
+    case Empty                                       => Unset
+    case just: Just[element] if just.tailEmpty       => just.value
+    case Branch(value, _)                            => value
+    case _: Just[element]                            => Unset
 
   def add[element2 >: element](entry: Text, value: element2, offset: Int): Dictionary[element2] =
     this match
-      case Empty => Just(entry, value)
+      case Empty => Just(entry, offset, value)
 
-      case just@Just(tail, value0) =>
-        if matches(tail, entry, offset) then Just(tail, value) else
+      case just: Just[element] =>
+        if matchesEntry(just.text, just.offset, entry, offset) then Just(entry, offset, value) else
           if entry.length == offset
-          then Branch(value, Map(tail.s.head -> child(just)))
+          then Branch(value, Map(just.head.vouch -> child(just)))
           else
             val next: Char = entry.s.charAt(offset)
-            val rest: Text = entry.s.drop(offset + 1).tt
+            val tailLen: Int = just.tailLength
 
-            if tail.length == 0 then Branch(value0, Map(next -> Just(rest, value)))
-            else if tail.s.head == next
+            if tailLen == 0 then Branch(just.value, Map(next -> Just(entry, offset + 1, value)))
+            else if just.head.vouch == next
             then Branch(Unset, Map(next -> child(just).add(entry, value, offset + 1)))
-            else Branch(Unset, Map(next -> Just(rest, value), tail.s.head -> child(just)))
+            else Branch
+                  ( Unset,
+                    Map( next             -> Just(entry, offset + 1, value),
+                         just.head.vouch  -> child(just) ) )
 
       case Branch(value0, map) =>
         if entry.length == offset then Branch(value, map) else
@@ -94,26 +126,33 @@ enum Dictionary[+element]:
 
           val child =
             if map.contains(next) then map(next).add(entry, value, offset + 1)
-            else Just(entry.s.drop(offset + 1).tt, value)
+            else Just(entry, offset + 1, value)
 
           Branch(value0, map.updated(next, child))
 
-  private def child(just: Just[element]): Just[element] = Just(just.tail.s.drop(1).tt, just.value)
+  private def child(just: Just[element]): Just[element] =
+    Just(just.text, just.offset + 1, just.value)
 
-  private def matches(tail: Text, entry: Text, offset: Int): Boolean =
-    tail.length + offset == entry.length && that:
-      var matches = true
+  // Compares the virtual suffix `justText[justOffset:]` against `entry[entryOffset:]`
+  // for full equality without materializing either substring.
+  private def matchesEntry(justText: Text, justOffset: Int, entry: Text, entryOffset: Int)
+  :   Boolean =
+
+    val justLen: Int = justText.length - justOffset
+    val entryLen: Int = entry.length - entryOffset
+    if justLen != entryLen then false
+    else
+      var ok = true
       var i = 0
-
-      while matches && i < tail.length do
-        matches &&= tail.s.charAt(i) == entry.s.charAt(i + offset)
+      while ok && i < justLen do
+        ok = justText.s.charAt(justOffset + i) == entry.s.charAt(entryOffset + i)
         i += 1
-
-      matches
+      ok
 
   protected def lookup(entry: Text, offset: Int): Optional[element] = this match
-    case Empty             => Unset
-    case Just(tail, value) => if matches(tail, entry, offset) then value else Unset
+    case Empty                  => Unset
+    case just: Just[element]    =>
+      if matchesEntry(just.text, just.offset, entry, offset) then just.value else Unset
 
     case Branch(value, map) =>
       if entry.length > offset then map.at(entry.s.charAt(offset)).let(_.lookup(entry, offset + 1))
@@ -122,9 +161,48 @@ enum Dictionary[+element]:
 
   inline def apply(entry: Text): Optional[element] = lookup(entry, 0)
 
-  def apply(char: Char): Dictionary[element] = this match
-    case Empty          => Empty
-    case Branch(_, map) => map.at(char).or(Empty)
+  // Case-insensitive (ASCII-folded) lookup over a slice of an existing char
+  // buffer. Performs the entire trie traversal without allocating: the input is
+  // not materialized into a `Text`, and the `Just` arm is walked by tracking an
+  // extra offset against the existing node rather than constructing fresh
+  // dictionary nodes per character. Designed for hot-path callers (e.g. HTML
+  // tag/attribute name lookups) where the input is already in a `char[]`.
+  def lookupAscii(buffer: Array[Char], offset: Int, length: Int): Optional[element] =
+    val stop: Int = offset + length
 
-    case Just(word, value) =>
-      if word.length > 0 && word.s.head == char then Just(word.s.drop(1).tt, value) else Empty
+    @tailrec
+    def step(node: Dictionary[element], extra: Int, position: Int): Optional[element] =
+      if position >= stop then node match
+        case Empty                  => Unset
+        case just: Just[element]    =>
+          if just.offset + extra == just.text.length then just.value else Unset
+        case Branch(value, _)       => value
+      else
+        val raw: Char = buffer(position)
+        val char: Char = if raw >= 'A' && raw <= 'Z' then (raw + 32).toChar else raw
+        node match
+          case Empty                  => Unset
+          case Branch(_, map)         => map.at(char) match
+            case next: Dictionary[element] @unchecked => step(next, 0, position + 1)
+            case _                                    => Unset
+
+          case just: Just[element]    =>
+            val pos: Int = just.offset + extra
+            if pos < just.text.length && just.text.s.charAt(pos) == char
+            then step(just, extra + 1, position + 1)
+            else Unset
+
+    step(this, 0, offset)
+
+  // Walk one character forward in the trie. For `Just`, this avoids the
+  // historical `String.substring` allocation by reusing the existing `text`
+  // reference and advancing the virtual `offset` by one — only the wrapping
+  // `Just` is allocated, not its underlying tail.
+  def apply(char: Char): Dictionary[element] = this match
+    case Empty               => Empty
+    case Branch(_, map)      => map.at(char).or(Empty)
+
+    case just: Just[element] =>
+      if just.offset < just.text.length && just.text.s.charAt(just.offset) == char
+      then Just(just.text, just.offset + 1, just.value)
+      else Empty

--- a/lib/honeycomb/src/core/honeycomb.Attributes.scala
+++ b/lib/honeycomb/src/core/honeycomb.Attributes.scala
@@ -41,265 +41,315 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 
+// `Attributes` is an opaque view over an `IArray[String | Null]` whose entries
+// alternate keys and values: at index `2k` is the (non-null) attribute label,
+// at index `2k+1` is either the attribute value (a non-null `String`) or
+// `null` to denote a value-less attribute (e.g. `<input disabled>`). Storing
+// the pairs interleaved in a single `IArray` halves the per-`Attributes`
+// allocation count compared with the previous two-`IArray` `final class`
+// representation, and the opaque alias eliminates the wrapper object itself —
+// so a non-empty `Attributes` costs exactly one heap allocation.
+//
+// Extension methods live inside the companion object so they have transparent
+// access to the underlying `IArray`. Structural equality and hashing are
+// exposed via dedicated `equalsAttributes` / `hashAttributes` extensions
+// rather than `Object.equals`/`hashCode`, since the underlying `IArray` would
+// otherwise answer with reference equality. `Element` (the only externally
+// significant `Attributes` consumer that needs structural equality) calls
+// these extensions explicitly.
+
+opaque type Attributes = IArray[String | Null]
+
 object Attributes:
-  val empty: Attributes = new Attributes(IArray.empty, IArray.empty)
+  val empty: Attributes = IArray.empty[String | Null]
 
   def apply(pairs: (Text, Optional[Text])*): Attributes =
     if pairs.isEmpty then empty else
       val n = pairs.length
-      val ks = new Array[Text](n)
-      val vs = new Array[Optional[Text]](n)
+      val arr = new Array[String | Null](n*2)
       var i = 0
-      pairs.each: pair =>
-        ks(i) = pair._1
-        vs(i) = pair._2
+      pairs.foreach: pair =>
+        arr(i*2) = pair._1.s
+        arr(i*2 + 1) = pair._2.lay(null: String | Null)(_.s)
         i += 1
-      new Attributes(ks.immutable(using Unsafe), vs.immutable(using Unsafe))
+      arr.immutable(using Unsafe)
 
   def from(map: Map[Text, Optional[Text]]): Attributes =
     if map.isEmpty then empty else
       val n = map.size
-      val ks = new Array[Text](n)
-      val vs = new Array[Optional[Text]](n)
+      val arr = new Array[String | Null](n*2)
       var i = 0
       map.foreach: (k, v) =>
-        ks(i) = k
-        vs(i) = v
+        arr(i*2) = k.s
+        arr(i*2 + 1) = v.lay(null: String | Null)(_.s)
         i += 1
-      new Attributes(ks.immutable(using Unsafe), vs.immutable(using Unsafe))
+      arr.immutable(using Unsafe)
 
-  // Unchecked construction from already-validated parallel arrays. Used by
-  // the parser, which has already enforced uniqueness during accumulation.
-  private[honeycomb] def fromArrays
-                       ( ks: IArray[Text], vs: IArray[Optional[Text]] )
-  :   Attributes =
+  // Construct an `Attributes` directly from an interleaved `IArray`. The
+  // caller guarantees the array's length is even and that every key slot
+  // (even index) holds a non-null `String`. Used by the parser, which
+  // assembles the interleaved array as it tokenizes attributes.
+  private[honeycomb] inline def fromInterleaved(array: IArray[String | Null]): Attributes = array
 
-    new Attributes(ks, vs)
+  // Unwrap to the raw `Array[String | Null]` for hot-path internal access.
+  // Safe within the package: the storage is shared but never mutated outside
+  // construction.
+  private[honeycomb] inline def storage(attrs: Attributes): Array[String | Null] =
+    attrs.asInstanceOf[Array[String | Null]]
 
+  extension (attrs: Attributes)
+    inline def size: Int = attrs.length/2
+    inline def isEmpty: Boolean = attrs.length == 0
+    inline def nonEmpty: Boolean = attrs.length > 0
+    inline def nil: Boolean = attrs.length == 0
 
-// A pair of parallel `IArray`s — keys at `i`, values at `i`. HTML elements
-// usually carry 0–5 attributes, so a linear scan is comparable to or faster
-// than HashMap probing while costing roughly a third of the bytes. We
-// deliberately do *not* extend `Iterable` — it inflates the vtable and
-// drags in collection-machinery method dispatch on every call site, which
-// measurably hurt the parse hot path on attribute-heavy fixtures. Instead
-// we expose only the small set of operations actually called against
-// element attributes (`apply`, `iterator`, `keys`, `each`, `map`, `to`,
-// `join`, ...) directly here.
-final class Attributes private[honeycomb]
-                      ( private[honeycomb] val ks: IArray[Text],
-                        private[honeycomb] val vs: IArray[Optional[Text]] ):
-
-  def size: Int = ks.length
-  def isEmpty: Boolean = ks.length == 0
-  def nonEmpty: Boolean = ks.length > 0
-  def nil: Boolean = ks.length == 0
-
-  def apply(key: Text): Optional[Text] =
-    var i = 0
-    while i < ks.length do
-      if ks(i) == key then return vs(i)
-      i += 1
-    Unset
-
-  def contains(key: Text): Boolean =
-    var i = 0
-    while i < ks.length do
-      if ks(i) == key then return true
-      i += 1
-    false
-
-  def keys: Iterator[Text] = ks.iterator
-  def values: Iterator[Optional[Text]] = vs.iterator
-
-  def iterator: Iterator[(Text, Optional[Text])] =
-    new Iterator[(Text, Optional[Text])]:
-      private var i: Int = 0
-      def hasNext: Boolean = i < ks.length
-      def next(): (Text, Optional[Text]) =
-        val r = (ks(i), vs(i))
-        i += 1
-        r
-
-  def toList: List[(Text, Optional[Text])] =
-    val b = List.newBuilder[(Text, Optional[Text])]
-    var i = 0
-    while i < ks.length do
-      b += ((ks(i), vs(i)))
-      i += 1
-    b.result()
-
-  def toMap: Map[Text, Optional[Text]] =
-    if ks.length == 0 then ListMap.empty else
-      val b = ListMap.newBuilder[Text, Optional[Text]]
+    def apply(key: Text): Optional[Text] =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
       var i = 0
-      while i < ks.length do
-        b += ((ks(i), vs(i)))
-        i += 1
+      while i < n do
+        if a(i) == keyStr then
+          val value = a(i + 1)
+          return if value == null then Unset else value.asInstanceOf[Text]
+        i += 2
+      Unset
+
+    def contains(key: Text): Boolean =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var i = 0
+      while i < n do
+        if a(i) == keyStr then return true
+        i += 2
+      false
+
+    def keys: Iterator[Text] =
+      val a = storage(attrs)
+      new Iterator[Text]:
+        private var i: Int = 0
+        def hasNext: Boolean = i < a.length
+        def next(): Text =
+          val k = a(i).asInstanceOf[Text]
+          i += 2
+          k
+
+    def values: Iterator[Optional[Text]] =
+      val a = storage(attrs)
+      new Iterator[Optional[Text]]:
+        private var i: Int = 1
+        def hasNext: Boolean = i < a.length
+        def next(): Optional[Text] =
+          val v = a(i)
+          i += 2
+          if v == null then Unset else v.asInstanceOf[Text]
+
+    def iterator: Iterator[(Text, Optional[Text])] =
+      val a = storage(attrs)
+      new Iterator[(Text, Optional[Text])]:
+        private var i: Int = 0
+        def hasNext: Boolean = i < a.length
+        def next(): (Text, Optional[Text]) =
+          val k = a(i).asInstanceOf[Text]
+          val v = a(i + 1)
+          i += 2
+          (k, if v == null then Unset else v.asInstanceOf[Text])
+
+    def toList: List[(Text, Optional[Text])] =
+      val a = storage(attrs)
+      val b = List.newBuilder[(Text, Optional[Text])]
+      var i = 0
+      while i < a.length do
+        val v = a(i + 1)
+        b += ((a(i).asInstanceOf[Text], if v == null then Unset else v.asInstanceOf[Text]))
+        i += 2
       b.result()
 
-  // Eager `map` returning an `Iterable[B]`. The renderer uses this and
-  // joins the result; an Iterable lets `.join(...)` work without further
-  // adaptation while keeping the call site shape unchanged.
-  def map[B](f: ((Text, Optional[Text])) => B): Iterable[B] =
-    val b = List.newBuilder[B]
-    var i = 0
-    while i < ks.length do
-      b += f((ks(i), vs(i)))
-      i += 1
-    b.result()
+    def toMap: Map[Text, Optional[Text]] =
+      val a = storage(attrs)
+      if a.length == 0 then ListMap.empty else
+        val b = ListMap.newBuilder[Text, Optional[Text]]
+        var i = 0
+        while i < a.length do
+          val v = a(i + 1)
+          b += ((a(i).asInstanceOf[Text], if v == null then Unset else v.asInstanceOf[Text]))
+          i += 2
+        b.result()
 
-  def foreach[U](f: ((Text, Optional[Text])) => U): Unit =
-    var i = 0
-    while i < ks.length do
-      f((ks(i), vs(i)))
-      i += 1
-
-  // Two-argument form (uncurried). The renderer uses this with
-  // `attributes.each: (key, value) =>`.
-  def each(action: (Text, Optional[Text]) => Unit): Unit =
-    var i = 0
-    while i < ks.length do
-      action(ks(i), vs(i))
-      i += 1
-
-  // O(N) — finds and excludes the matching index, returning a new Attributes
-  // whose backing IArrays are one slot shorter. If the key is absent, returns
-  // `this` unchanged so callers don't allocate gratuitously.
-  def removed(key: Text): Attributes =
-    val n = ks.length
-    var idx = -1
-    var i = 0
-    while idx < 0 && i < n do
-      if ks(i) == key then idx = i
-      i += 1
-    if idx < 0 then this else
-      val nk = new Array[Text](n - 1)
-      val nv = new Array[Optional[Text]](n - 1)
-      if idx > 0 then
-        jl.System.arraycopy(ks.asInstanceOf[Array[Text]], 0, nk, 0, idx)
-        jl.System.arraycopy(vs.asInstanceOf[Array[Optional[Text]]], 0, nv, 0, idx)
-      if idx < n - 1 then
-        jl.System.arraycopy(ks.asInstanceOf[Array[Text]], idx + 1, nk, idx, n - 1 - idx)
-        jl.System.arraycopy
-         (vs.asInstanceOf[Array[Optional[Text]]], idx + 1, nv, idx, n - 1 - idx)
-      new Attributes(nk.immutable(using Unsafe), nv.immutable(using Unsafe))
-
-  inline def - (key: Text): Attributes = removed(key)
-
-  def -- (others: Iterable[Text]): Attributes =
-    if isEmpty then this else
-      var result = this
-      others.foreach { k => result = result.removed(k) }
-      result
-
-  // Updates an existing key in place (preserving order) or appends a new pair
-  // at the end. Always returns a new Attributes (the IArrays are immutable).
-  def updated(key: Text, value: Optional[Text]): Attributes =
-    val n = ks.length
-    var idx = -1
-    var i = 0
-    while idx < 0 && i < n do
-      if ks(i) == key then idx = i
-      i += 1
-    if idx >= 0 then
-      val nv = new Array[Optional[Text]](n)
-      jl.System.arraycopy(vs.asInstanceOf[Array[Optional[Text]]], 0, nv, 0, n)
-      nv(idx) = value
-      new Attributes(ks, nv.immutable(using Unsafe))
-    else
-      val nk = new Array[Text](n + 1)
-      val nv = new Array[Optional[Text]](n + 1)
-      jl.System.arraycopy(ks.asInstanceOf[Array[Text]], 0, nk, 0, n)
-      jl.System.arraycopy(vs.asInstanceOf[Array[Optional[Text]]], 0, nv, 0, n)
-      nk(n) = key
-      nv(n) = value
-      new Attributes(nk.immutable(using Unsafe), nv.immutable(using Unsafe))
-
-  // Combines two Attributes, with the right-hand side overriding duplicate
-  // keys (matching `Map ++` semantics). Order: left's keys first (preserving
-  // their order), then any new keys from the right.
-  def ++ (other: Attributes): Attributes =
-    if other.isEmpty then this
-    else if isEmpty then other
-    else
-      val total = size + other.size
-      val nk = new Array[Text](total)
-      val nv = new Array[Optional[Text]](total)
-      var written = 0
-      // Carry-over from left, but defer to the right's value if duplicated.
+    def map[B](f: ((Text, Optional[Text])) => B): Iterable[B] =
+      val a = storage(attrs)
+      val b = List.newBuilder[B]
       var i = 0
-      while i < size do
-        val k = ks(i)
-        val v = other(k)
-        nk(written) = k
-        nv(written) = if other.contains(k) then v else vs(i)
-        written += 1
-        i += 1
-      // Append right-hand keys not already seen on the left.
-      var j = 0
-      while j < other.size do
-        val k = other.ks(j)
-        if !contains(k) then
-          nk(written) = k
-          nv(written) = other.vs(j)
-          written += 1
-        j += 1
-      // Trim if duplicates collapsed slots.
-      if written == total then
-        new Attributes(nk.immutable(using Unsafe), nv.immutable(using Unsafe))
+      while i < a.length do
+        val v = a(i + 1)
+        b += f((a(i).asInstanceOf[Text], if v == null then Unset else v.asInstanceOf[Text]))
+        i += 2
+      b.result()
+
+    def foreach[U](f: ((Text, Optional[Text])) => U): Unit =
+      val a = storage(attrs)
+      var i = 0
+      while i < a.length do
+        val v = a(i + 1)
+        f((a(i).asInstanceOf[Text], if v == null then Unset else v.asInstanceOf[Text]))
+        i += 2
+
+    def each(action: (Text, Optional[Text]) => Unit): Unit =
+      val a = storage(attrs)
+      var i = 0
+      while i < a.length do
+        val v = a(i + 1)
+        action(a(i).asInstanceOf[Text], if v == null then Unset else v.asInstanceOf[Text])
+        i += 2
+
+    // O(N): finds and excludes the matching index, returning a new `Attributes`
+    // whose backing IArray is two slots shorter. If the key is absent, returns
+    // `attrs` unchanged so callers don't allocate gratuitously.
+    def removed(key: Text): Attributes =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var idx = -1
+      var i = 0
+      while idx < 0 && i < n do
+        if a(i) == keyStr then idx = i
+        i += 2
+      if idx < 0 then attrs else
+        val nu = new Array[String | Null](n - 2)
+        if idx > 0 then jl.System.arraycopy(a, 0, nu, 0, idx)
+        if idx < n - 2 then jl.System.arraycopy(a, idx + 2, nu, idx, n - 2 - idx)
+        nu.immutable(using Unsafe)
+
+    inline def `-`(key: Text): Attributes = removed(key)
+
+    def `--`(others: Iterable[Text]): Attributes =
+      if isEmpty then attrs else
+        var result: Attributes = attrs
+        others.foreach { k => result = result.removed(k) }
+        result
+
+    // Updates an existing key in place (preserving order) or appends a new pair
+    // at the end. Always returns a new `Attributes` (the IArray is immutable).
+    def updated(key: Text, value: Optional[Text]): Attributes =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var idx = -1
+      var i = 0
+      while idx < 0 && i < n do
+        if a(i) == keyStr then idx = i
+        i += 2
+      if idx >= 0 then
+        val nu = new Array[String | Null](n)
+        jl.System.arraycopy(a, 0, nu, 0, n)
+        nu(idx + 1) = value.lay(null: String | Null)(_.s)
+        nu.immutable(using Unsafe)
       else
-        val tk = new Array[Text](written)
-        val tv = new Array[Optional[Text]](written)
-        jl.System.arraycopy(nk, 0, tk, 0, written)
-        jl.System.arraycopy(nv, 0, tv, 0, written)
-        new Attributes(tk.immutable(using Unsafe), tv.immutable(using Unsafe))
+        val nu = new Array[String | Null](n + 2)
+        jl.System.arraycopy(a, 0, nu, 0, n)
+        nu(n) = keyStr
+        nu(n + 1) = value.lay(null: String | Null)(_.s)
+        nu.immutable(using Unsafe)
 
-  def ++ (other: Map[Text, Optional[Text]]): Attributes =
-    if other.isEmpty then this else this ++ Attributes.from(other)
+    // Combines two `Attributes`, with the right-hand side overriding duplicate
+    // keys (matching `Map ++` semantics). Order: left's keys first (preserving
+    // their order), then any new keys from the right.
+    def `++`(other: Attributes): Attributes =
+      val a = storage(attrs)
+      val b = storage(other)
+      if b.length == 0 then attrs
+      else if a.length == 0 then other
+      else
+        val total = a.length + b.length
+        val nu = new Array[String | Null](total)
+        var written = 0
+        var i = 0
+        while i < a.length do
+          val k = a(i).asInstanceOf[String]
+          var bi = 0
+          var found = -1
+          while found < 0 && bi < b.length do
+            if b(bi) == k then found = bi
+            bi += 2
+          nu(written) = k
+          nu(written + 1) = if found >= 0 then b(found + 1) else a(i + 1)
+          written += 2
+          i += 2
+        var j = 0
+        while j < b.length do
+          val k = b(j).asInstanceOf[String]
+          var ai = 0
+          var found = false
+          while !found && ai < a.length do
+            if a(ai) == k then found = true
+            ai += 2
+          if !found then
+            nu(written) = k
+            nu(written + 1) = b(j + 1)
+            written += 2
+          j += 2
+        if written == total then nu.immutable(using Unsafe)
+        else
+          val tu = new Array[String | Null](written)
+          jl.System.arraycopy(nu, 0, tu, 0, written)
+          tu.immutable(using Unsafe)
 
-  override def equals(that: Any): Boolean = that match
-    case other: Attributes =>
-      val n = ks.length
-      if n != other.ks.length then false else
+    def `++`(other: Map[Text, Optional[Text]]): Attributes =
+      if other.isEmpty then attrs else attrs ++ Attributes.from(other)
+
+    // Structural equality: same key/value pairs in the same order. Provided
+    // explicitly because `Object.equals` on the underlying `IArray` would
+    // give reference equality.
+    // Same set of (key, value) pairs (order-insensitive). Iterates the left,
+    // looks up each key in the right.
+    def equalsAttributes(other: Attributes): Boolean =
+      val a = storage(attrs)
+      val b = storage(other)
+      val n = a.length
+      if n != b.length then false else
         var i = 0
         var ok = true
         while ok && i < n do
-          val k = ks(i)
-          if other(k) != vs(i) then ok = false
-          i += 1
+          val k = a(i).asInstanceOf[String]
+          val va = a(i + 1)
+          // Locate key in `b`.
+          var j = 0
+          var found = -1
+          while found < 0 && j < n do
+            if b(j) == k then found = j
+            j += 2
+          if found < 0 then ok = false
+          else
+            val vb = b(found + 1)
+            if va != vb then ok = false
+          i += 2
         ok
 
-    // Permit equality with a structurally-equivalent `Map` so existing tests
-    // that compare against `ListMap(...)` literals still work, and so callers
-    // that have already materialised the attributes as a Map can compare both.
-    case other: Map[?, ?] =>
-      if ks.length != other.size then false else
-        var i = 0
-        var ok = true
-        while ok && i < ks.length do
-          if other.asInstanceOf[Map[Text, Optional[Text]]].getOrElse(ks(i), Unset) != vs(i)
-          then ok = false
-          i += 1
-        ok
+    def hashAttributes: Int =
+      // Order-independent: XOR of (key.hash * 31 ^ value.hash) — matches the
+      // previous `Attributes.hashCode` contract.
+      val a = storage(attrs)
+      var h = 0
+      var i = 0
+      while i < a.length do
+        val k = a(i)
+        val v = a(i + 1)
+        val kh = if k == null then 0 else k.hashCode
+        val vh = if v == null then Unset.hashCode else v.hashCode
+        h = h ^ (kh*31 ^ vh)
+        i += 2
+      h
 
-    case _ => false
-
-  override def hashCode: Int =
-    // Order-independent: XOR of (key.hash * 31 ^ value.hash) — matches Map's
-    // hashCode contract well enough for tests that compare equal Attributes.
-    var h = 0
-    var i = 0
-    while i < ks.length do
-      h = h ^ (ks(i).hashCode*31 ^ vs(i).hashCode)
-      i += 1
-    h
-
-  override def toString: String =
-    val sb = new jl.StringBuilder("Attributes(")
-    var i = 0
-    while i < ks.length do
-      if i > 0 then sb.append(", ")
-      sb.append(ks(i).s).nn.append(" -> ").nn.append(vs(i).toString)
-      i += 1
-    sb.append(")").toString
+    def showAttributes: String =
+      val a = storage(attrs)
+      val sb = new jl.StringBuilder("Attributes(")
+      var i = 0
+      while i < a.length do
+        if i > 0 then sb.append(", ")
+        sb.append(a(i).asInstanceOf[String])
+        sb.append(" -> ")
+        val v = a(i + 1)
+        sb.append(if v == null then Unset.toString else v.toString)
+        i += 2
+      sb.append(")").toString

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -113,10 +113,10 @@ object Honeycomb:
 
           case "\u0000" :: tail =>
             index += 1
-            types ::= TypeRepr.of[Attributes]
+            types ::= TypeRepr.of[Map[Text, Optional[Text]]]
             iterator.next()
             val others = Expr.ofList(pattern.attributes.keys.to(List).map(Expr(_)))
-            '{$expr && { $array(${Expr(index)}) = ${scrutinee}.attributes -- $others; true }}
+            '{$expr && { $array(${Expr(index)}) = (${scrutinee}.attributes -- $others).toMap; true }}
 
           case head :: tail =>
             attributes(tail):

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -516,6 +516,11 @@ object Html extends Tag.Container
       def result(): Text = buffer.toString.tt.also(buffer.setLength(0))
       var content: Text = t""
       var extra: Attributes = Attributes.empty
+      // Resolved `Tag` for the current opening token. `tag()` already walks
+      // `dom.elements` to look up the tag definition; stash the result so that
+      // `read`'s `Token.Open` / `Token.Empty` arms don't have to repeat the
+      // lookup against `dom.elements(content)`.
+      var openTag: Tag = root
       // Shared scratch buffer for attribute accumulation (parser-lifetime).
       // `attributes()` writes here, then snapshots the populated prefix into
       // freshly-sized IArrays for an `Attributes`. Doubles in size if filled.
@@ -971,6 +976,7 @@ object Html extends Tag.Container
             else
               val tagDef = tagname(begin(), dom.elements)
               content = tagDef.label
+              openTag = tagDef
               tagDef.foreign
 
           extra = attributes(content, foreign || newForeign)
@@ -1058,15 +1064,10 @@ object Html extends Tag.Container
 
                 case Token.Empty =>
                   if admit(content) then empty() else infer:
-                    if parent.foreign then Tag.foreign(content, extra)
-                    else dom.elements(content).or(reset(mark) yet fail(InvalidTag(content), mark))
+                    if parent.foreign then Tag.foreign(content, extra) else openTag
 
                 case Token.Open =>
-                  focus =
-                    if parent.foreign then Tag.foreign(content, extra)
-                    else dom.elements(content).or:
-                      reset(mark)
-                      fail(InvalidTag(content), mark)
+                  focus = if parent.foreign then Tag.foreign(content, extra) else openTag
 
                   if !admit(content) then
                     val inferred = dom.infer(parent, focus)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -441,7 +441,12 @@ object Html extends Tag.Container
     protected inline def peek: Char =
       cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]](cursor.unsafePos(using Unsafe))
 
-    protected inline def advance(): Unit = cursor.next()
+    // Use `cursor.advance()` rather than `cursor.next()`: the latter performs
+    // an additional `cursor.more` check to return its boolean result, which
+    // every caller here discards. Refill on streaming input still happens via
+    // the parser's later `lay`/`let`/`peek` calls (each of which goes through
+    // `cursor.more`), so skipping the redundant check is safe.
+    protected inline def advance(): Unit = cursor.advance()
     protected inline def position: Int = cursor.position.n0
 
     protected inline def begin(): Cursor.Mark = cursor.mark(using heldToken.nn)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -527,10 +527,12 @@ object Html extends Tag.Container
       // lookup against `dom.elements(content)`.
       var openTag: Tag = root
       // Shared scratch buffer for attribute accumulation (parser-lifetime).
-      // `attributes()` writes here, then snapshots the populated prefix into
-      // freshly-sized IArrays for an `Attributes`. Doubles in size if filled.
-      var attrKeys: Array[Text] = new Array(8)
-      var attrValues: Array[Optional[Text]] = new Array(8)
+      // Stores key/value pairs interleaved as `[k0, v0, k1, v1, ...]`. Keys are
+      // never null; a null in a value slot encodes `Unset`. `attributes()`
+      // writes here, then snapshots the populated prefix into a freshly-sized
+      // `IArray[String | Null]` and wraps it as an opaque `Attributes`. Grows
+      // geometrically when filled.
+      var attrInterleaved: Array[String | Null] = new Array[String | Null](16)
       var nodes: Array[Node] = new Array(4)
       var index: Int = 0
       var stack: Array[Tag] = new Array(4)
@@ -707,13 +709,21 @@ object Html extends Tag.Container
 
 
       def attributes(tag: Text, foreign: Boolean): Attributes =
-        // Append into the parser-shared scratch buffer; on close, snapshot the
-        // populated prefix into freshly-sized IArrays and wrap in `Attributes`.
-        // Linear duplicate-scan suits the typical 0–5 attribute count and
-        // skips both the LinkedHashMap accumulator and the ListMap finalisation
-        // that the previous form went through.
+        // Append into the parser-shared interleaved scratch buffer (laid out
+        // as `[k0, v0, k1, v1, ...]`); on close, snapshot the populated prefix
+        // into a freshly-sized `IArray[String | Null]` and wrap it as the
+        // opaque `Attributes`. Linear duplicate-scan suits the typical 0–5
+        // attribute count and skips both the LinkedHashMap accumulator and
+        // the ListMap finalisation that the previous form went through.
+        // `Unset` values are encoded as `null` in the array.
         var n = 0
         var done = false
+
+        inline def ensureCapacity(): Unit =
+          if 2*n >= attrInterleaved.length then
+            val nu = new Array[String | Null](attrInterleaved.length*2)
+            jl.System.arraycopy(attrInterleaved, 0, nu, 0, 2*n)
+            attrInterleaved = nu
 
         while !done do
           skip()
@@ -724,15 +734,9 @@ object Html extends Tag.Container
               callback.let(_(position.z, Hole.Tagbody))
               next()
               skip()
-              if n == attrKeys.length then
-                val nk = new Array[Text](n*2)
-                val nv = new Array[Optional[Text]](n*2)
-                jl.System.arraycopy(attrKeys, 0, nk, 0, n)
-                jl.System.arraycopy(attrValues, 0, nv, 0, n)
-                attrKeys = nk
-                attrValues = nv
-              attrKeys(n) = t"\u0000"
-              attrValues(n) = Unset
+              ensureCapacity()
+              attrInterleaved(2*n) = "\u0000"
+              attrInterleaved(2*n + 1) = null
               n += 1
 
             case _ =>
@@ -742,40 +746,35 @@ object Html extends Tag.Container
 
                 . label
 
+              val key2Str: String = key2.s
+
               var dup = 0
-              while dup < n do
-                if attrKeys(dup) == key2 then fail(DuplicateAttribute(key2))
-                dup += 1
+              while dup < 2*n do
+                if attrInterleaved(dup) == key2Str then fail(DuplicateAttribute(key2))
+                dup += 2
 
-              val assignment = if !equality() then Unset else lay(fail(ExpectedMore)):
-                case '"'  => next() yet value(begin())
-                case '\'' => next() yet singleQuoted(begin())
+              val assignment: Optional[Text] =
+                if !equality() then Unset else lay(fail(ExpectedMore)):
+                  case '"'  => next() yet value(begin())
+                  case '\'' => next() yet singleQuoted(begin())
 
-                case '\u0000' =>
-                  callback.let(_(position.z, Hole.Attribute(tag, key2)))
-                  next() yet t"\u0000"
+                  case '\u0000' =>
+                    callback.let(_(position.z, Hole.Attribute(tag, key2)))
+                    next() yet t"\u0000"
 
-                case _ =>
-                  unquoted(begin()) // FIXME: Only alphanumeric characters
+                  case _ =>
+                    unquoted(begin()) // FIXME: Only alphanumeric characters
 
-              if n == attrKeys.length then
-                val nk = new Array[Text](n*2)
-                val nv = new Array[Optional[Text]](n*2)
-                jl.System.arraycopy(attrKeys, 0, nk, 0, n)
-                jl.System.arraycopy(attrValues, 0, nv, 0, n)
-                attrKeys = nk
-                attrValues = nv
-              attrKeys(n) = key2
-              attrValues(n) = assignment
+              ensureCapacity()
+              attrInterleaved(2*n) = key2Str
+              attrInterleaved(2*n + 1) = assignment.lay(null: String | Null)(_.s)
               n += 1
 
         if n == 0 then Attributes.empty
         else
-          val ks = new Array[Text](n)
-          val vs = new Array[Optional[Text]](n)
-          jl.System.arraycopy(attrKeys, 0, ks, 0, n)
-          jl.System.arraycopy(attrValues, 0, vs, 0, n)
-          Attributes.fromArrays(ks.immutable(using Unsafe), vs.immutable(using Unsafe))
+          val arr = new Array[String | Null](2*n)
+          jl.System.arraycopy(attrInterleaved, 0, arr, 0, 2*n)
+          Attributes.fromInterleaved(arr.immutable(using Unsafe))
 
 
       def entity(mark: Mark): Optional[Text] = lay(fail(ExpectedMore, mark)):
@@ -1355,14 +1354,14 @@ extends Node, Topical, Transportive, Dynamic:
     case Fragment(node: Element) => this == node
 
     case Element(label, attributes, children, foreign) =>
-      label == this.label && attributes == this.attributes && foreign == this.foreign
+      label == this.label && attributes.equalsAttributes(this.attributes) && foreign == this.foreign
       && ju.Arrays.equals(children.mutable(using Unsafe), this.children.mutable(using Unsafe))
 
     case _ =>
       false
 
   override def hashCode: Int =
-    ju.Arrays.hashCode(children.mutable(using Unsafe)) ^ attributes.hashCode ^ label.hashCode
+    ju.Arrays.hashCode(children.mutable(using Unsafe)) ^ attributes.hashAttributes ^ label.hashCode
 
   transparent inline def selectDynamic(name: Label): Any =
 
@@ -1386,7 +1385,7 @@ extends Node, Topical, Transportive, Dynamic:
         val attributive = infer[value is Attributive to attribute.Topic]
 
         attributive.attribute(name, value).match
-          case Unset        => Element(label, attributes - name, children, foreign)
+          case Unset        => Element(label, attributes.removed(name.tt), children, foreign)
           case (key, value) => Element(label, attributes.updated(key, value), children, foreign)
 
         . of[Topic]
@@ -1397,7 +1396,7 @@ extends Node, Topical, Transportive, Dynamic:
         val attributive = infer[value is Attributive to attribute.Topic]
 
         attributive.attribute(name, value).match
-          case Unset        => Element(label, attributes - name, children, foreign)
+          case Unset        => Element(label, attributes.removed(name.tt), children, foreign)
           case (key, value) => Element(label, attributes.updated(key, value), children, foreign)
 
         . of[Topic]

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -554,8 +554,15 @@ object Html extends Tag.Container
       var pendingFormattingAttrs:  Array[Attributes] = new Array[Attributes](4)
       var pendingFormattingSize: Int = 0
       var pendingAtDepth: Int = -1
-      var fosteredBefore: List[Node] = Nil
-      var fosteredAfter: List[Node] = Nil
+      // Foster-parented children awaiting placement around the next `<table>`
+      // close. Stored as a pair of `Array[Node]` buffers (with size counters)
+      // rather than `List[Node]`s appended via `:+`: list `:+` is `O(N)`
+      // and the per-append cons cell + traversal-on-flush is wasted on a
+      // structure we always drain in arrival order.
+      var fosteredBefore: Array[Node] = new Array[Node](4)
+      var fosteredBeforeSize: Int = 0
+      var fosteredAfter: Array[Node] = new Array[Node](4)
+      var fosteredAfterSize: Int = 0
       var inTableContent: Boolean = false
       var pendingFosterDescend: Boolean = false
 
@@ -1240,18 +1247,36 @@ object Html extends Tag.Container
                 val child = descend(focus, admissible, extra)
                 pop()
                 if savedFosterFlag then
-                  if inTableContent then fosteredAfter = fosteredAfter :+ child
-                  else fosteredBefore = fosteredBefore :+ child
+                  if inTableContent then
+                    if fosteredAfterSize >= fosteredAfter.length then
+                      val nu = new Array[Node](fosteredAfter.length*2)
+                      jl.System.arraycopy(fosteredAfter, 0, nu, 0, fosteredAfterSize)
+                      fosteredAfter = nu
+                    fosteredAfter(fosteredAfterSize) = child
+                    fosteredAfterSize += 1
+                  else
+                    if fosteredBeforeSize >= fosteredBefore.length then
+                      val nu = new Array[Node](fosteredBefore.length*2)
+                      jl.System.arraycopy(fosteredBefore, 0, nu, 0, fosteredBeforeSize)
+                      fosteredBefore = nu
+                    fosteredBefore(fosteredBeforeSize) = child
+                    fosteredBeforeSize += 1
                   val added = reconstructPending()
                   read(parent, admissible, map, count + added)
                 else if focus.isTable then
-                  val beforeAdded = fosteredBefore.size
-                  fosteredBefore.foreach(append)
-                  fosteredBefore = Nil
+                  val beforeAdded = fosteredBeforeSize
+                  var i = 0
+                  while i < fosteredBeforeSize do
+                    append(fosteredBefore(i))
+                    i += 1
+                  fosteredBeforeSize = 0
                   append(child)
-                  val afterAdded = fosteredAfter.size
-                  fosteredAfter.foreach(append)
-                  fosteredAfter = Nil
+                  val afterAdded = fosteredAfterSize
+                  i = 0
+                  while i < fosteredAfterSize do
+                    append(fosteredAfter(i))
+                    i += 1
+                  fosteredAfterSize = 0
                   inTableContent = false
                   val added = reconstructPending()
                   read(parent, admissible, map, count + 1 + beforeAdded + afterAdded + added)
@@ -1267,8 +1292,20 @@ object Html extends Tag.Container
                 val trimmed = text.trim
                 if trimmed.length > 0 then
                   val node = TextNode(trimmed)
-                  if inTableContent then fosteredAfter = fosteredAfter :+ node
-                  else fosteredBefore = fosteredBefore :+ node
+                  if inTableContent then
+                    if fosteredAfterSize >= fosteredAfter.length then
+                      val nu = new Array[Node](fosteredAfter.length*2)
+                      jl.System.arraycopy(fosteredAfter, 0, nu, 0, fosteredAfterSize)
+                      fosteredAfter = nu
+                    fosteredAfter(fosteredAfterSize) = node
+                    fosteredAfterSize += 1
+                  else
+                    if fosteredBeforeSize >= fosteredBefore.length then
+                      val nu = new Array[Node](fosteredBefore.length*2)
+                      jl.System.arraycopy(fosteredBefore, 0, nu, 0, fosteredBeforeSize)
+                      fosteredBefore = nu
+                    fosteredBefore(fosteredBeforeSize) = node
+                    fosteredBeforeSize += 1
                 read(parent, admissible, map, count)
               else
                 whitespace() yet read(parent, admissible, map, count)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -905,7 +905,7 @@ object Html extends Tag.Container
               val consumed = p - startPos
               if consumed > 0 then
                 cursor.unsafeBumpPos(consumed)(using Unsafe)
-                if cursor.lineation.active then
+                if cursor.lineActive then
                   if newlines == 0 then cursor.unsafeBumpColumn(consumed)(using Unsafe)
                   else
                     cursor.unsafeBumpLine(newlines)(using Unsafe)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -737,12 +737,25 @@ object Html extends Tag.Container
         // Append into the parser-shared interleaved scratch buffer (laid out
         // as `[k0, v0, k1, v1, ...]`); on close, snapshot the populated prefix
         // into a freshly-sized `IArray[String | Null]` and wrap it as the
-        // opaque `Attributes`. Linear duplicate-scan suits the typical 0–5
-        // attribute count and skips both the LinkedHashMap accumulator and
-        // the ListMap finalisation that the previous form went through.
-        // `Unset` values are encoded as `null` in the array.
+        // opaque `Attributes`. `Unset` values are encoded as `null` in the
+        // array.
+        //
+        // Duplicate detection uses a Bloom-filter-style cheap test before
+        // falling back to a linear scan: we keep a running OR / AND of the
+        // hashCodes of all already-stored keys, and for each new key check
+        // whether `(hashOr | h) == hashOr && (hashAnd & h) == hashAnd`. If
+        // *either* condition fails the new hash has bits outside the
+        // accumulated envelope and cannot match any prior key, so the scan
+        // is skipped. Only when both conditions hold (rare for typical
+        // 0–5-attribute elements with disjoint label hashes) do we walk
+        // the existing keys to confirm. The check loses precision as the
+        // attribute count grows, but for the HTML common case this turns
+        // O(n^2) string comparisons into O(n) bit ops + a handful of false
+        // positives.
         var n = 0
         var done = false
+        var hashOr = 0
+        var hashAnd = -1
 
         inline def ensureCapacity(): Unit =
           if 2*n >= attrInterleaved.length then
@@ -772,11 +785,19 @@ object Html extends Tag.Container
                 . label
 
               val key2Str: String = key2.s
+              val h: Int = key2Str.hashCode
 
-              var dup = 0
-              while dup < 2*n do
-                if attrInterleaved(dup) == key2Str then fail(DuplicateAttribute(key2))
-                dup += 2
+              // Bloom-style fast-skip; only fall back to a linear scan when
+              // the new hashcode's bits are entirely within the accumulated
+              // envelope (i.e. it might match a prior key).
+              if (hashOr | h) == hashOr && (hashAnd & h) == hashAnd then
+                var dup = 0
+                while dup < 2*n do
+                  if attrInterleaved(dup) == key2Str then fail(DuplicateAttribute(key2))
+                  dup += 2
+
+              hashOr |= h
+              hashAnd &= h
 
               val assignment: Optional[Text] =
                 if !equality() then Unset else lay(fail(ExpectedMore)):

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -593,12 +593,16 @@ object Html extends Tag.Container
         advance()
         if !more then raise(ParseError(Html, currentPosition(), ExpectedMore))
 
-      inline def expect(char: Char): Unit =
+      // Non-inline: each `expect`/`expectInsensitive` call site otherwise
+      // re-expands `advance` + `lay` + `fail` + `Issue.Unexpected.apply`,
+      // which over the doctype/cdata parsers contributes a large chunk of
+      // `tag\$8`'s bytecode.
+      def expect(char: Char): Unit =
         advance()
         lay(fail(ExpectedMore)): datum =>
           if datum != char then fail(Unexpected(datum))
 
-      inline def expectInsensitive(char: Char): Unit =
+      def expectInsensitive(char: Char): Unit =
         advance()
         lay(fail(ExpectedMore)): datum =>
           if asciiLower(datum) != asciiLower(char) then fail(Unexpected(datum))

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -449,6 +449,20 @@ object Html extends Tag.Container
     protected inline def slice(start: Cursor.Mark, end: Cursor.Mark): Text =
       cursor.grab(start, end).asInstanceOf[Text]
 
+    // ASCII-range character predicates and case fold. Lower the per-character
+    // overhead from `Character.isLetter`/`Character.isDigit`/`Character.toLowerCase`
+    // (Unicode-property table walks) to a couple of integer comparisons. HTML
+    // tag and attribute names, decimal/hex digits, and the trie's keys are all
+    // strictly ASCII, so this is a sound substitution on every parser hot path
+    // that previously called the JDK helpers.
+    protected inline def asciiLetter(char: Char): Boolean =
+      (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z')
+
+    protected inline def asciiDigit(char: Char): Boolean = char >= '0' && char <= '9'
+
+    protected inline def asciiLower(char: Char): Char =
+      if char >= 'A' && char <= 'Z' then (char + 32).toChar else char
+
     protected inline def reset(start: Cursor.Mark): Unit = cursor.cue(start)
 
     protected def cloneTo
@@ -565,7 +579,7 @@ object Html extends Tag.Container
       inline def expectInsensitive(char: Char): Unit =
         advance()
         lay(fail(ExpectedMore)): datum =>
-          if datum.minuscule != char.minuscule then fail(Unexpected(datum))
+          if asciiLower(datum) != asciiLower(char) then fail(Unexpected(datum))
 
       def fail
         ( issue: Issue,
@@ -590,7 +604,7 @@ object Html extends Tag.Container
       @tailrec
       def tagname(mark: Mark, dictionary: Dictionary[Tag]): Tag =
         lay(fail(ExpectedMore, mark)):
-          case char if char.isLetter || char.isDigit => dictionary(char.minuscule) match
+          case char if asciiLetter(char) || asciiDigit(char) => dictionary(asciiLower(char)) match
             case Dictionary.Empty =>
               advance()
               val end = begin()
@@ -617,7 +631,7 @@ object Html extends Tag.Container
 
       @tailrec
       def foreignTag(mark: Mark): Text = lay(fail(ExpectedMore, mark)):
-        case char if char.isLetter                       => next() yet foreignTag(mark)
+        case char if asciiLetter(char)                   => next() yet foreignTag(mark)
         case ' ' | '\f' | '\n' | '\r' | '\t' | '/' | '>' => slice(mark, begin()).lower
         case '\u0000'                                    => fail(BadInsertion, mark)
         case char                                        => fail(Unexpected(char), mark)
@@ -625,7 +639,7 @@ object Html extends Tag.Container
       @tailrec
       def key(mark: Mark, dictionary: Dictionary[Attribute]): Attribute =
         lay(fail(ExpectedMore, mark)):
-          case char if char.isLetter || char == '-' => dictionary(char.minuscule) match
+          case char if asciiLetter(char) || char == '-' => dictionary(asciiLower(char)) match
             case Dictionary.Empty => fail(UnknownAttributeStart(slice(mark, begin())), mark)
             case dictionary       => next() yet key(mark, dictionary)
 
@@ -641,7 +655,7 @@ object Html extends Tag.Container
 
       @tailrec
       def foreignKey(mark: Mark): Text = lay(fail(ExpectedMore, mark)):
-        case char if char.isLetter || char == '-'        => next() yet foreignKey(mark)
+        case char if asciiLetter(char) || char == '-'    => next() yet foreignKey(mark)
         case ' ' | '\f' | '\n' | '\r' | '\t' | '=' | '>' => slice(mark, begin())
         case '\u0000'                                    => fail(BadInsertion, mark)
         case char                                        => fail(Unexpected(char), mark)
@@ -770,7 +784,7 @@ object Html extends Tag.Container
       @tailrec
       def hexEntity(mark: Mark, value: Int): Optional[Text] =
         lay(fail(ExpectedMore, mark)):
-          case digit if digit.isDigit =>
+          case digit if asciiDigit(digit) =>
             advance() yet hexEntity(mark, 16*value + (digit - '0'))
 
           case letter if 'a' <= letter <= 'f' =>
@@ -787,14 +801,14 @@ object Html extends Tag.Container
 
       @tailrec
       def decimalEntity(mark: Mark, value: Int): Optional[Text] = lay(fail(ExpectedMore, mark)):
-        case digit if digit.isDigit => next() yet decimalEntity(mark, 10*value + (digit - '0'))
+        case digit if asciiDigit(digit) => next() yet decimalEntity(mark, 10*value + (digit - '0'))
         case ';'                    => next() yet value.unicode
         case char                   => Unset
 
       @tailrec
       def textEntity(mark: Mark, dictionary: Dictionary[Text]): Optional[Text] =
         lay(fail(ExpectedMore, mark)):
-          case char if char.isLetter | char.isDigit =>
+          case char if asciiLetter(char) || asciiDigit(char) =>
             dictionary(char) match
               case Dictionary.Empty => Unset
               case dictionary       => advance() yet textEntity(mark, dictionary)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -1236,7 +1236,7 @@ object Html extends Tag.Container
                 push(focus)
                 val savedFosterFlag = pendingFosterDescend
                 pendingFosterDescend = false
-                if parent.label == t"table" && !savedFosterFlag then inTableContent = true
+                if parent.isTable && !savedFosterFlag then inTableContent = true
                 val child = descend(focus, admissible, extra)
                 pop()
                 if savedFosterFlag then
@@ -1244,7 +1244,7 @@ object Html extends Tag.Container
                   else fosteredBefore = fosteredBefore :+ child
                   val added = reconstructPending()
                   read(parent, admissible, map, count + added)
-                else if focus.label == t"table" then
+                else if focus.isTable then
                   val beforeAdded = fosteredBefore.size
                   fosteredBefore.foreach(append)
                   fosteredBefore = Nil

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -601,8 +601,8 @@ object Html extends Tag.Container
               next() yet tagname(mark, other)
 
           case ' ' | '\f' | '\n' | '\r' | '\t' | '/' | '>' => dictionary match
-            case Dictionary.Just("", tag)       => tag
-            case Dictionary.Branch(tag: Tag, _) => tag
+            case just: Dictionary.Just[Tag] if just.tailEmpty => just.value
+            case Dictionary.Branch(tag: Tag, _)               => tag
 
             case other =>
               val end = begin()

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -874,10 +874,11 @@ object Html extends Tag.Container
       // `String.substring` (a JVM intrinsic) without round-tripping through
       // `buffer`. Falls back to `textualSlow` for the harder cases.
       //
-      // The inner loop binds the cursor's char buffer to a local `Array[Char]`
-      // reference and reuses the just-loaded `c` to drive lineation tracking
-      // via `unsafeAdvanceWith` — saving a redundant buffer read on every
-      // non-delimiter character of text content.
+      // The inner loop is a tight `while` over the cursor's `Array[Char]`
+      // buffer with a register-resident `var p`, accumulating any newlines
+      // along the way. After the scan, lineation is reconciled with the
+      // cursor in one shot, so the per-character path doesn't pay the
+      // `Cursor.unsafeAdvanceWith` lineation branch on every non-delimiter.
       def textual(mark: Mark, close: Optional[Text], entities: Boolean): Text =
         if close.present then textualSlow(mark, close, entities) else
           @tailrec
@@ -885,12 +886,35 @@ object Html extends Tag.Container
             if !cursor.more then slice(mark, begin())
             else
               val buf = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
-              val c = buf(cursor.unsafePos(using Unsafe))
-              if c == '<' || c == 0.toChar then slice(mark, begin())
-              else if c == '&' && entities then textualSlow(mark, close, entities)
-              else
-                cursor.unsafeAdvanceWith(c.asInstanceOf[cursor.addressable.Operand])(using Unsafe)
-                fast()
+              val limit = cursor.unsafeWriteEnd(using Unsafe)
+              val startPos = cursor.unsafePos(using Unsafe)
+              var p = startPos
+              var hit: Char = 1.toChar // sentinel: "no delimiter found"
+              var newlines = 0
+              var lastNewline = -1
+
+              while p < limit && hit == 1.toChar do
+                val c = buf(p)
+                if c == '<' || c == 0.toChar then hit = c
+                else if c == '&' && entities then hit = c
+                else
+                  if c == '\n' then
+                    newlines += 1
+                    lastNewline = p
+                  p += 1
+
+              val consumed = p - startPos
+              if consumed > 0 then
+                cursor.unsafeBumpPos(consumed)(using Unsafe)
+                if cursor.lineation.active then
+                  if newlines == 0 then cursor.unsafeBumpColumn(consumed)(using Unsafe)
+                  else
+                    cursor.unsafeBumpLine(newlines)(using Unsafe)
+                    cursor.unsafeSetColumn(p - lastNewline - 1)(using Unsafe)
+
+              if hit == '&' then textualSlow(mark, close, entities)
+              else if hit != 1.toChar then slice(mark, begin())
+              else fast() // buffer exhausted; outer @tailrec re-fetches buf via cursor.more
 
           fast()
 

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -853,15 +853,27 @@ object Html extends Tag.Container
       // (no RCDATA close-tag check needed), build the result via
       // `String.substring` (a JVM intrinsic) without round-tripping through
       // `buffer`. Falls back to `textualSlow` for the harder cases.
+      //
+      // The inner loop binds the cursor's char buffer to a local `Array[Char]`
+      // reference and reuses the just-loaded `c` to drive lineation tracking
+      // via `unsafeAdvanceWith` — saving a redundant buffer read on every
+      // non-delimiter character of text content.
       def textual(mark: Mark, close: Optional[Text], entities: Boolean): Text =
         if close.present then textualSlow(mark, close, entities) else
           @tailrec
-          def fast(): Text = lay(slice(mark, begin())):
-            case '<' | '\u0000' => slice(mark, begin())
-            case '&' if entities => textualSlow(mark, close, entities)
-            case char => advance() yet fast()
+          def fast(): Text =
+            if !cursor.more then slice(mark, begin())
+            else
+              val buf = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
+              val c = buf(cursor.unsafePos(using Unsafe))
+              if c == '<' || c == 0.toChar then slice(mark, begin())
+              else if c == '&' && entities then textualSlow(mark, close, entities)
+              else
+                cursor.unsafeAdvanceWith(c.asInstanceOf[cursor.addressable.Operand])(using Unsafe)
+                fast()
 
           fast()
+
 
       def comment(mark: Mark): Text = lay(fail(ExpectedMore)):
         case '-' =>

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -741,21 +741,20 @@ object Html extends Tag.Container
         // array.
         //
         // Duplicate detection uses a Bloom-filter-style cheap test before
-        // falling back to a linear scan: we keep a running OR / AND of the
+        // falling back to a linear scan: maintain a running OR of the
         // hashCodes of all already-stored keys, and for each new key check
-        // whether `(hashOr | h) == hashOr && (hashAnd & h) == hashAnd`. If
-        // *either* condition fails the new hash has bits outside the
-        // accumulated envelope and cannot match any prior key, so the scan
-        // is skipped. Only when both conditions hold (rare for typical
-        // 0–5-attribute elements with disjoint label hashes) do we walk
-        // the existing keys to confirm. The check loses precision as the
-        // attribute count grows, but for the HTML common case this turns
-        // O(n^2) string comparisons into O(n) bit ops + a handful of false
-        // positives.
+        // whether `(hashOr | h) == hashOr`. If the new hash has any bit
+        // outside the accumulated envelope it cannot match any prior key
+        // and the scan is skipped. Only when its bits are all already in
+        // the envelope (rare for typical 0–7-attribute elements with
+        // disjoint label hashes) do we walk the existing keys to confirm.
+        // The check loses precision as the attribute count grows (the OR
+        // eventually saturates), but for the HTML common case this turns
+        // O(n^2) string comparisons into O(n) bit ops plus a handful of
+        // false positives.
         var n = 0
         var done = false
         var hashOr = 0
-        var hashAnd = -1
 
         inline def ensureCapacity(): Unit =
           if 2*n >= attrInterleaved.length then
@@ -790,14 +789,13 @@ object Html extends Tag.Container
               // Bloom-style fast-skip; only fall back to a linear scan when
               // the new hashcode's bits are entirely within the accumulated
               // envelope (i.e. it might match a prior key).
-              if (hashOr | h) == hashOr && (hashAnd & h) == hashAnd then
+              if (hashOr | h) == hashOr then
                 var dup = 0
                 while dup < 2*n do
                   if attrInterleaved(dup) == key2Str then fail(DuplicateAttribute(key2))
                   dup += 2
 
               hashOr |= h
-              hashAnd &= h
 
               val assignment: Optional[Text] =
                 if !equality() then Unset else lay(fail(ExpectedMore)):

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -538,7 +538,15 @@ object Html extends Tag.Container
       var stack: Array[Tag] = new Array(4)
       var depth: Int = 0
       var fragment: IArray[Node] = IArray()
-      var pendingFormatting: List[(Text, Attributes)] = Nil
+      // Pending formatting tags awaiting reconstruction (see WHATWG "active
+      // formatting elements"). Stored as parallel arrays of label/Attributes
+      // pairs rather than a `List[(Text, Attributes)]`: `:+` on a `List` is
+      // O(N) (and allocates a `Tuple2` per append), and even though valid
+      // HTML rarely populates this list, malformed-input handling can append
+      // multiple entries at once. Capacity grows geometrically when filled.
+      var pendingFormattingLabels: Array[Text] = new Array[Text](4)
+      var pendingFormattingAttrs:  Array[Attributes] = new Array[Attributes](4)
+      var pendingFormattingSize: Int = 0
       var pendingAtDepth: Int = -1
       var fosteredBefore: List[Node] = Nil
       var fosteredAfter: List[Node] = Nil
@@ -1066,14 +1074,18 @@ object Html extends Tag.Container
 
               inline def infer(inline tag: Tag): Unit =
                 reset(mark)
-
-                dom.infer(parent, tag).let: tag =>
-                  focus = tag
+                // Use a direct `if inferred.absent` check rather than
+                // `dom.infer(...).let { ... }.or { ... }`: `Optional.let` is
+                // not inline, so the lambda body would capture the surrounding
+                // `focus` and `level` `var`s as `ObjectRef`s on every `<`
+                // entry, allocating two refs per element open.
+                val inferred: Optional[Tag] = dom.infer(parent, tag)
+                if inferred.absent then
+                  if parent.autoclose then close()
+                  else fail(InadmissibleTag(content, parent.label), mark)
+                else
+                  focus = inferred.vouch
                   level = Level.Descend
-
-                . or:
-                    if parent.autoclose then close()
-                    else fail(InadmissibleTag(content, parent.label), mark)
 
               next()
               if lay(false)(_ == '\u0000') then
@@ -1128,7 +1140,17 @@ object Html extends Tag.Container
                     else if stackContainsAncestor(content) then
                       if formattingTags.contains(parent.label) then
                         pendingAtDepth = findAncestorIndex(content)
-                        pendingFormatting = pendingFormatting :+ ((parent.label, map))
+                        if pendingFormattingSize >= pendingFormattingLabels.length then
+                          val newCap = pendingFormattingLabels.length*2
+                          val nl = new Array[Text](newCap)
+                          val na = new Array[Attributes](newCap)
+                          jl.System.arraycopy(pendingFormattingLabels, 0, nl, 0, pendingFormattingSize)
+                          jl.System.arraycopy(pendingFormattingAttrs,  0, na, 0, pendingFormattingSize)
+                          pendingFormattingLabels = nl
+                          pendingFormattingAttrs  = na
+                        pendingFormattingLabels(pendingFormattingSize) = parent.label
+                        pendingFormattingAttrs (pendingFormattingSize) = map
+                        pendingFormattingSize += 1
                       reset(mark)
                       close()
                     else if formattingTags.contains(content) then
@@ -1144,27 +1166,32 @@ object Html extends Tag.Container
                     current = Element(content, map, array(count), parent.foreign)
 
             def reconstructPending(): Int =
-              if pendingFormatting.isEmpty || depth != pendingAtDepth then 0
+              if pendingFormattingSize == 0 || depth != pendingAtDepth then 0
               else if !more || lay(false)(_ == '<') then
-                pendingFormatting = Nil
+                pendingFormattingSize = 0
                 pendingAtDepth = -1
                 0
               else
-                val pending = pendingFormatting
-                pendingFormatting = Nil
+                val pendingCount = pendingFormattingSize
+                pendingFormattingSize = 0
                 pendingAtDepth = -1
                 var added = 0
-                pending.foreach: (label, attrs) =>
-                  dom.elements(label).let: cloneTag =>
-                    push(cloneTag)
-                    val cloneChild = descend(cloneTag, admissible, attrs)
+                var i = 0
+                while i < pendingCount do
+                  val label = pendingFormattingLabels(i)
+                  val attrs = pendingFormattingAttrs(i)
+                  val cloneTag: Optional[Tag] = dom.elements(label)
+                  if cloneTag.present then
+                    val tag = cloneTag.vouch
+                    push(tag)
+                    val cloneChild = descend(tag, admissible, attrs)
                     pop()
                     cloneChild match
                       case Element(_, _, children, _) if children.length == 0 => ()
-
                       case _ =>
                         append(cloneChild)
                         added += 1
+                  i += 1
                 added
 
             level match

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -449,9 +449,15 @@ object Html extends Tag.Container
     protected inline def advance(): Unit = cursor.advance()
     protected inline def position: Int = cursor.position.n0
 
-    protected inline def begin(): Cursor.Mark = cursor.mark(using heldToken.nn)
+    // Non-`inline` so that `cursor.mark`'s lineation-tracking expansion
+    // (recordMark allocation + `lineationActive` branch) is emitted once in
+    // its own method rather than re-expanded into every call site, keeping
+    // `read`/`tag`/`tagname` small enough for the JIT to pick up. The body
+    // is still simple enough for the JIT to inline at hot call sites via
+    // its own inlining heuristics.
+    protected def begin(): Cursor.Mark = cursor.mark(using heldToken.nn)
 
-    protected inline def slice(start: Cursor.Mark, end: Cursor.Mark): Text =
+    protected def slice(start: Cursor.Mark, end: Cursor.Mark): Text =
       cursor.grab(start, end).asInstanceOf[Text]
 
     // ASCII-range character predicates and case fold. Lower the per-character
@@ -468,7 +474,7 @@ object Html extends Tag.Container
     protected inline def asciiLower(char: Char): Char =
       if char >= 'A' && char <= 'Z' then (char + 32).toChar else char
 
-    protected inline def reset(start: Cursor.Mark): Unit = cursor.cue(start)
+    protected def reset(start: Cursor.Mark): Unit = cursor.cue(start)
 
     protected def cloneTo
                   (start: Cursor.Mark, end: Cursor.Mark)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -543,10 +543,6 @@ object Html extends Tag.Container
 
       def stackContainsAncestor(label: Text): Boolean = findAncestorIndex(label) >= 0
 
-      def isTableLikeContext(tag: Tag): Boolean =
-        tag.label == t"table" || tag.label == t"tbody" || tag.label == t"thead"
-        || tag.label == t"tfoot" || tag.label == t"tr"
-
       def append(node: Node): Unit =
         if index >= nodes.length then
           val nodes2 = new Array[Node](nodes.length*2)
@@ -1078,7 +1074,7 @@ object Html extends Tag.Container
                       if parent.autoclose then
                         reset(mark)
                         close()
-                      else if isTableLikeContext(parent) && !focus.void then
+                      else if parent.tableLike && !focus.void then
                         pendingFosterDescend = true
                         level = Level.Descend
                       else
@@ -1184,7 +1180,7 @@ object Html extends Tag.Container
 
           case char => parent.mode match
             case Mode.Whitespace =>
-              if isTableLikeContext(parent) then
+              if parent.tableLike then
                 val text = textual(begin(), Unset, true)
                 val trimmed = text.trim
                 if trimmed.length > 0 then

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -1007,9 +1007,15 @@ object Html extends Tag.Container
 
         case '/' =>
           next()
-          content =
-            if foreign then foreignTag(begin()) else tagname(begin(), dom.elements).label
-
+          if foreign then content = foreignTag(begin())
+          else
+            val tagDef = tagname(begin(), dom.elements)
+            content = tagDef.label
+            // Stash the resolved closing tag so `read`'s `Token.Close` arm
+            // can compare `openTag eq parent` (reference equality on the
+            // interned `Tag` instance) instead of `content != parent.label`
+            // (`String.equals` on the labels).
+            openTag = tagDef
           Token.Close
 
         case '\u0000' => fail(BadInsertion)
@@ -1143,7 +1149,17 @@ object Html extends Tag.Container
                   else level = Level.Descend
 
                 case Token.Close =>
-                  if content != parent.label then
+                  // For non-foreign tags, `tagname` returns a `Tag` instance
+                  // from the interned `dom.elements` trie and `parent` is
+                  // itself one of those interned instances, so a mismatch is
+                  // detectable via reference inequality — cheaper than
+                  // `String.equals` on the labels. Foreign tags have to fall
+                  // back to text equality since `Tag.foreign` mints fresh
+                  // instances per element.
+                  val nameMismatch =
+                    if parent.foreign then content != parent.label
+                    else openTag ne parent
+                  if nameMismatch then
                     if parent.autoclose then
                       reset(mark)
                       close()

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -233,6 +233,11 @@ extends Element(label, Attributes.from(presets), IArray(), foreign), Formal, Dyn
     && (label == t"tr" || label == t"table" || label == t"tbody"
         || label == t"thead" || label == t"tfoot")
 
+  // True iff the tag's label is exactly `"table"`. Used by the parser's
+  // foster-parenting logic to detect "are we entering a table?" without
+  // re-running `label == t"table"` on every descend.
+  val isTable: Boolean = label == t"table"
+
 
   inline def applyDynamicNamed[label <: Label: Precise](inline method: label)
     ( inline attributes: (String, Any)* )

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -223,6 +223,16 @@ abstract class Tag
 extends Element(label, Attributes.from(presets), IArray(), foreign), Formal, Dynamic:
   type Result <: Element
 
+  // Pre-computed "is this a table-context tag" flag, evaluated once per Tag
+  // instance at construction time. Replaces a five-way `Text` equality check
+  // that previously fired per child element during HTML parsing. The leading
+  // `t` short-circuit avoids paying the comparison chain for the overwhelming
+  // majority of (non-table) tags.
+  val tableLike: Boolean =
+    label.s.charAt(0) == 't'
+    && (label == t"tr" || label == t"table" || label == t"tbody"
+        || label == t"thead" || label == t"tfoot")
+
 
   inline def applyDynamicNamed[label <: Label: Precise](inline method: label)
     ( inline attributes: (String, Any)* )

--- a/lib/honeycomb/src/core/honeycomb.internal.scala
+++ b/lib/honeycomb/src/core/honeycomb.internal.scala
@@ -116,10 +116,10 @@ object internal:
 
           case "\u0000" :: tail =>
             index += 1
-            types ::= TypeRepr.of[Attributes]
+            types ::= TypeRepr.of[Map[Text, Optional[Text]]]
             iterator.next()
             val others = Expr.ofList(pattern.attributes.keys.to(List).map(Expr(_)))
-            '{$expr && { $array(${Expr(index)}) = ${scrutinee}.attributes -- $others; true }}
+            '{$expr && { $array(${Expr(index)}) = (${scrutinee}.attributes -- $others).toMap; true }}
 
           case head :: tail =>
             attributes(tail):

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import scala.collection.mutable as scm
-
 import denominative.*
 import prepositional.*
 import proscenium.*
@@ -72,6 +70,9 @@ object Cursor:
   extension (offset: Offset)
     inline def line: Ordinal = (offset >> 32 & 0xffffffff).toInt.z
     inline def column: Ordinal = offset.toInt.z
+    private[zephyrine] inline def toLong: Long = offset
+
+  private[zephyrine] inline def offsetFromLong(long: Long): Offset = long
 
 
   // Default initial buffer size for streaming use; pre-filled buffers use the
@@ -148,8 +149,14 @@ final class Cursor[data]
   private var holdStart: Int = -1
   private var ended:     Boolean = false
 
-  private val marks:   scm.ArrayDeque[Cursor.Mark] = scm.ArrayDeque()
-  private val offsets: scm.ArrayDeque[Cursor.Offset] = scm.ArrayDeque()
+  // Parallel arrays (not deques) of unboxed `Long`-typed `Mark` and `Offset`
+  // values for the currently-held region. Using `Array[Long]` rather than
+  // `ArrayDeque[Mark]`/`ArrayDeque[Offset]` avoids two `java.lang.Long` boxes
+  // per `mark()` call — a meaningful saving on parser hot paths that mark
+  // every token boundary.
+  private var marks:     Array[Long] = new Array[Long](16)
+  private var offsets:   Array[Long] = new Array[Long](16)
+  private var marksSize: Int = 0
 
   private var lineNo:   Ordinal = Prim
   private var columnNo: Ordinal = Prim
@@ -326,10 +333,34 @@ final class Cursor[data]
   inline def mark(using held: Cursor.Held): Cursor.Mark =
     Cursor.Mark(basePos + pos).tap: mark =>
       if lineation.active then
-        marks.append(mark)
-        offsets.append(Cursor.Offset(lineNo, columnNo))
+        recordMark(mark.absolute, Cursor.Offset(lineNo, columnNo).toLong)
 
-  inline def offset(mark: Cursor.Mark): Cursor.Offset = offsets(marks.lastIndexOf(mark))
+  // Append `(mark, offset)` to the parallel `Long` buffers, growing geometrically
+  // when full. Off the hot path's inline budget so `mark()` itself stays small.
+  private def recordMark(mark: Long, offset: Long): Unit =
+    val cap = marks.length
+    if marksSize >= cap then
+      val newCap = cap*2
+      val nm = new Array[Long](newCap)
+      val no = new Array[Long](newCap)
+      System.arraycopy(marks,   0, nm, 0, marksSize)
+      System.arraycopy(offsets, 0, no, 0, marksSize)
+      marks   = nm
+      offsets = no
+    marks(marksSize)   = mark
+    offsets(marksSize) = offset
+    marksSize += 1
+
+  // Linear scan from the most-recently appended mark backwards. `cue()` is the
+  // only caller and only fires on backtrack, so this stays cold relative to
+  // `mark()` itself.
+  private def offsetForMark(mark: Long): Long =
+    var i = marksSize - 1
+    while i >= 0 && marks(i) != mark do i -= 1
+    offsets(i)
+
+  inline def offset(mark: Cursor.Mark): Cursor.Offset =
+    Cursor.offsetFromLong(offsetForMark(mark.absolute))
 
   inline def cue(mark: Cursor.Mark): Unit =
     pos = (mark.absolute - basePos).toInt
@@ -344,8 +375,7 @@ final class Cursor[data]
     action(using new Cursor.Held()).also:
       if !wasHeld then
         holdStart = -1
-        marks.clear()
-        offsets.clear()
+        marksSize = 0
 
   inline def grab(start: Cursor.Mark, end: Cursor.Mark): data =
     val len = (end.absolute - start.absolute).toInt

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -246,6 +246,27 @@ final class Cursor[data]
         if !lineation.track(operand) then columnNo.next
         else { lineNo = lineNo.next; Prim }
 
+  // Bulk-advance primitives. Allow a caller (typically a parser running a
+  // register-resident scan loop) to consume `n` characters without paying the
+  // per-character lineation update inside `advance`/`unsafeAdvanceWith`, then
+  // reconcile lineation in one shot. The caller is responsible for tracking
+  // newlines while it scans.
+  inline def unsafeBumpPos(by: Int)(using erased Unsafe): Unit = pos += by
+
+  // Increase the line counter by `by`, leaving the column counter untouched.
+  inline def unsafeBumpLine(by: Int)(using erased Unsafe): Unit =
+    lineNo = denominative.Ordinal.zerary(lineNo.n0 + by)
+
+  // Increase the column counter by `by`. Must not be called across newlines.
+  inline def unsafeBumpColumn(by: Int)(using erased Unsafe): Unit =
+    columnNo = denominative.Ordinal.zerary(columnNo.n0 + by)
+
+  // Set the column counter directly. Used after a bulk advance over a range
+  // that contained at least one newline, to set the column to the offset
+  // since the most-recent newline.
+  inline def unsafeSetColumn(value: Int)(using erased Unsafe): Unit =
+    columnNo = denominative.Ordinal.zerary(value)
+
   // `next()` is `advance(); more`, so it returns `true` while more data is
   // available and `false` when the stream is exhausted.
   inline def next(): Boolean =

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -236,6 +236,16 @@ final class Cursor[data]
         else { lineNo = lineNo.next; Prim }
     else pos += 1
 
+  // Variant of `advance` for callers that have just read the current operand
+  // (e.g. via `unsafeBuffer(pos)` in a tight scan loop). Reuses the supplied
+  // `operand` instead of re-loading it from the buffer for lineation tracking.
+  inline def unsafeAdvanceWith(operand: addressable.Operand)(using erased Unsafe): Unit =
+    pos += 1
+    if lineation.active then
+      columnNo =
+        if !lineation.track(operand) then columnNo.next
+        else { lineNo = lineNo.next; Prim }
+
   // `next()` is `advance(); more`, so it returns `true` while more data is
   // available and `false` when the stream is exhausted.
   inline def next(): Boolean =

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -149,6 +149,14 @@ final class Cursor[data]
   private var holdStart: Int = -1
   private var ended:     Boolean = false
 
+  // Cache `lineation.active` once at construction so the per-`advance()`
+  // dispatch is a final-field load instead of an interface call. The JIT
+  // can no longer prove that `lineation`'s concrete `Lineation` instance has
+  // a constant `active`, since `lineation: Lineation` erases the given's
+  // concrete type at the field boundary, and the parser-side hot loops
+  // would otherwise pay an `invokeinterface` on every character advance.
+  private val lineationActive: Boolean = lineation.active
+
   // Parallel arrays (not deques) of unboxed `Long`-typed `Mark` and `Offset`
   // values for the currently-held region. Using `Array[Long]` rather than
   // `ArrayDeque[Mark]`/`ArrayDeque[Offset]` avoids two `java.lang.Long` boxes
@@ -228,7 +236,7 @@ final class Cursor[data]
   // tighter — important for raw byte-scan parsers like Merino where the
   // hot loop is `while more && {peek-test} do advance()`.
   inline def advance(): Unit =
-    if lineation.active then
+    if lineationActive then
       val operand = addressable.storageAddress(buffer, pos)
       pos += 1
       columnNo =
@@ -241,7 +249,7 @@ final class Cursor[data]
   // `operand` instead of re-loading it from the buffer for lineation tracking.
   inline def unsafeAdvanceWith(operand: addressable.Operand)(using erased Unsafe): Unit =
     pos += 1
-    if lineation.active then
+    if lineationActive then
       columnNo =
         if !lineation.track(operand) then columnNo.next
         else { lineNo = lineNo.next; Prim }
@@ -287,6 +295,11 @@ final class Cursor[data]
   inline def available: Int = writeEnd - pos
   inline def line: Ordinal = lineNo
   inline def column: Ordinal = columnNo
+
+  // Cached active-flag for the configured lineation. Hot-loop callers should
+  // use this in preference to `lineation.active` to avoid the per-call
+  // interface dispatch that the abstract `Lineation` member would imply.
+  inline def lineActive: Boolean = lineationActive
 
   // Stream of all unconsumed data from the current position onwards. Yields
   // the buffered tail first (one chunk materialised from `pos` to `writeEnd`),
@@ -363,7 +376,7 @@ final class Cursor[data]
   // hold block, where compaction cannot drop the marked region.
   inline def mark(using held: Cursor.Held): Cursor.Mark =
     Cursor.Mark(basePos + pos).tap: mark =>
-      if lineation.active then
+      if lineationActive then
         recordMark(mark.absolute, Cursor.Offset(lineNo, columnNo).toLong)
 
   // Append `(mark, offset)` to the parallel `Long` buffers, growing geometrically
@@ -395,7 +408,7 @@ final class Cursor[data]
 
   inline def cue(mark: Cursor.Mark): Unit =
     pos = (mark.absolute - basePos).toInt
-    if lineation.active then
+    if lineationActive then
       val o = offset(mark)
       lineNo = o.line
       columnNo = o.column


### PR DESCRIPTION
Reduce per-character and per-element overhead in the HTML parser. A series of allocation-rate, JIT-inlining, and reference-equality changes across `gossamer.Dictionary`, `zephyrine.Cursor`, and the `honeycomb` parser collectively raise parse throughput on `mill honeycomb.bench.run` by 50–80% across all five fixtures and bring Honeycomb from 2.0–3.1× slower than jsoup to 1.15–1.65× slower.

HTML parsing is now substantially faster across the size range. Parsing
throughput on the bundled `honeycomb.bench` fixtures rose by 50–80% versus
the previous `main`, narrowing the gap to jsoup from 2.0–3.1× slower to
1.15–1.65×.

The work touches three modules:

- `gossamer.Dictionary` now stores `Just(text, offset, value)` so trie
  walks no longer allocate a fresh substring per character, and adds a
  `lookupAscii` helper for case-insensitive lookup against an existing
  `char[]` slice.
- `zephyrine.Cursor` replaces the boxed-`Long` `ArrayDeque` mark/offset
  storage with primitive `Array[Long]` buffers, caches `lineation.active`
  to avoid an interface dispatch per advance, and adds an
  `unsafeAdvanceWith` helper plus bulk-lineation primitives so parsers
  can defer the per-character lineation update during tight scan loops.
- `honeycomb.Attributes` is now an opaque `IArray[String | Null]` with
  alternating keys and values; non-empty attribute sets cost a single
  array allocation instead of three.

The HTML parser itself uses these to streamline tag dispatch, attribute
parsing (single allocation-free linear scan with a Bloom-style fast-skip
for duplicate detection), text-content scanning (bulk-scan with deferred
lineation reconcile), and several smaller wins (cached resolved `Tag`
from `tagname`, `Tag.tableLike` / `Tag.isTable` precomputed at
construction, ASCII fast paths for `isLetter`/`isDigit`/`toLowerCase`,
de-inlining of large helpers like `begin` / `slice` / `expect` to keep
hot methods inside HotSpot's free-inline budgets, reference equality
on resolved `Tag` instances for close-tag matching).

The public API is unchanged.