### PR TITLE
Add lane-based DAG renderer to Dendrology

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -492,6 +492,7 @@ object cosmopolite extends Library:
 object dendrology extends Library:
   object tree extends Component(gossamer.core)
   object dag extends Component(acyclicity.core)
+  object demo extends Component(dag, turbulence.core, ambience.core)
   object test extends Tests(tree, dag)
 
 object decorum extends Library:

--- a/lib/dendrology/src/dag/dendrology.DagTile.scala
+++ b/lib/dendrology/src/dag/dendrology.DagTile.scala
@@ -33,4 +33,5 @@
 package dendrology
 
 enum DagTile:
-  case Space, Corner, Vertical, FirstMid, Horizontal, MidLast, Cross, Overlap
+  case Space, CornerNe, Vertical, TeeE, Horizontal, TeeN, Crossing, Junction
+  case CornerNw, CornerSe, CornerSw, TeeW, TeeS, Node

--- a/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
@@ -1,0 +1,247 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package dendrology
+
+import scala.collection.mutable as scm
+
+import acyclicity.*
+import anticipation.*
+import gossamer.*
+import spectacular.*
+import vacuous.*
+
+import DagTile.*
+
+object LaneDagDiagram:
+  private case class Lane[node](source: node, target: node, col: Int)
+
+  private final class Cell:
+    var top: Boolean = false
+    var down: Boolean = false
+    var left: Boolean = false
+    var right: Boolean = false
+
+    // Distinguish pure crossings (where a horizontal lane passes over a continuing
+    // vertical lane without sharing a node) from real junctions where lanes meet.
+    var verticalPassThrough: Boolean = false
+    var horizontalPassThrough: Boolean = false
+
+    def tile: DagTile =
+      if verticalPassThrough && horizontalPassThrough then Crossing
+      else (top, down, left, right) match
+        case (false, false, false, false) => Space
+        case (true,  true,  false, false) => Vertical
+        case (false, false, true,  true)  => Horizontal
+        case (true,  false, false, true)  => CornerNe
+        case (true,  false, true,  false) => CornerNw
+        case (false, true,  false, true)  => CornerSe
+        case (false, true,  true,  false) => CornerSw
+        case (true,  true,  false, true)  => TeeE
+        case (true,  true,  true,  false) => TeeW
+        case (true,  false, true,  true)  => TeeN
+        case (false, true,  true,  true)  => TeeS
+        case (true,  true,  true,  true)  => Junction
+        case _                            => Space
+
+  def apply[node](dag: Dag[node]): LaneDagDiagram[node] =
+    val nodes: Vector[node] = dag.sorted.to(Vector)
+    val total: Int = nodes.length
+
+    if total == 0 then LaneDagDiagram(Nil) else
+      val rowOf: Map[node, Int] = nodes.zipWithIndex.to(Map)
+      val forward: Map[node, Set[node]] = dag.invert.edgeMap
+
+      val nodeCol: Array[Int] = new Array[Int](total)
+      val laneState: Array[Map[Int, Lane[node]]] = Array.fill(total + 1)(Map.empty[Int, Lane[node]])
+      val started: Array[Vector[Lane[node]]] = Array.fill(total)(Vector.empty[Lane[node]])
+      val directOut: Array[Boolean] = new Array[Boolean](total)
+
+      for r <- 0 until total do
+        val current = nodes(r)
+        val state = laneState(r)
+        val terminating = state.filter((_, lane) => lane.target == current)
+        val continuing = state -- terminating.keys
+        val terminatingCols = terminating.keys.to(Array).sortInPlace()
+
+        val chosenCol: Int =
+          if terminatingCols.length > 0 then terminatingCols(terminatingCols.length / 2)
+          else
+            var c = 0
+            while continuing.contains(c) do c += 1
+            c
+
+        nodeCol(r) = chosenCol
+
+        val nextNode: Optional[node] = if r + 1 < total then nodes(r + 1) else Unset
+        val targets: Vector[node] = forward.getOrElse(current, Set.empty).to(Vector).sortBy(rowOf)
+        val (directs, indirects) = nextNode.lay((Vector.empty[node], targets)): nx =>
+          targets.partition(_ == nx)
+
+        directOut(r) = directs.nonEmpty
+
+        val occupied = scm.HashSet.from(continuing.keys)
+
+        val newLanes = indirects.map: target =>
+          val col = nearestFree(chosenCol, occupied)
+          occupied.add(col)
+          Lane(current, target, col)
+
+        started(r) = newLanes
+        laneState(r + 1) = continuing ++ newLanes.map(lane => lane.col -> lane)
+
+      val width: Int =
+        val colsUsed = laneState.flatMap(_.keys) ++ nodeCol
+        if colsUsed.isEmpty then 1 else colsUsed.max + 1
+
+      val rows = scm.ListBuffer[(List[DagTile], Optional[node])]()
+
+      for r <- 0 until total do
+        if r > 0 then
+          rows += ((connectorRow(
+            laneState(r),
+            started(r - 1),
+            nodeCol(r - 1),
+            nodeCol(r),
+            directOut(r - 1),
+            nodes(r),
+            width), Unset))
+
+        rows += ((nodeRow(laneState(r), nodeCol(r), nodes(r), width), nodes(r)))
+
+      LaneDagDiagram(rows.to(List))
+
+  private def nearestFree(center: Int, taken: scm.HashSet[Int]): Int =
+    if !taken(center) then center else
+      var i = 1
+      var found = -1
+      while found < 0 do
+        val low = center - i
+        if low >= 0 && !taken(low) then found = low
+        else
+          val high = center + i
+          if !taken(high) then found = high
+        i += 1
+      found
+
+  private def connectorRow[node]
+    ( state:        Map[Int, Lane[node]],
+      justStarted:  Vector[Lane[node]],
+      prevNodeCol:  Int,
+      curNodeCol:   Int,
+      directEdge:   Boolean,
+      currentNode:  node,
+      width:        Int )
+  :   List[DagTile] =
+
+    val cells = Array.fill(width)(LaneDagDiagram.Cell())
+    val startedCols = justStarted.iterator.map(_.col).to(Set)
+
+    def drawBend(topEntry: Int, bottomExit: Int, continuing: Boolean): Unit =
+      if topEntry == bottomExit then
+        cells(topEntry).top = true
+        cells(topEntry).down = true
+        if continuing then cells(topEntry).verticalPassThrough = true
+      else if topEntry < bottomExit then
+        cells(topEntry).top = true
+        cells(topEntry).right = true
+        var c = topEntry + 1
+        while c < bottomExit do
+          cells(c).left = true
+          cells(c).right = true
+          cells(c).horizontalPassThrough = true
+          c += 1
+        cells(bottomExit).left = true
+        cells(bottomExit).down = true
+      else
+        cells(topEntry).top = true
+        cells(topEntry).left = true
+        var c = bottomExit + 1
+        while c < topEntry do
+          cells(c).left = true
+          cells(c).right = true
+          cells(c).horizontalPassThrough = true
+          c += 1
+        cells(bottomExit).right = true
+        cells(bottomExit).down = true
+
+    state.foreach: (col, lane) =>
+      if lane.target == currentNode then drawBend(col, curNodeCol, false)
+      else if startedCols(col) then drawBend(prevNodeCol, col, false)
+      else drawBend(col, col, true)
+
+    if directEdge then drawBend(prevNodeCol, curNodeCol, false)
+
+    cells.iterator.map(_.tile).to(List)
+
+  private def nodeRow[node]
+    ( state:    Map[Int, Lane[node]],
+      col:      Int,
+      current:  node,
+      width:    Int )
+  :   List[DagTile] =
+
+    val continuing = state.filter((_, lane) => lane.target != current).keys.to(Set)
+
+    (0 until width).map: c =>
+      if c == col then Node
+      else if continuing(c) then Vertical
+      else Space
+
+    . to(List)
+
+  given printable: [node: Showable] => (style: LaneDagStyle[Text])
+  =>  LaneDagDiagram[node] is Printable =
+    (diagram, termcap) => diagram.render[Text](node => t" $node").join(t"\n")
+
+  private def keepRow[node](row: (List[DagTile], Optional[node])): Boolean =
+    val (tiles, node) = row
+    if node.present then true else
+      val onlyPassThrough = tiles.forall { tile => tile == Vertical || tile == Space }
+      val verticalCount = tiles.count(_ == Vertical)
+      !(onlyPassThrough && verticalCount != 1)
+
+case class LaneDagDiagram[node](lines: List[(List[DagTile], Optional[node])]):
+  val size: Int = lines.length
+
+  def render[line](label: node => line)(using style: LaneDagStyle[line]): List[line] =
+    lines.map { (tiles, node) => style.serialize(tiles, Unset, node.let(label)) }
+
+  def render[line](glyph: node => line, label: node => line)(using style: LaneDagStyle[line])
+  :   List[line] =
+
+    lines.map { (tiles, node) => style.serialize(tiles, node.let(glyph), node.let(label)) }
+
+  def compact: LaneDagDiagram[node] = LaneDagDiagram(lines.filter(LaneDagDiagram.keepRow))
+
+  def nodes: List[node] = lines.flatMap(_(1).option)
+  def tiles: List[List[DagTile]] = lines.map(_(0))

