### PR TITLE
Clean up temp dirs leaked by Rig.dispatch and test scaffolding

### DIFF
--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -51,6 +51,8 @@ extension (shell: Shell)
 
         val path = summon[Enclave.Tool].path.parent.vouch.encode
 
+        var psFile: Optional[Path on Linux] = Unset
+
         val shellInvocation = shell match
           case Shell.Zsh        => t"zsh -l"
           case Shell.Fish       => t"fish -l"
@@ -110,9 +112,10 @@ extension (shell: Shell)
             import filesystemOptions.dereferenceSymlinks.enabled
             import charEncoders.utf8
 
-            val psFile: Path on Linux = unsafely(temporaryDirectory/t"exoskeleton-${Uuid()}.ps1")
-            unsafely(psFile.open(psScript.tt.writeTo(_)))
-            t"POWERSHELL_UPDATECHECK=Off pwsh -NoLogo -NoExit -File ${psFile.encode}"
+            val file: Path on Linux = unsafely(temporaryDirectory/t"exoskeleton-${Uuid()}.ps1")
+            unsafely(file.open(psScript.tt.writeTo(_)))
+            psFile = file
+            t"POWERSHELL_UPDATECHECK=Off pwsh -NoLogo -NoExit -File ${file.encode}"
 
         sh"tmux new-session -d -s ${tmux.id} -x $width -y $height '$shellInvocation'".exec[Unit]()
         Tmux.attend:
@@ -164,5 +167,9 @@ extension (shell: Shell)
         val result = action
 
         sh"tmux kill-session -t ${tmux.id}".exec[Exit]()
+
+        psFile.let: file =>
+          import filesystemOptions.deleteRecursively.disabled
+          safely(file.delete())
 
         result

--- a/lib/superlunary/src/core/superlunary.Rig.scala
+++ b/lib/superlunary/src/core/superlunary.Rig.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package superlunary
 
+import java.nio.file as jnf
+import java.util as ju
 import java.util.function as juf
+import java.lang as jl
 
 import scala.quoted.*
 
@@ -50,6 +53,20 @@ import serpentine.*
 
 import interfaces.paths.pathOnLinux
 import systems.java
+
+
+def deleteOnShutdown(directory: jnf.Path): Unit =
+  val runnable: Runnable = () =>
+    if jnf.Files.exists(directory) then
+      val stream = jnf.Files.walk(directory).nn
+      try
+        stream.sorted(ju.Comparator.reverseOrder).nn.forEach: path =>
+          try
+            val _ = jnf.Files.deleteIfExists(path.nn)
+          catch case _: Throwable => ()
+      finally stream.close()
+
+  jl.Runtime.getRuntime.nn.addShutdownHook(jl.Thread(runnable))
 
 
 trait Rig(using classloader0: Classloader) extends Targetable, Formal, Transportive:
@@ -112,6 +129,8 @@ trait Rig(using classloader0: Classloader) extends Targetable, Formal, Transport
         val out =
           import strategies.throwUnsafely
           (temporaryDirectory / uuid).on[Linux]
+
+        deleteOnShutdown(jnf.Paths.get(out.encode.s).nn)
 
         val settings: staging.Compiler.Settings =
           staging.Compiler.Settings.make

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -59,6 +59,18 @@ object Tests extends Suite(m"Ziggurat tests"):
     else runTests()
 
   def runTests(): Unit =
+    val tempDirs = scala.collection.mutable.ListBuffer.empty[Path on Linux]
+
+    def tempDir(): Path on Linux =
+      val dir: Path on Linux = temporaryDirectory[Path on Linux] / Uuid().show
+      dir.create[Directory]()
+      tempDirs += dir
+      dir
+
+    try runTestsBody(tempDir) finally tempDirs.foreach: dir =>
+      safely(dir.delete())
+
+  private def runTestsBody(tempDir: () => Path on Linux): Unit =
     val labels = List(t"linux-x64", t"linux-arm64", t"macos-x64", t"macos-arm64")
 
     val payloads = labels.map: label =>
@@ -68,8 +80,7 @@ object Tests extends Suite(m"Ziggurat tests"):
     val bundleBytes: Data = PolyglotInstaller.bundle(payloads)
 
     def stage(): (Path on Linux, Path on Linux) =
-      val dir: Path on Linux = temporaryDirectory[Path on Linux] / Uuid().show
-      dir.create[Directory]()
+      val dir = tempDir()
       val script = dir / t"hello"
       script.create[File]()
       script.open: handle =>
@@ -129,8 +140,7 @@ object Tests extends Suite(m"Ziggurat tests"):
       if !winSshOk
       then Out.println(t"Windows host $host unreachable via SSH; skipping Windows tests")
       else
-        val workDir: Path on Linux = temporaryDirectory[Path on Linux] / Uuid().show
-        workDir.create[Directory]()
+        val workDir: Path on Linux = tempDir()
 
         val compilePs = workDir / t"compile.ps1"
         compilePs.create[File]()


### PR DESCRIPTION
Test runs in Ethereal, Exoskeleton, Profanity, and Ziggurat were leaving
behind UUID-named directories in the system temporary directory on every
run — most from `superlunary.Rig.dispatch` caching a ~130 MB staged binary
per invocation, plus a few smaller per-test scratch files. JVM shutdown
hooks and a test-side `finally` block now clean these up so the temp
directory stays clean across runs.

`superlunary.Rig.dispatch` now registers a JVM shutdown hook to recursively
delete its staged output directory on exit. This affects every tool built
on `Rig` — including `Enclave` in Exoskeleton — so the per-dispatch temp
directory is no longer retained beyond the JVM's lifetime.

`Shell.tmux` (in `exoskeleton.rig`) now removes the
`exoskeleton-{uuid}.ps1` launcher script it writes into the temp directory
after the tmux session is killed.

Ziggurat's tests now track every staged directory they create and delete
them in a `finally` block.