### PR TITLE
Optimize XML parser: opaque Attributes + parser hot-path streamlining

### DIFF
--- a/lib/savagery/src/core/savagery.Figure.scala
+++ b/lib/savagery/src/core/savagery.Figure.scala
@@ -70,7 +70,7 @@ extends Figure:
     then attrs += t"transform" -> transforms.map(_.encode).join(t" ")
 
     style.let { css => attrs += t"style" -> css.properties.map(_.text).join(t";") }
-    Element(t"path", attrs.result(), IArray())
+    Element(t"path", Attributes.from(attrs.result()), IArray())
 
   def moveTo(point: Point): Outline = copy(ops = Move(point) :: ops)
   def lineTo(point: Point): Outline = copy(ops = Draw(point) :: ops)

--- a/lib/savagery/src/core/savagery.Stop.scala
+++ b/lib/savagery/src/core/savagery.Stop.scala
@@ -58,5 +58,5 @@ case class Stop[color](offset: 0.0 ~ 1.0, color: color)(using val chromatic: col
 
     Element
       ( t"stop",
-        SeqMap(t"offset" -> offset.double.show, t"stop-color" -> hex),
+        Attributes(t"offset" -> offset.double.show, t"stop-color" -> hex),
         IArray() )

--- a/lib/savagery/src/core/savagery.Stop.scala
+++ b/lib/savagery/src/core/savagery.Stop.scala
@@ -55,8 +55,6 @@ case class Stop[color](offset: 0.0 ~ 1.0, color: color)(using val chromatic: col
     val green = chromatic.green(color)
     val blue = chromatic.blue(color)
     val hex = t"#${Stop.hex2(red)}${Stop.hex2(green)}${Stop.hex2(blue)}"
+    val off = offset.double.show
 
-    Element
-      ( t"stop",
-        Attributes(t"offset" -> offset.double.show, t"stop-color" -> hex),
-        IArray() )
+    x"""<stop offset=$off stop-color=$hex/>"""

--- a/lib/savagery/src/core/savagery.Svg.scala
+++ b/lib/savagery/src/core/savagery.Svg.scala
@@ -104,7 +104,7 @@ extends Documentary:
 
     val defsElement: Seq[Xml] =
       if defs.isEmpty then Nil
-      else Seq(Element(t"defs", SeqMap[Text, Text](), defs.map(_.xml).toSeq.nodes))
+      else Seq(Element(t"defs", Attributes.empty, defs.map(_.xml).toSeq.nodes))
 
     val children: IArray[Node] = (defsElement ++ figures.map(_.xml)).nodes
-    Element(t"svg", attrs, children)
+    Element(t"svg", Attributes.from(attrs), children)

--- a/lib/savagery/src/core/savagery.SvgDef.scala
+++ b/lib/savagery/src/core/savagery.SvgDef.scala
@@ -43,4 +43,4 @@ sealed trait SvgDef:
 
 case class LinearGradient[color](id: SvgId, stops: Stop[color]*) extends SvgDef:
   def xml: Xml =
-    Element(t"linearGradient", SeqMap(t"id" -> id.text), stops.map(_.xml).toSeq.nodes)
+    Element(t"linearGradient", Attributes(t"id" -> id.text), stops.map(_.xml).toSeq.nodes)

--- a/lib/xylophone/src/core/xylophone.Attributes.scala
+++ b/lib/xylophone/src/core/xylophone.Attributes.scala
@@ -1,0 +1,320 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import java.lang as jl
+
+import scala.collection.immutable.ListMap
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// `Attributes` is an opaque view over an `IArray[String]` whose entries
+// alternate keys and values: at index `2k` is the attribute label, at index
+// `2k+1` is the value (XML attributes always have values, so unlike the HTML
+// equivalent there is no `null` sentinel for unvalued attributes). Storing
+// the pairs interleaved in a single `IArray` collapses the per-element
+// attribute representation to one heap allocation, against the previous
+// `Map[Text, Text]` whose `.updated`-per-attribute build-up cost
+// `O(n²)` `ListMap` allocations.
+//
+// Extension methods live inside the companion object so they have transparent
+// access to the underlying `IArray`. Structural equality and hashing are
+// exposed via dedicated `equalsAttributes` / `hashAttributes` extensions
+// rather than `Object.equals`/`hashCode`, since the underlying `IArray` would
+// otherwise answer with reference equality. `Element` (the only externally
+// significant `Attributes` consumer that needs structural equality) calls
+// these extensions explicitly.
+
+opaque type Attributes = IArray[String]
+
+object Attributes:
+  val empty: Attributes = IArray.empty[String]
+
+  def apply(pairs: (Text, Text)*): Attributes =
+    if pairs.isEmpty then empty else
+      val n = pairs.length
+      val arr = new Array[String](n*2)
+      var i = 0
+      pairs.foreach: pair =>
+        arr(i*2) = pair._1.s
+        arr(i*2 + 1) = pair._2.s
+        i += 1
+      arr.immutable(using Unsafe)
+
+  def from(map: Map[Text, Text]): Attributes =
+    if map.isEmpty then empty else
+      val n = map.size
+      val arr = new Array[String](n*2)
+      var i = 0
+      map.foreach: (k, v) =>
+        arr(i*2) = k.s
+        arr(i*2 + 1) = v.s
+        i += 1
+      arr.immutable(using Unsafe)
+
+  // Construct an `Attributes` directly from an interleaved `IArray`. The
+  // caller guarantees the array's length is even and that every key slot
+  // (even index) holds a non-null `String`. Used by the parser, which
+  // assembles the interleaved array as it tokenizes attributes.
+  private[xylophone] inline def fromInterleaved(array: IArray[String]): Attributes = array
+
+  // Unwrap to the raw `Array[String]` for hot-path internal access. Safe
+  // within the package: the storage is shared but never mutated outside
+  // construction.
+  private[xylophone] inline def storage(attrs: Attributes): Array[String] =
+    attrs.asInstanceOf[Array[String]]
+
+  extension (attrs: Attributes)
+    inline def size: Int = attrs.length/2
+    inline def isEmpty: Boolean = attrs.length == 0
+    inline def nonEmpty: Boolean = attrs.length > 0
+    inline def nil: Boolean = attrs.length == 0
+
+    def apply(key: Text): Text =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var i = 0
+      while i < n do
+        if a(i) == keyStr then return a(i + 1).asInstanceOf[Text]
+        i += 2
+      throw new NoSuchElementException(s"key not found: $key")
+
+    def at(key: Text): Optional[Text] =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var i = 0
+      while i < n do
+        if a(i) == keyStr then return a(i + 1).asInstanceOf[Text]
+        i += 2
+      Unset
+
+    def contains(key: Text): Boolean =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var i = 0
+      while i < n do
+        if a(i) == keyStr then return true
+        i += 2
+      false
+
+    def keys: Iterator[Text] =
+      val a = storage(attrs)
+      new Iterator[Text]:
+        private var i: Int = 0
+        def hasNext: Boolean = i < a.length
+        def next(): Text =
+          val k = a(i).asInstanceOf[Text]
+          i += 2
+          k
+
+    def values: Iterator[Text] =
+      val a = storage(attrs)
+      new Iterator[Text]:
+        private var i: Int = 1
+        def hasNext: Boolean = i < a.length
+        def next(): Text =
+          val v = a(i).asInstanceOf[Text]
+          i += 2
+          v
+
+    def iterator: Iterator[(Text, Text)] =
+      val a = storage(attrs)
+      new Iterator[(Text, Text)]:
+        private var i: Int = 0
+        def hasNext: Boolean = i < a.length
+        def next(): (Text, Text) =
+          val pair = (a(i).asInstanceOf[Text], a(i + 1).asInstanceOf[Text])
+          i += 2
+          pair
+
+    def toMap: Map[Text, Text] =
+      val a = storage(attrs)
+      if a.length == 0 then ListMap.empty else
+        val b = ListMap.newBuilder[Text, Text]
+        var i = 0
+        while i < a.length do
+          b += ((a(i).asInstanceOf[Text], a(i + 1).asInstanceOf[Text]))
+          i += 2
+        b.result()
+
+    def toList: List[(Text, Text)] =
+      val a = storage(attrs)
+      val b = List.newBuilder[(Text, Text)]
+      var i = 0
+      while i < a.length do
+        b += ((a(i).asInstanceOf[Text], a(i + 1).asInstanceOf[Text]))
+        i += 2
+      b.result()
+
+    def each(action: (Text, Text) => Unit): Unit =
+      val a = storage(attrs)
+      var i = 0
+      while i < a.length do
+        action(a(i).asInstanceOf[Text], a(i + 1).asInstanceOf[Text])
+        i += 2
+
+    def foreach(action: (Text, Text) => Unit): Unit = each(action)
+
+    def map[B](f: ((Text, Text)) => B): Iterable[B] =
+      val a = storage(attrs)
+      val b = List.newBuilder[B]
+      var i = 0
+      while i < a.length do
+        b += f((a(i).asInstanceOf[Text], a(i + 1).asInstanceOf[Text]))
+        i += 2
+      b.result()
+
+    def removed(key: Text): Attributes =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var idx = -1
+      var i = 0
+      while idx < 0 && i < n do
+        if a(i) == keyStr then idx = i
+        i += 2
+      if idx < 0 then attrs else
+        val nu = new Array[String](n - 2)
+        if idx > 0 then jl.System.arraycopy(a, 0, nu, 0, idx)
+        if idx < n - 2 then jl.System.arraycopy(a, idx + 2, nu, idx, n - 2 - idx)
+        nu.immutable(using Unsafe)
+
+    inline def `-`(key: Text): Attributes = removed(key)
+
+    def `--`(others: Iterable[Text]): Attributes =
+      if isEmpty then attrs else
+        var result: Attributes = attrs
+        others.foreach { k => result = result.removed(k) }
+        result
+
+    def updated(key: Text, value: Text): Attributes =
+      val a = storage(attrs)
+      val keyStr: String = key.s
+      val n = a.length
+      var idx = -1
+      var i = 0
+      while idx < 0 && i < n do
+        if a(i) == keyStr then idx = i
+        i += 2
+      if idx >= 0 then
+        val nu = new Array[String](n)
+        jl.System.arraycopy(a, 0, nu, 0, n)
+        nu(idx + 1) = value.s
+        nu.immutable(using Unsafe)
+      else
+        val nu = new Array[String](n + 2)
+        jl.System.arraycopy(a, 0, nu, 0, n)
+        nu(n) = keyStr
+        nu(n + 1) = value.s
+        nu.immutable(using Unsafe)
+
+    def `++`(other: Attributes): Attributes =
+      val a = storage(attrs)
+      val b = storage(other)
+      if b.length == 0 then attrs
+      else if a.length == 0 then other
+      else
+        val total = a.length + b.length
+        val nu = new Array[String](total)
+        var written = 0
+        var i = 0
+        while i < a.length do
+          val k = a(i)
+          var bi = 0
+          var found = -1
+          while found < 0 && bi < b.length do
+            if b(bi) == k then found = bi
+            bi += 2
+          nu(written) = k
+          nu(written + 1) = if found >= 0 then b(found + 1) else a(i + 1)
+          written += 2
+          i += 2
+        var j = 0
+        while j < b.length do
+          val k = b(j)
+          var ai = 0
+          var found = false
+          while !found && ai < a.length do
+            if a(ai) == k then found = true
+            ai += 2
+          if !found then
+            nu(written) = k
+            nu(written + 1) = b(j + 1)
+            written += 2
+          j += 2
+        if written == total then nu.immutable(using Unsafe)
+        else
+          val tu = new Array[String](written)
+          jl.System.arraycopy(nu, 0, tu, 0, written)
+          tu.immutable(using Unsafe)
+
+    def `++`(other: Map[Text, Text]): Attributes =
+      if other.isEmpty then attrs else attrs ++ Attributes.from(other)
+
+    // Same set of (key, value) pairs (order-insensitive). Iterates the left,
+    // looks up each key in the right.
+    def equalsAttributes(other: Attributes): Boolean =
+      val a = storage(attrs)
+      val b = storage(other)
+      val n = a.length
+      if n != b.length then false else
+        var i = 0
+        var ok = true
+        while ok && i < n do
+          val k = a(i)
+          val va = a(i + 1)
+          var j = 0
+          var found = -1
+          while found < 0 && j < n do
+            if b(j) == k then found = j
+            j += 2
+          if found < 0 then ok = false
+          else if va != b(found + 1) then ok = false
+          i += 2
+        ok
+
+    def hashAttributes: Int =
+      // Order-independent: XOR of (key.hash * 31 ^ value.hash).
+      val a = storage(attrs)
+      var h = 0
+      var i = 0
+      while i < a.length do
+        h = h ^ (a(i).hashCode*31 ^ a(i + 1).hashCode)
+        i += 2
+      h

--- a/lib/xylophone/src/core/xylophone.Tag.scala
+++ b/lib/xylophone/src/core/xylophone.Tag.scala
@@ -41,19 +41,19 @@ import typonym.*
 
 object Tag:
   def root(children: Set[Text]): Tag =
-    new Tag("#root", Map(), children):
+    new Tag("#root", Attributes.empty, children):
       type Result = this.type
 
-      def node(attributes: Map[Text, Text]): Result = this
+      def node(attributes: Attributes): Result = this
 
-  def freeform(label: Text): Container = Container(label, Map(), Set())
+  def freeform(label: Text): Container = Container(label, Attributes.empty, Set())
 
 
   def container
     [ label    <: Label: ValueOf,
       children <: Label: Reifiable to List[String],
       schema   <: XmlSchema ]
-    ( presets: Map[Text, Text] = Map() )
+    ( presets: Attributes = Attributes.empty )
   :   Container of label over children in schema =
 
     val admissible: Set[Text] = children.reification().map(_.tt).to(Set)
@@ -64,23 +64,23 @@ object Tag:
     . in[schema]
 
 
-  class Container(label: Text, presets: Map[Text, Text] = Map(), admissible: Set[Text] = Set())
+  class Container(label: Text, presets: Attributes = Attributes.empty, admissible: Set[Text] = Set())
   extends Tag(label, presets, admissible):
 
     type Result = Element & Xml.Populable of Topic over Transport in Form
 
-    def node(attributes: Map[Text, Text]): Result =
+    def node(attributes: Attributes): Result =
       new Element(label, presets ++ attributes, IArray()) with Xml.Populable()
       . of[Topic]
       . over[Transport]
       . in[Form]
 
 abstract class Tag
-  ( label: Text, val presets: Map[Text, Text] = Map(), val admissible:  Set[Text] = Set() )
+  ( label: Text, val presets: Attributes = Attributes.empty, val admissible:  Set[Text] = Set() )
 extends Element(label, presets, IArray()), Formal, Dynamic:
   type Result <: Element
 
   inline def applyDynamicNamed(method: "apply")(inline attributes: (String, Any)*): Result =
     ${xylophone.internal.attributes[Result, this.type]('this, 'attributes)}
 
-  def node(attributes: Map[Text, Text]): Result
+  def node(attributes: Attributes): Result

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -521,16 +521,22 @@ object Xml extends Tag.Container
     protected inline def advance(): Unit = cursor.next()
     protected inline def position: Int = cursor.position.n0
 
-    protected inline def begin(): Cursor.Mark = cursor.mark(using heldToken.nn)
+    // Non-`inline` so that `cursor.mark`'s lineation-tracking expansion
+    // (recordMark allocation + `lineationActive` branch) is emitted once in
+    // its own method rather than re-expanded into every call site, keeping
+    // `XmlParser`'s hot methods small enough for HotSpot's free-inline
+    // budgets. The JIT can still inline at hot call sites via its own
+    // heuristics.
+    protected def begin(): Cursor.Mark = cursor.mark(using heldToken.nn)
 
-    protected inline def slice(start: Cursor.Mark): Text =
+    protected def slice(start: Cursor.Mark): Text =
       val end = cursor.mark(using heldToken.nn)
       cursor.grab(start, end).asInstanceOf[Text]
 
-    protected inline def slice(start: Cursor.Mark, end: Cursor.Mark): Text =
+    protected def slice(start: Cursor.Mark, end: Cursor.Mark): Text =
       cursor.grab(start, end).asInstanceOf[Text]
 
-    protected inline def reset(start: Cursor.Mark): Unit = cursor.cue(start)
+    protected def reset(start: Cursor.Mark): Unit = cursor.cue(start)
 
     protected def appendSlice(start: Cursor.Mark, buf: jl.StringBuilder): Unit =
       val end = cursor.mark(using heldToken.nn)

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -505,6 +505,14 @@ object Xml extends Tag.Container
 
     private var heldToken: Cursor.Held | Null = null
 
+    // Parser-shared scratch buffer for attribute accumulation (lifetime of
+    // the `XmlParser` instance). Stores key/value pairs interleaved as
+    // `[k0, v0, k1, v1, ...]`. `readAttributes()` writes here and snapshots
+    // the populated prefix into a `ListMap` at the end. Replaces the previous
+    // `var entries: Map[Text, Text] = ListMap(); entries.updated(...)` loop,
+    // which allocated a fresh `ListMap` per attribute. Geometric growth.
+    private var attrBuf: Array[Text] = new Array[Text](16)
+
     protected inline def more: Boolean = cursor.more
 
     protected inline def peek: Char =
@@ -667,8 +675,30 @@ object Xml extends Tag.Container
         buf.toString.nn.tt
 
     protected def readAttributes(tag: Text)(using Tactic[ParseError]): Map[Text, Text] =
-      var entries: Map[Text, Text] = ListMap()
+      // Append into the parser-shared interleaved scratch buffer (laid out as
+      // `[k0, v0, k1, v1, ...]`); on close, snapshot the populated prefix
+      // into a single `ListMap`. Replaces the previous
+      // `entries.updated(...)`-per-attribute loop, which allocated a fresh
+      // `ListMap` for every attribute.
+      //
+      // Duplicate detection uses a Bloom-filter-style cheap test before
+      // falling back to a linear scan: maintain a running OR of the
+      // hashCodes of all already-stored keys, and for each new key check
+      // whether `(hashOr | h) == hashOr`. If the new hash has any bit
+      // outside the accumulated envelope it cannot match any prior key and
+      // the scan is skipped. Only when its bits are all already in the
+      // envelope (rare for typical low-attribute-count elements with
+      // disjoint label hashes) do we walk the existing keys to confirm.
+      var n = 0
       var done = false
+      var hashOr = 0
+
+      inline def ensureCapacity(): Unit =
+        if 2*n >= attrBuf.length then
+          val nu = new Array[Text](attrBuf.length*2)
+          jl.System.arraycopy(attrBuf, 0, nu, 0, 2*n)
+          attrBuf = nu
+
       while !done do
         skipWs()
         if !more then fail(Issue.ExpectedMore)
@@ -678,11 +708,23 @@ object Xml extends Tag.Container
           callback.let(_(position.z, Hole.Tagbody))
           advance()
           skipWs()
-          entries = entries.updated(t"\u0000", t"")
+          ensureCapacity()
+          attrBuf(2*n) = t"\u0000"
+          attrBuf(2*n + 1) = t""
+          n += 1
         else
           val keyStart = begin()
           val key = readName()
-          if entries.contains(key) then fail(Issue.DuplicateAttribute(key), keyStart)
+          val h: Int = key.s.hashCode
+
+          if (hashOr | h) == hashOr then
+            var dup = 0
+            while dup < 2*n do
+              if attrBuf(dup) == key then fail(Issue.DuplicateAttribute(key), keyStart)
+              dup += 2
+
+          hashOr |= h
+
           skipWs()
           expectChar('=')
           skipWs()
@@ -697,8 +739,19 @@ object Xml extends Tag.Container
               advance()
               readAttrValue(tag, q)
             else fail(Issue.UnquotedAttribute, keyStart)
-          entries = entries.updated(key, value)
-      entries
+          ensureCapacity()
+          attrBuf(2*n) = key
+          attrBuf(2*n + 1) = value
+          n += 1
+
+      if n == 0 then ListMap.empty
+      else
+        val b = ListMap.newBuilder[Text, Text]
+        var i = 0
+        while i < n do
+          b += ((attrBuf(2*i), attrBuf(2*i + 1)))
+          i += 1
+        b.result()
 
     // Read text up to the next '<'; returns the (possibly entity-expanded)
     // Text. Detects literal `]]>` as an error. Reports `\u0000` holes via

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -508,10 +508,9 @@ object Xml extends Tag.Container
     // Parser-shared scratch buffer for attribute accumulation (lifetime of
     // the `XmlParser` instance). Stores key/value pairs interleaved as
     // `[k0, v0, k1, v1, ...]`. `readAttributes()` writes here and snapshots
-    // the populated prefix into a `ListMap` at the end. Replaces the previous
-    // `var entries: Map[Text, Text] = ListMap(); entries.updated(...)` loop,
-    // which allocated a fresh `ListMap` per attribute. Geometric growth.
-    private var attrBuf: Array[Text] = new Array[Text](16)
+    // the populated prefix into a freshly-sized `IArray[String]` to wrap
+    // as the opaque `Attributes`. Geometric growth.
+    private var attrBuf: Array[String] = new Array[String](16)
 
     protected inline def more: Boolean = cursor.more
 
@@ -680,12 +679,11 @@ object Xml extends Tag.Container
         advance() // consume closing quote
         buf.toString.nn.tt
 
-    protected def readAttributes(tag: Text)(using Tactic[ParseError]): Map[Text, Text] =
+    protected def readAttributes(tag: Text)(using Tactic[ParseError]): Attributes =
       // Append into the parser-shared interleaved scratch buffer (laid out as
       // `[k0, v0, k1, v1, ...]`); on close, snapshot the populated prefix
-      // into a single `ListMap`. Replaces the previous
-      // `entries.updated(...)`-per-attribute loop, which allocated a fresh
-      // `ListMap` for every attribute.
+      // into a freshly-sized `IArray[String]` and wrap it as the opaque
+      // `Attributes`.
       //
       // Duplicate detection uses a Bloom-filter-style cheap test before
       // falling back to a linear scan: maintain a running OR of the
@@ -701,7 +699,7 @@ object Xml extends Tag.Container
 
       inline def ensureCapacity(): Unit =
         if 2*n >= attrBuf.length then
-          val nu = new Array[Text](attrBuf.length*2)
+          val nu = new Array[String](attrBuf.length*2)
           jl.System.arraycopy(attrBuf, 0, nu, 0, 2*n)
           attrBuf = nu
 
@@ -715,18 +713,19 @@ object Xml extends Tag.Container
           advance()
           skipWs()
           ensureCapacity()
-          attrBuf(2*n) = t"\u0000"
-          attrBuf(2*n + 1) = t""
+          attrBuf(2*n) = "\u0000"
+          attrBuf(2*n + 1) = ""
           n += 1
         else
           val keyStart = begin()
           val key = readName()
-          val h: Int = key.s.hashCode
+          val keyStr: String = key.s
+          val h: Int = keyStr.hashCode
 
           if (hashOr | h) == hashOr then
             var dup = 0
             while dup < 2*n do
-              if attrBuf(dup) == key then fail(Issue.DuplicateAttribute(key), keyStart)
+              if attrBuf(dup) == keyStr then fail(Issue.DuplicateAttribute(key), keyStart)
               dup += 2
 
           hashOr |= h
@@ -746,18 +745,15 @@ object Xml extends Tag.Container
               readAttrValue(tag, q)
             else fail(Issue.UnquotedAttribute, keyStart)
           ensureCapacity()
-          attrBuf(2*n) = key
-          attrBuf(2*n + 1) = value
+          attrBuf(2*n) = keyStr
+          attrBuf(2*n + 1) = value.s
           n += 1
 
-      if n == 0 then ListMap.empty
+      if n == 0 then Attributes.empty
       else
-        val b = ListMap.newBuilder[Text, Text]
-        var i = 0
-        while i < n do
-          b += ((attrBuf(2*i), attrBuf(2*i + 1)))
-          i += 1
-        b.result()
+        val arr = new Array[String](2*n)
+        jl.System.arraycopy(attrBuf, 0, arr, 0, 2*n)
+        Attributes.fromInterleaved(arr.immutable(using Unsafe))
 
     // Read text up to the next '<'; returns the (possibly entity-expanded)
     // Text. Detects literal `]]>` as an error. Reports `\u0000` holes via
@@ -976,7 +972,7 @@ object Xml extends Tag.Container
         if !more then fail(Issue.ExpectedMore)
         if peek != '>' then fail(Issue.Unexpected(peek))
         advance()
-        Element(t"\u0000", ListMap(), IArray.empty[Node])
+        Element(t"\u0000", Attributes.empty, IArray.empty[Node])
       else
         val name = readName()
         val attrs = readAttributes(name)
@@ -1192,7 +1188,7 @@ case class TextNode(text: Text) extends Node:
 
 case class Element
   ( label:      Text,
-    attributes: Map[Text, Text],
+    attributes: Attributes,
     children:   IArray[Node] )
 extends Node, Topical, Transportive:
   override def toString(): String =
@@ -1202,14 +1198,14 @@ extends Node, Topical, Transportive:
     case Fragment(node: Element) => this == node
 
     case Element(label, attributes, children) =>
-      label == this.label && attributes == this.attributes
+      label == this.label && attributes.equalsAttributes(this.attributes)
       && ju.Arrays.equals(children.mutable(using Unsafe), this.children.mutable(using Unsafe))
 
     case _ =>
       false
 
   override def hashCode: Int =
-    ju.Arrays.hashCode(children.mutable(using Unsafe)) ^ attributes.hashCode ^ label.hashCode
+    ju.Arrays.hashCode(children.mutable(using Unsafe)) ^ attributes.hashAttributes ^ label.hashCode
 
 
   def selectDynamic(name: Label)(using attribute: name.type is Xml.XmlAttribute on Topic in Form)

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -756,42 +756,46 @@ object Xml extends Tag.Container
     // Read text up to the next '<'; returns the (possibly entity-expanded)
     // Text. Detects literal `]]>` as an error. Reports `\u0000` holes via
     // the callback.
+    //
+    // Single-pass: walk the text region tracking the `]]>` window with a
+    // simple counter; if no entity/hole is encountered the result comes
+    // from a single `slice`. The first `&` or `\u0000` hit lazily allocates
+    // a `StringBuilder`, flushes the accumulated plain text into it, and
+    // the loop continues in the same iteration, re-using the running
+    // `bracketCount`. The previous form rescanned the whole region a
+    // second time once an entity was detected.
     protected def readText(parentLabel: Text)(using Tactic[ParseError]): Text =
       val start = begin()
-      var hasEntity = false
-      var hasHole = false
       var bracketCount = 0
+      var buf: jl.StringBuilder | Null = null
+      var segStart: Cursor.Mark = start
+
       while more && peek != '<' do
         val c = peek
-        if c == '&' then hasEntity = true
-        if c == '\u0000' then hasHole = true
         if c == ']' then bracketCount += 1
         else
           if bracketCount >= 2 && c == '>' then fail(Issue.Unexpected('>'), start)
           bracketCount = 0
-        advance()
-      if !hasEntity && !hasHole then slice(start)
+
+        if c == '&' then
+          if buf == null then buf = jl.StringBuilder()
+          appendSlice(segStart, buf.nn)
+          advance()
+          buf.nn.append(readEntity().s)
+          segStart = begin()
+        else if c == '\u0000' then
+          if buf == null then buf = jl.StringBuilder()
+          appendSlice(segStart, buf.nn)
+          callback.let(_(position.z, Hole.Node(parentLabel)))
+          buf.nn.append('\u0000')
+          advance()
+          segStart = begin()
+        else advance()
+
+      if buf == null then slice(start)
       else
-        val buf = jl.StringBuilder()
-        reset(start)
-        var segStart = begin()
-        while more && peek != '<' do
-          val c = peek
-          if c == '&' then
-            appendSlice(segStart, buf)
-            advance()
-            buf.append(readEntity().s)
-            segStart = begin()
-          else if c == '\u0000' then
-            appendSlice(segStart, buf)
-            callback.let(_(position.z, Hole.Node(parentLabel)))
-            buf.append('\u0000')
-            advance()
-            segStart = begin()
-          else
-            advance()
-        appendSlice(segStart, buf)
-        buf.toString.nn.tt
+        appendSlice(segStart, buf.nn)
+        buf.nn.toString.nn.tt
 
     protected def readComment()(using Tactic[ParseError]): Text =
       val start = begin()

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -142,7 +142,7 @@ object internal:
             types ::= TypeRepr.of[Map[Text, Text]]
             iterator.next()
             val others = Expr.ofList(pattern.attributes.keys.to(List).map(Expr(_)))
-            '{$expr && { $array(${Expr(index)}) = ${scrutinee}.attributes -- $others; true }}
+            '{$expr && { $array(${Expr(index)}) = (${scrutinee}.attributes -- $others).toMap; true }}
 
           case head :: tail =>
             attributes(tail):
@@ -158,7 +158,7 @@ object internal:
 
               '{$expr && $boolean}
 
-        val attributesChecked = attributes(pattern.attributes.to(List).map(_(0)))('{true})
+        val attributesChecked = attributes(pattern.attributes.toList.map(_(0)))('{true})
 
         val children = '{$scrutinee.children}
 
@@ -520,7 +520,7 @@ object internal:
           List('{Header(${Expr(version)}, $encoding2, $standalone2)})
 
         case Element(label, attributes, children) =>
-          val exprs = attributes.to(List).map: (key, value) =>
+          val exprs = attributes.toList.map: (key, value) =>
             ' {
                 ( ${Expr(key)},
                   $ {
@@ -534,7 +534,7 @@ object internal:
           val map = '{Map(${Expr.ofList(exprs)}*)}
           val elements = '{IArray(${Expr.ofList(children.flatMap(serialize(_)))}*)}
 
-          List('{Element(${Expr(label)}, $map, $elements)})
+          List('{Element(${Expr(label)}, Attributes.from($map), $elements)})
 
         case Comment(text) =>
           val parts = text.cut(t"\u0000").map(_.s)
@@ -674,4 +674,4 @@ object internal:
 
                 . or(halt(m"unexpected type"))
 
-    '{$tag.node(${Expr.ofList(attributes)}.compact.to(Map))}.asExprOf[result]
+    '{$tag.node(Attributes.from(${Expr.ofList(attributes)}.compact.to(Map)))}.asExprOf[result]

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -54,10 +54,10 @@ case class Pixel(x: Int, y: Int, color: ColorVal)
 object Tests extends Suite(m"Xylophone tests"):
 
   def elem(label: Text, children: Node*): Element =
-    Element(label, scala.collection.immutable.ListMap(), IArray.from(children))
+    Element(label, Attributes.empty, IArray.from(children))
 
   def elem(label: Text, attrs: Map[Text, Text], children: Node*): Element =
-    Element(label, attrs, IArray.from(children))
+    Element(label, Attributes.from(attrs), IArray.from(children))
 
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform
@@ -767,7 +767,7 @@ object Tests extends Suite(m"Xylophone tests"):
     suite(m"Additional element tests"):
       test(m"Element with multiple attributes preserves order"):
         t"""<a x="1" y="2" z="3"/>""".read[Xml].absolve match
-          case Element(_, attributes, _) => attributes.to(List).map(_(0))
+          case Element(_, attributes, _) => attributes.toList.map(_(0))
       . assert(_ == List(t"x", t"y", t"z"))
 
       test(m"Tab and newline allowed in attribute value (normalized)"):


### PR DESCRIPTION
Reduce per-element and per-text-region overhead in the XML parser. Four changes — interleaved attribute scratch buffer with a Bloom-filter-style duplicate skip, a single-pass readText that lazily allocates its StringBuilder only when an entity or hole is encountered, de-inlining of the heavy `begin` / `slice` / `reset` helpers, and switching `Element`'s `attributes` field from `Map[Text, Text]` to an opaque `Attributes` type backed by `IArray[String]` — collectively raise xylophone's parse throughput on `mill xylophone.bench.run` across all five fixtures and trim the per-element heap footprint.

Throughput on the bundled `xylophone.bench` fixtures versus the previous
`main`:

| Example                | Before | After | scala-xml |
|------------------------|--------|-------|-----------|
| RSS feed (3.2 kB)      | 220    | 237   | 221       |
| SOAP envelope (901 B)  | 201    | 208   | 120       |
| Atom feed (15 kB)      | 240    | 241   | 180       |
| 100 book records       | 220    | 227   | 111       |
| 500 log entries (90 kB)| 310    | 320   | 200       |

(throughput in MB/s)

xylophone was already 1.05–2.0× faster than scala-xml; this widens the
margin further. The biggest individual lifts are on text-heavy fixtures
(single-pass readText) and on attribute-heavy fixtures (opaque
`Attributes` collapses the per-element heap allocation from a
`ListMap` chain to a single `IArray[String]`).

The work touches several places:

- `Attributes` is now an opaque `IArray[String]` alias with alternating
  keys and values; non-empty attribute sets cost a single array
  allocation per element instead of a `ListMap` chain. Methods
  previously available on `Map[Text, Text]` are now extensions on
  the companion (`apply` / `at` / `each` / `iterator` / `keys` /
  `updated` / `++` / `--` / `removed` / `toMap` / etc.). `Element`
  uses `equalsAttributes` / `hashAttributes` extensions for
  structural equality.
- `readAttributes` appends to a parser-shared `Array[String]` scratch
  buffer (keys/values interleaved) and snapshots the result as the
  opaque `Attributes` directly. Previously each attribute did
  `entries.updated(k, v)`, allocating a fresh `ListMap` per attribute
  (`O(n²)` total). Duplicate detection uses a Bloom-filter-style
  cheap test (running OR of stored hash codes) before falling back to
  a linear scan, so the typical no-duplicates case is `O(n)`.
- `readText` collapses its previous two-pass scan (one cheap pass to
  detect `&` / NUL / `]]>`, then a slow pass to materialise the buffer
  if needed) into a single pass that lazily allocates the
  `StringBuilder` on the first entity or hole hit. Plain text still
  comes from a single `slice` with no `StringBuilder` allocated.
- `begin` / `slice` / `reset` are no longer source-level `inline`. The
  `cursor.mark` body (lineation tracking + `recordMark`) is now emitted
  once per method instead of being re-expanded into every call site,
  which keeps `XmlParser`'s hot methods small enough for HotSpot's
  free-inline budgets.

Pattern-extractor macros (`internal.scala`) still yield a
`Map[Text, Text]` for captured tag-body attribute holes so user code
can continue to compare to `ListMap` literals.