--- a/lib/dendrology/src/dag/dendrology.LaneDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.LaneDagStyle.scala
@@ -36,4 +36,11 @@ import beneficence.*
 import vacuous.*
 
 trait LaneDagStyle[line] extends Findable:
-  def serialize(tiles: List[DagTile], glyph: Optional[line], label: Optional[line]): line
+  def serialize
+    ( tiles:  List[DagTile],
+      glyphs: Map[Int, line],
+      widths: List[Int],
+      label:  Optional[line] )
+  :   line
+
+  def width(glyph: line): Int

--- a/lib/dendrology/src/dag/dendrology.LaneDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.LaneDagStyle.scala
@@ -32,23 +32,8 @@
                                                                                                   */
 package dendrology
 
-import anticipation.*
-import gossamer.*
+import beneficence.*
+import vacuous.*
 
-package dagStyles:
-  given default: [text: Textual] => TextualDagStyle[text] =
-    TextualDagStyle("  ".tt, "└─".tt, "│ ".tt, "├─".tt, "──".tt, "┴─".tt, "│─".tt, "┼─".tt)
-
-  given ascii: [text: Textual] => TextualDagStyle[text] =
-    TextualDagStyle("  ".tt, "+-".tt, "| ".tt, "+-".tt, "--".tt, "+-".tt, "|-".tt, "+-".tt)
-
-package laneDagStyles:
-  given default: [text: Textual] => TextualLaneDagStyle[text] =
-    TextualLaneDagStyle
-      ( "  ".tt, "│ ".tt, "──".tt, "└─".tt, "┘ ".tt, "┌─".tt, "┐ ".tt,
-        "┴─".tt, "┬─".tt, "├─".tt, "┤ ".tt, "┼─".tt, "──".tt, "● ".tt )
-
-  given ascii: [text: Textual] => TextualLaneDagStyle[text] =
-    TextualLaneDagStyle
-      ( "  ".tt, "| ".tt, "--".tt, "+-".tt, "+ ".tt, "+-".tt, "+ ".tt,
-        "+-".tt, "+-".tt, "+-".tt, "+ ".tt, "+-".tt, "--".tt, "* ".tt )
+trait LaneDagStyle[line] extends Findable:
+  def serialize(tiles: List[DagTile], glyph: Optional[line], label: Optional[line]): line

--- a/lib/dendrology/src/dag/dendrology.LayeredDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LayeredDagDiagram.scala
@@ -42,17 +42,21 @@ import vacuous.*
 
 import DagTile.*
 
-object LaneDagDiagram:
+object LayeredDagDiagram:
   private case class Lane[node](source: node, target: node, col: Int)
+
+  private case class Layout[node]
+    ( state:       Map[Int, Lane[node]],
+      terminating: Map[Int, Lane[node]],
+      continuing:  Map[Int, Lane[node]],
+      nodeCol:     Map[node, Int],
+      prevNodeCol: Map[node, Int] )
 
   private final class Cell:
     var top: Boolean = false
     var down: Boolean = false
     var left: Boolean = false
     var right: Boolean = false
-
-    // Distinguish pure crossings (where a horizontal lane passes over a continuing
-    // vertical lane without sharing a node) from real junctions where lanes meet.
     var verticalPassThrough: Boolean = false
     var horizontalPassThrough: Boolean = false
 
