### PR TITLE
ethereal: fix Windows startup, console flash, and orphan JVMs

### DIFF
--- a/lib/ethereal/Cargo.toml
+++ b/lib/ethereal/Cargo.toml
@@ -25,6 +25,7 @@ uds_windows = "1"
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_System_Console",
+  "Win32_System_JobObjects",
   "Win32_System_Threading",
   "Win32_System_IO",
   "Win32_Storage_FileSystem",

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -210,9 +210,12 @@ def cli[bus <: Matchable](using executive: Executive)
   val startTime: Long =
     safely(System.properties.ethereal.startTime[Long]()).or(jl.System.currentTimeMillis())
 
-  val runtimeDir: Optional[Path on Local] = Xdg.runtimeDir
-  val stateHome: Path on Local = Xdg.stateHome
-  val baseDir: Path on Local = runtimeDir.or(stateHome) //name
+  // Use `Directories.*` rather than `Xdg.*` so Windows resolves to a native
+  // location (`%LOCALAPPDATA%\Temp`) instead of `%USERPROFILE%\.local\state`,
+  // which the Rust launcher in `state.rs` does not look at.
+  val runtimeDir: Optional[Path on Local] = Directories.runtimeDir
+  val stateHome: Path on Local = Directories.stateHome
+  val baseDir: Path on Local = runtimeDir.or(stateHome)
   val buildFile: Path on Local = baseDir/name/"build"
   val pidFile: Path on Local = baseDir/name/"pid"
   val socketFile: Path on Local = baseDir/name/"socket"

--- a/lib/ethereal/src/runner/src/state.rs
+++ b/lib/ethereal/src/runner/src/state.rs
@@ -7,18 +7,41 @@ use crate::uds::UnixStream;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+// Must match the Scala daemon's view of the base directory (see
+// `ethereal_core.scala`, which uses `Directories.runtimeDir.or(Directories.stateHome)`),
+// otherwise the launcher polls one socket path while the JVM binds another and
+// startup silently times out.
 pub fn base_dir(name: &str) -> PathBuf {
-    let runtime = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from);
-    let state = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
-    let home = std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local").join("state"));
-    let base = runtime.or(state).or(home).unwrap_or_else(|| PathBuf::from("."));
+    #[cfg(windows)]
+    let base = local_app_data().join("Temp");
+    #[cfg(unix)]
+    let base = {
+        let runtime = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from);
+        let state = std::env::var_os("XDG_STATE_HOME").map(PathBuf::from);
+        let home = std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local").join("state"));
+        runtime.or(state).or(home).unwrap_or_else(|| PathBuf::from("."))
+    };
     base.join(name)
 }
 
 pub fn data_home() -> PathBuf {
-    if let Some(dir) = std::env::var_os("XDG_DATA_HOME") { return PathBuf::from(dir); }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home).join(".local").join("share");
+    #[cfg(windows)]
+    { local_app_data() }
+    #[cfg(unix)]
+    {
+        if let Some(dir) = std::env::var_os("XDG_DATA_HOME") { return PathBuf::from(dir); }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(".local").join("share");
+        }
+        PathBuf::from(".")
+    }
+}
+
+#[cfg(windows)]
+fn local_app_data() -> PathBuf {
+    if let Some(dir) = std::env::var_os("LOCALAPPDATA") { return PathBuf::from(dir); }
+    if let Some(profile) = std::env::var_os("USERPROFILE") {
+        return PathBuf::from(profile).join("AppData").join("Local");
     }
     PathBuf::from(".")
 }

--- a/lib/ethereal/src/runner/src/wrapper.rs
+++ b/lib/ethereal/src/runner/src/wrapper.rs
@@ -58,6 +58,15 @@ pub fn run(args: &[String]) -> ! {
     const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
     if args.is_empty() { std::process::exit(1); }
+
+    // Tie the JVM's lifetime to the wrapper's via a Job Object with
+    // KILL_ON_JOB_CLOSE: when the wrapper dies — including via
+    // `Stop-Process -Force` / `TerminateProcess`, which bypasses any
+    // handler — the kernel closes the wrapper's handles, the job's last
+    // reference goes with them, and Windows terminates every process in
+    // the job. The JVM joins the job by inheritance from the wrapper.
+    bind_to_kill_on_close_job();
+
     let java = &args[0];
     let java_args = &args[1..];
     let mut child = match Command::new(java)
@@ -70,4 +79,35 @@ pub fn run(args: &[String]) -> ! {
     };
     let status = child.wait().ok();
     std::process::exit(status.and_then(|status| status.code()).unwrap_or(1));
+}
+
+#[cfg(windows)]
+fn bind_to_kill_on_close_job() {
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        JobObjectExtendedLimitInformation, SetInformationJobObject,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    unsafe {
+        let job: HANDLE = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        if job.is_null() { return; }
+
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let info_size = std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32;
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const _,
+            info_size,
+        );
+
+        AssignProcessToJobObject(job, GetCurrentProcess());
+        // Deliberately leak the handle: closing it now would trigger
+        // KILL_ON_JOB_CLOSE immediately. The kernel reclaims it when the
+        // wrapper exits, which is exactly the moment we want it to fire.
+    }
 }

--- a/lib/ethereal/src/runner/src/wrapper.rs
+++ b/lib/ethereal/src/runner/src/wrapper.rs
@@ -50,10 +50,21 @@ extern "C" fn forward(signal: libc::c_int) {
 
 #[cfg(windows)]
 pub fn run(args: &[String]) -> ! {
+    use std::os::windows::process::CommandExt;
+    // The wrapper itself was launched with DETACHED_PROCESS and so has no
+    // console; without CREATE_NO_WINDOW, Windows would allocate a fresh
+    // console for the JVM child and flash a "java" terminal window on screen
+    // for as long as the daemon runs.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
     if args.is_empty() { std::process::exit(1); }
     let java = &args[0];
     let java_args = &args[1..];
-    let mut child = match Command::new(java).args(java_args).spawn() {
+    let mut child = match Command::new(java)
+        .args(java_args)
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+    {
         Ok(child) => child,
         Err(_)    => std::process::exit(1),
     };


### PR DESCRIPTION
Three Windows-only fixes to the Ethereal launcher and daemon. First,
Ethereal programs now start successfully on Windows: the Rust launcher
and the Scala daemon were resolving the Unix-domain-socket path
differently and timing out silently. Second, the brief "java" terminal
window that flashed for the lifetime of the daemon process no longer
appears. Third, killing the native daemon process — including via
`Stop-Process -Force` — now also kills the JVM, instead of orphaning it.

### Windows runtime

- Ethereal-launched programs now start successfully on Windows. The
  Rust launcher previously fell back to the current directory when
  `XDG_RUNTIME_DIR`/`XDG_STATE_HOME`/`HOME` were unset (the typical
  Windows case), while the JVM resolved its base directory to
  `%USERPROFILE%\.local\state`. Both now use `%LOCALAPPDATA%\Temp\<name>`
  via `ambience.Directories.runtimeDir`/`stateHome`.
- The brief "java" terminal window that flashed for the lifetime of
  the daemon process no longer appears — the wrapper now passes
  `CREATE_NO_WINDOW` when spawning the JVM, since it has no console
  of its own (it was started with `DETACHED_PROCESS`).
- Killing the native daemon process now also kills the JVM. The wrapper
  binds itself to an anonymous Job Object with
  `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; the JVM joins the job by
  inheritance. When the wrapper dies for any reason — including
  `TerminateProcess` / `Stop-Process -Force` — Windows terminates every
  process in the job.