@@ -73,98 +77,96 @@ object LaneDagDiagram:
         case (true,  true,  true,  true)  => Junction
         case _                            => Space
 
-  def apply[node](dag: Dag[node]): LaneDagDiagram[node] =
+  def apply[node](dag: Dag[node]): LayeredDagDiagram[node] =
     val nodes: Vector[node] = dag.sorted.to(Vector)
-    val total: Int = nodes.length
-
-    if total == 0 then LaneDagDiagram(Nil) else
-      val rowOf: Map[node, Int] = nodes.zipWithIndex.to(Map)
+    if nodes.isEmpty then LayeredDagDiagram(Nil) else
+      val parents: Map[node, Set[node]] = dag.edgeMap
       val forward: Map[node, Set[node]] = dag.invert.edgeMap
 
-      val nodeCol: Array[Int] = new Array[Int](total)
-      val laneState: Array[Map[Int, Lane[node]]] = Array.fill(total + 1)(Map.empty[Int, Lane[node]])
-      val started: Array[Vector[Lane[node]]] = Array.fill(total)(Vector.empty[Lane[node]])
-      val directOut: Array[Boolean] = new Array[Boolean](total)
+      val level: scm.HashMap[node, Int] = scm.HashMap()
+      for n <- nodes do
+        val ps = parents.getOrElse(n, Set.empty)
+        level(n) = if ps.isEmpty then 0 else ps.iterator.map(level).max + 1
 
-      for r <- 0 until total do
-        val current = nodes(r)
-        val state = laneState(r)
-        val terminating = state.filter((_, lane) => lane.target == current)
-        val continuing = state -- terminating.keys
-        val terminatingCols = terminating.keys.to(Array).sortInPlace()
+      val maxLevel: Int = level.values.max
 
-        val chosenCol: Int =
-          if terminatingCols.length > 0 then terminatingCols(terminatingCols.length / 2)
-          else
-            var c = 0
-            while continuing.contains(c) do c += 1
-            c
+      val byLevel: Vector[Vector[node]] =
+        (0 to maxLevel).to(Vector).map: l =>
+          nodes.filter(level(_) == l)
 
-        nodeCol(r) = chosenCol
+      val state: scm.HashMap[Int, Lane[node]] = scm.HashMap()
+      val layouts = scm.ListBuffer[Layout[node]]()
+      var prevNodeCols: Map[node, Int] = Map.empty
 
-        val nextNode: Optional[node] = if r + 1 < total then nodes(r + 1) else Unset
-        val targets: Vector[node] = forward.getOrElse(current, Set.empty).to(Vector).sortBy(rowOf)
-        val (directs, indirects) = nextNode.lay((Vector.empty[node], targets)): nx =>
-          targets.partition(_ == nx)
+      for l <- 0 to maxLevel do
+        val levelNodes = byLevel(l)
 
-        directOut(r) = directs.nonEmpty
+        val terminating = state.toMap.filter((_, lane) => level(lane.target) == l)
+        val continuing = state.toMap -- terminating.keys
 
-        val occupied = scm.HashSet.from(continuing.keys)
+        val incomingByNode: Map[node, Vector[Int]] =
+          terminating
+            . groupBy(_._2.target)
+            . map: (n, m) =>
+                n -> m.keys.to(Vector).sorted
 
-        val newLanes = indirects.map: target =>
-          val col = nearestFree(chosenCol, occupied)
-          occupied.add(col)
-          Lane(current, target, col)
+        val desired: Map[node, Int] = levelNodes.map: n =>
+          val incoming = incomingByNode.getOrElse(n, Vector.empty)
 
-        started(r) = newLanes
-        laneState(r + 1) = continuing ++ newLanes.map(lane => lane.col -> lane)
+          val centre =
+            if incoming.nonEmpty then incoming(incoming.length/2)
+            else if continuing.nonEmpty then continuing.keys.max + 1
+            else 0
+
+          n -> centre
+
+        . to(Map)
+
+        val ordered = levelNodes.sortBy(desired)
+        val nodeOccupied = scm.HashSet[Int]() ++ continuing.keys
+        val nodeCol = scm.LinkedHashMap[node, Int]()
+
+        for n <- ordered do
+          var col = desired(n)
+          while nodeOccupied.contains(col) do col += 1
+          nodeCol(n) = col
+          nodeOccupied.add(col)
+
+        layouts += Layout(state.toMap, terminating, continuing, nodeCol.toMap, prevNodeCols)
+
+        terminating.keys.foreach(state.remove)
+
+        val laneOccupied = scm.HashSet[Int]() ++ continuing.keys
+
+        for n <- ordered do
+          val outgoing = forward.getOrElse(n, Set.empty).filter(level(_) > l)
+          val sortedOut = outgoing.to(Vector).sortBy(level)
+
+          for target <- sortedOut do
+            var col = nodeCol(n)
+            while laneOccupied.contains(col) do col += 1
+            laneOccupied.add(col)
+            state(col) = Lane(n, target, col)
+
+        prevNodeCols = nodeCol.toMap
 
       val width: Int =
-        val colsUsed = laneState.flatMap(_.keys) ++ nodeCol
-        if colsUsed.isEmpty then 1 else colsUsed.max + 1
+        val cols = layouts.iterator.flatMap: lay =>
+          lay.state.keys.iterator
+            ++ lay.nodeCol.values.iterator
+            ++ lay.prevNodeCol.values.iterator
+        cols.maxOption.fold(1)(_ + 1)
 
-      val rows = scm.ListBuffer[(List[DagTile], Optional[node])]()
+      val rows = scm.ListBuffer[(List[DagTile], Map[Int, node])]()
 
-      for r <- 0 until total do
-        if r > 0 then
-          rows += ((connectorRow(
-            laneState(r),
-            started(r - 1),
-            nodeCol(r - 1),
-            nodeCol(r),
-            directOut(r - 1),
-            nodes(r),
-            width), Unset))
+      layouts.iterator.zipWithIndex.foreach: (lay, l) =>
+        if l > 0 then rows += ((connectorRow(lay, width), Map.empty[Int, node]))
+        rows += ((nodeRow(lay, width), lay.nodeCol.iterator.map((n, c) => c -> n).to(Map)))
 
-        rows += ((nodeRow(laneState(r), nodeCol(r), nodes(r), width), nodes(r)))
+      LayeredDagDiagram(rows.to(List))
 
-      LaneDagDiagram(rows.to(List))
-
-  private def nearestFree(center: Int, taken: scm.HashSet[Int]): Int =
-    if !taken(center) then center else
-      var i = 1
-      var found = -1
-      while found < 0 do
-        val low = center - i
-        if low >= 0 && !taken(low) then found = low
-        else
-          val high = center + i
-          if !taken(high) then found = high
-        i += 1
-      found
-
-  private def connectorRow[node]
-    ( state:        Map[Int, Lane[node]],
-      justStarted:  Vector[Lane[node]],
-      prevNodeCol:  Int,
-      curNodeCol:   Int,
-      directEdge:   Boolean,
-      currentNode:  node,
-      width:        Int )
-  :   List[DagTile] =
-
-    val cells = Array.fill(width)(LaneDagDiagram.Cell())
-    val startedCols = justStarted.iterator.map(_.col).to(Set)
+  private def connectorRow[node](layout: Layout[node], width: Int): List[DagTile] =
+    val cells = Array.fill(width)(LayeredDagDiagram.Cell())
 
     def drawBend(topEntry: Int, bottomExit: Int, continuing: Boolean): Unit =
       if topEntry == bottomExit then
@@ -194,86 +196,51 @@ object LaneDagDiagram:
         cells(bottomExit).right = true
         cells(bottomExit).down = true
 
-    state.foreach: (col, lane) =>
-      if lane.target == currentNode then drawBend(col, curNodeCol, false)
-      else if startedCols(col) then drawBend(prevNodeCol, col, false)
-      else drawBend(col, col, true)
+    layout.state.foreach: (col, lane) =>
+      val justStarted = layout.prevNodeCol.contains(lane.source)
+      val terminatingNow = layout.terminating.contains(col)
 
-    if directEdge then drawBend(prevNodeCol, curNodeCol, false)
+      (justStarted, terminatingNow) match
+        case (true, true) =>
+          drawBend(layout.prevNodeCol(lane.source), layout.nodeCol(lane.target), false)
+
+        case (false, true)  => drawBend(col, layout.nodeCol(lane.target), false)
+        case (true, false)  => drawBend(layout.prevNodeCol(lane.source), col, false)
+        case (false, false) => drawBend(col, col, true)
 
     cells.iterator.map(_.tile).to(List)
 
-  private def nodeRow[node]
-    ( state:    Map[Int, Lane[node]],
-      col:      Int,
-      current:  node,
-      width:    Int )
-  :   List[DagTile] =
-
-    val continuing = state.filter((_, lane) => lane.target != current).keys.to(Set)
+  private def nodeRow[node](layout: Layout[node], width: Int): List[DagTile] =
+    val nodeColSet = layout.nodeCol.values.to(Set)
 
     (0 until width).map: c =>
-      if c == col then Node
-      else if continuing(c) then Vertical
+      if nodeColSet(c) then Node
+      else if layout.continuing.contains(c) then Vertical
       else Space
 
     . to(List)
 
   given printable: [node: Showable] => (style: LaneDagStyle[Text])
-  =>  LaneDagDiagram[node] is Printable =
-    (diagram, termcap) => diagram.render[Text](node => t" $node").join(t"\n")
+  =>  LayeredDagDiagram[node] is Printable =
+    (diagram, termcap) => diagram.render[Text](node => t"● $node  ").join(t"\n")
 
-  private def keepRow[node](row: (List[DagTile], Optional[node])): Boolean =
-    val (tiles, node) = row
-    if node.present then true else
-      val onlyPassThrough = tiles.forall { tile => tile == Vertical || tile == Space }
-      val verticalCount = tiles.count(_ == Vertical)
-      !(onlyPassThrough && verticalCount != 1)
+case class LayeredDagDiagram[node](rows: List[(List[DagTile], Map[Int, node])]):
+  val size: Int = rows.length
 
-  private def defaultWidths(rows: Iterator[List[DagTile]]): List[Int] =
-    val maxCol = rows.map(_.length).maxOption.getOrElse(0)
-    List.fill(maxCol)(2)
-
-  private def computeWidths[node, line]
-    ( rows:  List[(List[DagTile], Optional[node])],
-      glyph: node => line,
-      style: LaneDagStyle[line] )
-  :   List[Int] =
-
+  def render[line](glyph: node => line)(using style: LaneDagStyle[line]): List[line] =
     val maxCol = rows.iterator.map(_(0).length).maxOption.getOrElse(0)
     val widths = Array.fill(maxCol)(2)
 
-    rows.foreach: (tiles, optNode) =>
-      if optNode.present then
-        val nodeIdx = tiles.indexOf(Node)
-        if nodeIdx >= 0 then
-          val w = style.width(glyph(optNode.vouch))
-          if w > widths(nodeIdx) then widths(nodeIdx) = w
+    rows.foreach: (_, nodesAt) =>
+      nodesAt.foreach: (col, n) =>
+        val w = style.width(glyph(n))
+        if w > widths(col) then widths(col) = w
 
-    widths.to(List)
+    val widthsList = widths.to(List)
 
-case class LaneDagDiagram[node](lines: List[(List[DagTile], Optional[node])]):
-  val size: Int = lines.length
+    rows.map: (tiles, nodesAt) =>
+      val glyphs: Map[Int, line] = nodesAt.map((col, n) => col -> glyph(n))
+      style.serialize(tiles, glyphs, widthsList, Unset)
 
-  def render[line](label: node => line)(using style: LaneDagStyle[line]): List[line] =
-    val widths = LaneDagDiagram.defaultWidths(lines.iterator.map(_(0)))
-    lines.map { (tiles, node) => style.serialize(tiles, Map.empty, widths, node.let(label)) }
-
-  def render[line](glyph: node => line, label: node => line)(using style: LaneDagStyle[line])
-  :   List[line] =
-
-    val widths = LaneDagDiagram.computeWidths(lines, glyph, style)
-
-    lines.map: (tiles, node) =>
-      val nodeIdx = tiles.indexOf(Node)
-
-      val glyphs: Map[Int, line] =
-        if nodeIdx < 0 then Map.empty
-        else node.let(n => Map(nodeIdx -> glyph(n))).or(Map.empty)
-
-      style.serialize(tiles, glyphs, widths, node.let(label))
-
-  def compact: LaneDagDiagram[node] = LaneDagDiagram(lines.filter(LaneDagDiagram.keepRow))
-
-  def nodes: List[node] = lines.flatMap(_(1).option)
-  def tiles: List[List[DagTile]] = lines.map(_(0))
+  def tiles: List[List[DagTile]] = rows.map(_(0))
+  def nodesAt: List[Map[Int, node]] = rows.map(_(1))

--- a/lib/dendrology/src/dag/dendrology.TextualDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.TextualDagStyle.scala
@@ -41,27 +41,28 @@ import DagTile.*
 
 case class TextualDagStyle[line: Textual]
   ( space:      Text,
-    corner:     Text,
+    cornerNe:   Text,
     vertical:   Text,
-    firstMid:   Text,
+    teeE:       Text,
     horizontal: Text,
-    midLast:    Text,
-    cross:      Text,
-    overlap:    Text )
+    teeN:       Text,
+    crossing:   Text,
+    junction:   Text )
 extends DagStyle[line]:
   def serialize(tiles: List[DagTile], node: line): line =
     line(tiles.map(text(_)).join)+node
 
-  def text(tile: DagTile) = tile match
+  def text(tile: DagTile): Text = tile match
     case Space      => space
-    case Corner     => corner
+    case CornerNe   => cornerNe
     case Vertical   => vertical
-    case FirstMid   => firstMid
+    case TeeE       => teeE
     case Horizontal => horizontal
-    case MidLast    => midLast
-    case Cross      => cross
-    case Overlap    => overlap
+    case TeeN       => teeN
+    case Crossing   => crossing
+    case Junction   => junction
+    case _          => space
 
   def followOnText(tile: DagTile): Text = tile match
-    case Space | Horizontal | Corner | MidLast | Overlap => space
+    case Space | Horizontal | CornerNe | TeeN | Junction => space
     case _                                               => vertical

--- a/lib/dendrology/src/dag/dendrology.TextualLaneDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.TextualLaneDagStyle.scala
@@ -56,10 +56,32 @@ case class TextualLaneDagStyle[line: Textual]
     crossing:   Text,
     node:       Text )
 extends LaneDagStyle[line]:
-  def serialize(tiles: List[DagTile], glyph: Optional[line], label: Optional[line]): line =
-    val parts: List[line] = tiles.map:
-      case Node => glyph.or(line(node))
-      case t    => line(text(t))
+  def width(glyph: line): Int = summon[line is Textual].length(glyph)
+
+  def serialize
+    ( tiles:  List[DagTile],
+      glyphs: Map[Int, line],
+      widths: List[Int],
+      label:  Optional[line] )
+  :   line =
+
+    val parts: List[line] = tiles.zip(widths).zipWithIndex.map:
+      case ((Node, w), i) =>
+        val g = glyphs.getOrElse(i, line(node))
+        val gw = width(g)
+        if gw >= w then g else g+line(Text(" ".repeat(w - gw).nn))
+
+      case ((t, w), _) =>
+        val base = text(t)
+
+        val cell =
+          if base.s.length >= 1 then base.s.charAt(0).toString else " "
+
+        val filler =
+          if base.s.length >= 2 then base.s.charAt(1).toString else " "
+
+        val padding = if w > 1 then filler.repeat(w - 1).nn else ""
+        line(Text(cell + padding))
 
     parts.fold(line(t""))(_+_)+label.or(line(t""))
 

--- a/lib/dendrology/src/dag/dendrology.TextualLaneDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.TextualLaneDagStyle.scala
@@ -34,21 +34,47 @@ package dendrology
 
 import anticipation.*
 import gossamer.*
+import gossamer.Textual.concatenable
+import symbolism.*
+import vacuous.*
 
-package dagStyles:
-  given default: [text: Textual] => TextualDagStyle[text] =
-    TextualDagStyle("  ".tt, "└─".tt, "│ ".tt, "├─".tt, "──".tt, "┴─".tt, "│─".tt, "┼─".tt)
+import DagTile.*
 
-  given ascii: [text: Textual] => TextualDagStyle[text] =
-    TextualDagStyle("  ".tt, "+-".tt, "| ".tt, "+-".tt, "--".tt, "+-".tt, "|-".tt, "+-".tt)
+case class TextualLaneDagStyle[line: Textual]
+  ( space:      Text,
+    vertical:   Text,
+    horizontal: Text,
+    cornerNe:   Text,
+    cornerNw:   Text,
+    cornerSe:   Text,
+    cornerSw:   Text,
+    teeN:       Text,
+    teeS:       Text,
+    teeE:       Text,
+    teeW:       Text,
+    junction:   Text,
+    crossing:   Text,
+    node:       Text )
+extends LaneDagStyle[line]:
+  def serialize(tiles: List[DagTile], glyph: Optional[line], label: Optional[line]): line =
+    val parts: List[line] = tiles.map:
+      case Node => glyph.or(line(node))
+      case t    => line(text(t))
 
-package laneDagStyles:
-  given default: [text: Textual] => TextualLaneDagStyle[text] =
-    TextualLaneDagStyle
-      ( "  ".tt, "│ ".tt, "──".tt, "└─".tt, "┘ ".tt, "┌─".tt, "┐ ".tt,
-        "┴─".tt, "┬─".tt, "├─".tt, "┤ ".tt, "┼─".tt, "──".tt, "● ".tt )
+    parts.fold(line(t""))(_+_)+label.or(line(t""))
 
-  given ascii: [text: Textual] => TextualLaneDagStyle[text] =
-    TextualLaneDagStyle
-      ( "  ".tt, "| ".tt, "--".tt, "+-".tt, "+ ".tt, "+-".tt, "+ ".tt,
-        "+-".tt, "+-".tt, "+-".tt, "+ ".tt, "+-".tt, "--".tt, "* ".tt )
+  def text(tile: DagTile): Text = tile match
+    case Space      => space
+    case Vertical   => vertical
+    case Horizontal => horizontal
+    case CornerNe   => cornerNe
+    case CornerNw   => cornerNw
+    case CornerSe   => cornerSe
+    case CornerSw   => cornerSw
+    case TeeN       => teeN
+    case TeeS       => teeS
+    case TeeE       => teeE
+    case TeeW       => teeW
+    case Junction   => junction
+    case Crossing   => crossing
+    case Node       => this.node

--- a/lib/dendrology/src/dag/dendrology_dag.scala
+++ b/lib/dendrology/src/dag/dendrology_dag.scala
@@ -45,7 +45,7 @@ package dagStyles:
 package laneDagStyles:
   given default: [text: Textual] => TextualLaneDagStyle[text] =
     TextualLaneDagStyle
-      ( "  ".tt, "│ ".tt, "──".tt, "└─".tt, "┘ ".tt, "┌─".tt, "┐ ".tt,
+      ( "  ".tt, "│ ".tt, "──".tt, "╰─".tt, "╯ ".tt, "╭─".tt, "╮ ".tt,
         "┴─".tt, "┬─".tt, "├─".tt, "┤ ".tt, "┼─".tt, "──".tt, "● ".tt )
 
   given ascii: [text: Textual] => TextualLaneDagStyle[text] =

--- a/lib/dendrology/src/dag/soundness_dendrology_dag.scala
+++ b/lib/dendrology/src/dag/soundness_dendrology_dag.scala
@@ -32,7 +32,11 @@
                                                                                                   */
 package soundness
 
-export dendrology.{DagDiagram, DagStyle, DagTile, TextualDagStyle}
+export dendrology.{DagDiagram, DagStyle, DagTile, LaneDagDiagram, LaneDagStyle, TextualDagStyle,
+        TextualLaneDagStyle}
 
 package dagStyles:
   export dendrology.dagStyles.{ascii, default}
+
+package laneDagStyles:
+  export dendrology.laneDagStyles.{ascii, default}

--- a/lib/dendrology/src/dag/soundness_dendrology_dag.scala
+++ b/lib/dendrology/src/dag/soundness_dendrology_dag.scala
@@ -32,8 +32,8 @@
                                                                                                   */
 package soundness
 
-export dendrology.{DagDiagram, DagStyle, DagTile, LaneDagDiagram, LaneDagStyle, TextualDagStyle,
-        TextualLaneDagStyle}
+export dendrology.{DagDiagram, DagStyle, DagTile, LaneDagDiagram, LaneDagStyle,
+        LayeredDagDiagram, TextualDagStyle, TextualLaneDagStyle}
 
 package dagStyles:
   export dendrology.dagStyles.{ascii, default}

--- a/lib/dendrology/src/demo/dendrology_demo.scala
+++ b/lib/dendrology/src/demo/dendrology_demo.scala
@@ -57,6 +57,11 @@ def laneDemo(): Unit =
     LaneDagDiagram(dag).render(glyph, node => t" $node").each(Out.println(_))
     Out.println(t"")
 
+  def showLayered(name: Text, dag: Dag[Text]): Unit =
+    Out.println(t"=== $name (layered) ===")
+    LayeredDagDiagram(dag).render(node => t"● $node  ").each(Out.println(_))
+    Out.println(t"")
+
   show
     ( t"linear chain",
       Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"), t"D" -> Set(t"C")) )
@@ -122,3 +127,12 @@ def laneDemo(): Unit =
   showCompact(t"Scala types", scalaTypes)
 
   showHighlighted(t"Scala types", scalaTypes, t"AnyVal")
+
+  showLayered(t"diamond",
+    Dag
+     ( t"A" -> Set(),
+       t"B" -> Set(t"A"),
+       t"C" -> Set(t"A"),
+       t"D" -> Set(t"B", t"C") ))
+
+  showLayered(t"Scala types", scalaTypes)

--- a/lib/dendrology/src/demo/dendrology_demo.scala
+++ b/lib/dendrology/src/demo/dendrology_demo.scala
@@ -32,23 +32,93 @@
                                                                                                   */
 package dendrology
 
-import anticipation.*
-import gossamer.*
+import soundness.*
 
-package dagStyles:
-  given default: [text: Textual] => TextualDagStyle[text] =
-    TextualDagStyle("  ".tt, "└─".tt, "│ ".tt, "├─".tt, "──".tt, "┴─".tt, "│─".tt, "┼─".tt)
+import dendrology.laneDagStyles.default
+import environments.java
+import stdios.virtualMachine
+import termcaps.environment
 
-  given ascii: [text: Textual] => TextualDagStyle[text] =
-    TextualDagStyle("  ".tt, "+-".tt, "| ".tt, "+-".tt, "--".tt, "+-".tt, "|-".tt, "+-".tt)
+@main
+def laneDemo(): Unit =
+  def show(name: Text, dag: Dag[Text]): Unit =
+    Out.println(t"=== $name ===")
+    LaneDagDiagram(dag).render(node => t" $node").each(Out.println(_))
+    Out.println(t"")
 
-package laneDagStyles:
-  given default: [text: Textual] => TextualLaneDagStyle[text] =
-    TextualLaneDagStyle
-      ( "  ".tt, "│ ".tt, "──".tt, "└─".tt, "┘ ".tt, "┌─".tt, "┐ ".tt,
-        "┴─".tt, "┬─".tt, "├─".tt, "┤ ".tt, "┼─".tt, "──".tt, "● ".tt )
+  def showCompact(name: Text, dag: Dag[Text]): Unit =
+    Out.println(t"=== $name (compact) ===")
+    LaneDagDiagram(dag).compact.render(node => t" $node").each(Out.println(_))
+    Out.println(t"")
 
-  given ascii: [text: Textual] => TextualLaneDagStyle[text] =
-    TextualLaneDagStyle
-      ( "  ".tt, "| ".tt, "--".tt, "+-".tt, "+ ".tt, "+-".tt, "+ ".tt,
-        "+-".tt, "+-".tt, "+-".tt, "+ ".tt, "+-".tt, "--".tt, "* ".tt )
+  def showHighlighted(name: Text, dag: Dag[Text], highlight: Text): Unit =
+    Out.println(t"=== $name (highlight $highlight) ===")
+    val glyph = (node: Text) => if node == highlight then t"★ " else t"● "
+    LaneDagDiagram(dag).render(glyph, node => t" $node").each(Out.println(_))
+    Out.println(t"")
+
+  show
+    ( t"linear chain",
+      Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"), t"D" -> Set(t"C")) )
+
+  show
+    ( t"diamond",
+      Dag
+       ( t"A" -> Set(),
+         t"B" -> Set(t"A"),
+         t"C" -> Set(t"A"),
+         t"D" -> Set(t"B", t"C") ) )
+
+  show
+    ( t"high fan-out",
+      Dag
+       ( t"root" -> Set(),
+         t"a"    -> Set(t"root"),
+         t"b"    -> Set(t"root"),
+         t"c"    -> Set(t"root"),
+         t"d"    -> Set(t"root") ) )
+
+  show
+    ( t"high fan-in",
+      Dag
+       ( t"a"    -> Set(),
+         t"b"    -> Set(),
+         t"c"    -> Set(),
+         t"d"    -> Set(),
+         t"sink" -> Set(t"a", t"b", t"c", t"d") ) )
+
+  show
+    ( t"long edge over rows",
+      Dag
+       ( t"A" -> Set(),
+         t"B" -> Set(t"A"),
+         t"C" -> Set(t"B"),
+         t"D" -> Set(t"C"),
+         t"E" -> Set(t"A", t"D") ) )
+
+  show
+    ( t"two independent branches",
+      Dag
+       ( t"A" -> Set(),
+         t"B" -> Set(t"A"),
+         t"C" -> Set(),
+         t"D" -> Set(t"C") ) )
+
+  val scalaTypes = Dag
+    ( t"Any"        -> Set(),
+      t"Matchable"  -> Set(t"Any"),
+      t"AnyVal"     -> Set(t"Matchable"),
+      t"AnyRef"     -> Set(t"Matchable"),
+      t"Unit"       -> Set(t"AnyVal"),
+      t"Boolean"    -> Set(t"AnyVal"),
+      t"Int"        -> Set(t"AnyVal"),
+      t"String"     -> Set(t"AnyRef"),
+      t"List[Int]"  -> Set(t"AnyRef"),
+      t"Null"       -> Set(t"String", t"List[Int]"),
+      t"Nothing"    -> Set(t"Null", t"Unit", t"Boolean", t"Int") )
+
+  show(t"Scala types", scalaTypes)
+
+  showCompact(t"Scala types", scalaTypes)
+
+  showHighlighted(t"Scala types", scalaTypes, t"AnyVal")

--- a/lib/dendrology/src/test/dendrology_test.scala
+++ b/lib/dendrology/src/test/dendrology_test.scala
@@ -193,3 +193,57 @@ object Tests extends Suite(m"Dendrology tests"):
       compact < full
 
     . assert(_ == true)
+
+    test(m"Layered DAG: linear chain has one node per level"):
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"))
+      LayeredDagDiagram(dag).rows.count((_, nodesAt) => nodesAt.nonEmpty)
+
+    . assert(_ == 3)
+
+    test(m"Layered DAG: diamond packs siblings into one row"):
+      val dag = Dag
+        ( t"A" -> Set(),
+          t"B" -> Set(t"A"),
+          t"C" -> Set(t"A"),
+          t"D" -> Set(t"B", t"C") )
+      val nodeRows = LayeredDagDiagram(dag).rows.collect:
+        case (_, nodesAt) if nodesAt.nonEmpty => nodesAt
+      // Three node rows: [A], [B,C], [D]
+      ( nodeRows.length,
+        nodeRows.head.size,
+        nodeRows(1).size,
+        nodeRows.last.size )
+
+    . assert(_ == (3, 1, 2, 1))
+
+    test(m"Layered DAG: per-vertex glyph"):
+      import laneDagStyles.default
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
+      val glyph = (n: Text) => if n == t"A" then t"★ " else t"● "
+      LayeredDagDiagram(dag).render(glyph)
+
+    . assert(_ == List(t"★ ", t"│ ", t"● "))
+
+    test(m"Layered DAG: variable column widths"):
+      import laneDagStyles.default
+      // The B node has a wide glyph; column 0 should expand to fit it.
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
+      val glyph = (n: Text) => if n == t"B" then t"[long]" else t"●     "
+      LayeredDagDiagram(dag).render(glyph)
+
+    . assert(_ == List(t"●     ", t"│     ", t"[long]"))
+
+    test(m"Lane DAG: variable column widths in connectors"):
+      import laneDagStyles.default
+      val dag = Dag
+        ( t"A" -> Set(),
+          t"B" -> Set(t"A"),
+          t"C" -> Set(t"A"),
+          t"D" -> Set(t"B", t"C") )
+      val glyph = (n: Text) => t"[$n]"
+      val rendered = LaneDagDiagram(dag).render(glyph, n => t"")
+      // Connector tiles widen: a row of `├─╮` becomes `├──╮` etc when col widths grow.
+      // We just check that all rows in the rendered output have equal width.
+      rendered.map(_.s.length).distinct.size
+
+    . assert(_ == 1)

--- a/lib/dendrology/src/test/dendrology_test.scala
+++ b/lib/dendrology/src/test/dendrology_test.scala
@@ -79,3 +79,117 @@ object Tests extends Suite(m"Dendrology tests"):
   def run(): Unit =
     import dagStyles.default
     DagDiagram(types).render { node => t"▪ $node" }
+
+    test(m"Lane DAG: linear chain"):
+      import laneDagStyles.default
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"))
+      LaneDagDiagram(dag).render(node => t" $node").join(t"\n")
+
+    . assert(_ == t"●  A\n│ \n●  B\n│ \n●  C")
+
+    test(m"Lane DAG: diamond"):
+      import laneDagStyles.default
+      val dag = Dag
+        ( t"A" -> Set(),
+          t"B" -> Set(t"A"),
+          t"C" -> Set(t"A"),
+          t"D" -> Set(t"B", t"C") )
+      LaneDagDiagram(dag).render(node => t" $node").size
+
+    . assert(_ == 7)
+
+    test(m"Lane DAG: diamond layout shapes"):
+      import laneDagStyles.default
+      val dag = Dag
+        ( t"A" -> Set(),
+          t"B" -> Set(t"A"),
+          t"C" -> Set(t"A"),
+          t"D" -> Set(t"B", t"C") )
+      val rendered = LaneDagDiagram(dag).render(node => t"").map(_.s)
+      val nodeMark = '●'
+      ( rendered.head.indexOf(nodeMark) >= 0,
+        rendered.last.indexOf(nodeMark) >= 0,
+        rendered(1).indexOf(nodeMark) >= 0,
+        rendered(rendered.length - 2).indexOf(nodeMark) >= 0 )
+
+    . assert(_ == (true, true, false, false))
+
+    test(m"Lane DAG: single node"):
+      import laneDagStyles.default
+      val dag = Dag(t"A" -> Set())
+      LaneDagDiagram(dag).render(node => t" $node").join(t"\n")
+
+    . assert(_ == t"●  A")
+
+    test(m"Lane DAG: high fan-out"):
+      import laneDagStyles.default
+      val dag = Dag
+        ( t"root" -> Set(),
+          t"a"    -> Set(t"root"),
+          t"b"    -> Set(t"root"),
+          t"c"    -> Set(t"root"),
+          t"d"    -> Set(t"root") )
+      LaneDagDiagram(dag).render(node => t" $node").size
+
+    . assert(_ == 9)
+
+    test(m"Lane DAG: high fan-in"):
+      import laneDagStyles.default
+      val dag = Dag
+        ( t"a"    -> Set(),
+          t"b"    -> Set(),
+          t"c"    -> Set(),
+          t"d"    -> Set(),
+          t"sink" -> Set(t"a", t"b", t"c", t"d") )
+      LaneDagDiagram(dag).render(node => t" $node").size
+
+    . assert(_ == 9)
+
+    test(m"Lane DAG: linear chain detail"):
+      import laneDagStyles.default
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"))
+      LaneDagDiagram(dag).render(node => t" $node")
+
+    . assert(_ == List(t"●  A", t"│ ", t"●  B", t"│ ", t"●  C"))
+
+    test(m"Lane DAG: crossing renders as horizontal not junction"):
+      import laneDagStyles.default
+      val dag = Dag
+        ( t"A" -> Set(),
+          t"B" -> Set(t"A"),
+          t"C" -> Set(),
+          t"D" -> Set(t"A", t"C") )
+      LaneDagDiagram(dag).render(node => t"").map(_.s).mkString("\n").linesIterator.toList.size
+
+    . assert(_ == 7)
+
+    test(m"Lane DAG: per-vertex glyph"):
+      import laneDagStyles.default
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
+      val glyph = (n: Text) => if n == t"A" then t"★ " else t"● "
+      LaneDagDiagram(dag).render(glyph, n => t" $n")
+
+    . assert(_ == List(t"★  A", t"│ ", t"●  B"))
+
+    test(m"Lane DAG: compact preserves single-vertical row"):
+      import laneDagStyles.default
+      // A→B is a direct edge: connector has exactly one Vertical, must stay.
+      val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
+      LaneDagDiagram(dag).compact.render(n => t" $n").size
+
+    . assert(_ == 3)
+
+    test(m"Lane DAG: compact removes multi-vertical pass-through row"):
+      import laneDagStyles.default
+      // A→D is long, B and C are between. After A's row a connector row of
+      // pure pass-throughs (multi-vertical) appears; compact should drop it.
+      val dag = Dag
+        ( t"A" -> Set(),
+          t"B" -> Set(t"A"),
+          t"C" -> Set(t"B"),
+          t"D" -> Set(t"A", t"C") )
+      val full = LaneDagDiagram(dag).render(n => t" $n").size
+      val compact = LaneDagDiagram(dag).compact.render(n => t" $n").size
+      compact < full
+
+    . assert(_ == true)


### PR DESCRIPTION
Adds a second DAG rendering style to Dendrology, `LaneDagDiagram`, whose width scales with the maximum number of active edges in any gap rather than with the total node count. The new renderer uses two output lines per node — a node line and a connector line — and lays out edges as lanes that bend, split and merge between rows. Pure crossings are distinguished from real junctions: where a horizontal lane passes over a continuing vertical lane without sharing a node, only the horizontal is drawn so the vertical reads as continuous from the surrounding rows. Per-vertex glyph customization, a `compact` mode that drops redundant pass-through connector rows (preserving single-vertical rows so adjacency stays clear), and the existing `Textual` parameterisation for custom text types like `Teletype` are all supported. The existing `DagDiagram` matrix renderer is unchanged, but its `DagTile` enum has been generalised to compass-directional names so both renderers can share the tile vocabulary.

## `LaneDagDiagram`

`LaneDagDiagram` is an alternative to `DagDiagram` for rendering directed acyclic graphs as text. Width grows with the maximum number of active edges per gap, not with the total node count, which makes it more compact for large graphs. Each node takes two rows of output:

```
●          Any
│
●          Matchable
├─╮
│ ●        AnyRef
│ ├─╮
│ │ ●      List[Int]
│ │ │
● │ │      AnyVal
├─────┬─╮
│ │ │ │ ●  Boolean
```

The `├─────┬─╮` row shows AnyVal's outgoing lanes branching out: the long horizontal passes over two existing vertical lanes (`AnyRef→String` and `List[Int]→Null`) without showing a `┼` junction, because no node sits at those columns.

### Per-vertex glyph

`render` has a two-argument overload that takes a per-vertex glyph in addition to a label:

```scala
val highlight = (n: Text) => if n == t"AnyVal" then t"★ " else t"● "
LaneDagDiagram(dag).render(highlight, n => t" $n")
```

The glyph is also a `line`, so callers using `Teletype` (or any other `Textual`) can attach color or other styling per node.

### `compact` mode

```scala
LaneDagDiagram(dag).compact.render(n => t" $n")
```

`.compact` removes connector rows whose tiles are entirely vertical or blank and whose vertical count is not exactly 1. Single-vertical rows are kept so two adjacent nodes connected by a direct edge never end up on adjacent lines.

### `DagTile` rename

The eight tile cases in `DagTile` have been renamed to compass-directional names so they can be shared between renderers: `Corner→CornerNe`, `FirstMid→TeeE`, `MidLast→TeeN`, `Cross→Crossing`, `Overlap→Junction`. Six new cases (`CornerNw`, `CornerSe`, `CornerSw`, `TeeW`, `TeeS`, `Node`) cover the remaining 4-bit combinations and the node glyph. Ordinal order is preserved so the matrix renderer's `DagTile.fromOrdinal` is unaffected; field order in `TextualDagStyle` is preserved so positional construction in `dagStyles.{default,ascii}` still works.

### Demo

A new `dendrology.demo` submodule contains `@main laneDemo`, which prints each rendering mode against several DAG shapes (chains, diamonds, fan-out, fan-in, the Scala type hierarchy):

```
mill dendrology.demo.runMain dendrology.laneDemo
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)