### PR TITLE
hellenism: add services[T] and single-path classpath constructor

### DIFF
--- a/lib/anthology/src/bundle/anthology.Bundler.scala
+++ b/lib/anthology/src/bundle/anthology.Bundler.scala
@@ -59,13 +59,14 @@ import systems.java
 import workingDirectories.java
 
 object Bundler:
-  def classpath(out: Path on Linux): LocalClasspath = LocalClasspath:
-    Classpath.Directory(out)
-    :: (classloaders.threadContext.classpath.match
+  def classpath(out: Path on Linux): LocalClasspath =
+    val entries = Classpath.Directory(out) :: (classloaders.threadContext.classpath.match
       case classpath: LocalClasspath => classpath.entries
 
       case _ =>
         unsafely(System.properties.java.`class`.path().decode[LocalClasspath]).entries)
+
+    LocalClasspath(entries*)
 
 
   def bundle(directory: Path on Linux, jarfile0: Optional[Path on Linux], main: Optional[Fqcn])

--- a/lib/hellenism/res/test/META-INF/services/hellenism.TestService
+++ b/lib/hellenism/res/test/META-INF/services/hellenism.TestService
@@ -1,0 +1,2 @@
+hellenism.TestServiceA
+hellenism.TestServiceB

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -88,11 +88,14 @@ object Classpath extends Root(t""):
       case _: ClasspathEntry.Url => true
       case _                     => false
     then OnlineClasspath(entries)
-    else LocalClasspath:
-      entries.collect:
-        case directory: ClasspathEntry.Directory      => directory
-        case jar: ClasspathEntry.Jar                  => jar
-        case runtime: ClasspathEntry.JavaRuntime.type => runtime
+    else
+      type Entry = ClasspathEntry.Directory | ClasspathEntry.Jar | ClasspathEntry.JavaRuntime.type
+
+      LocalClasspath:
+        entries.collect[Entry]:
+          case directory: ClasspathEntry.Directory      => directory
+          case jar: ClasspathEntry.Jar                  => jar
+          case runtime: ClasspathEntry.JavaRuntime.type => runtime
 
 
   given streamable: [path <: Path on Classpath] => Tactic[ClasspathError]

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -33,6 +33,7 @@
 package hellenism
 
 import java.net as jn
+import java.util as ju
 
 import anticipation.*
 import contingency.*
@@ -108,6 +109,25 @@ object Classpath extends Root(t""):
       classloader.inputStream(path.encode)
 
 
+  def servicesFor[service](classpath: Classpath, cls: Class[service]): Set[service] =
+    val parent = Optional(cls.getClassLoader).or(ClassLoader.getSystemClassLoader.nn)
+
+    val urls: Array[jn.URL | Null] =
+      Array.from(classpath.entries.flatMap:
+        case ClasspathEntry.JavaRuntime => Nil
+        case other                      => List(other.javaUrl))
+
+    val loader = jn.URLClassLoader(urls, parent)
+    val seen = scala.collection.mutable.Set.empty[Class[?]]
+    val result = scala.collection.mutable.Set.empty[service]
+
+    ju.ServiceLoader.load(cls, loader).nn.stream.nn.forEach: provider =>
+      val provider0 = provider.nn
+      if seen.add(provider0.`type`.nn) then result += provider0.get.nn
+
+    result.toSet
+
+
 trait Classpath:
   def entries: List[ClasspathEntry]
   private def array: Array[jn.URL | Null] = Array.from(entries.map(_.javaUrl))
@@ -127,3 +147,6 @@ trait Classpath:
 
     new Classloader
       ( new jn.URLClassLoader(Array.from(urls), ClassLoader.getPlatformClassLoader().nn) )
+
+  inline def services[service]: Set[service] =
+    Classpath.servicesFor[service](this, reflectClass[service])

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -92,11 +92,12 @@ object Classpath extends Root(t""):
     else
       type Entry = ClasspathEntry.Directory | ClasspathEntry.Jar | ClasspathEntry.JavaRuntime.type
 
-      LocalClasspath:
-        entries.collect[Entry]:
-          case directory: ClasspathEntry.Directory      => directory
-          case jar: ClasspathEntry.Jar                  => jar
-          case runtime: ClasspathEntry.JavaRuntime.type => runtime
+      val items: List[Entry] = entries.collect:
+        case directory: ClasspathEntry.Directory      => directory
+        case jar: ClasspathEntry.Jar                  => jar
+        case runtime: ClasspathEntry.JavaRuntime.type => runtime
+
+      LocalClasspath(items*)
 
 
   given streamable: [path <: Path on Classpath] => Tactic[ClasspathError]

--- a/lib/hellenism/src/core/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/core/hellenism.LocalClasspath.scala
@@ -62,11 +62,10 @@ object LocalClasspath:
 
 
   def apply
-    ( entries
-      : List [ClasspathEntry.Directory | ClasspathEntry.Jar | ClasspathEntry.JavaRuntime.type] )
+    ( entries: (ClasspathEntry.Directory | ClasspathEntry.Jar | ClasspathEntry.JavaRuntime.type)* )
   :   LocalClasspath =
 
-    new LocalClasspath(entries, entries.to(Set))
+    new LocalClasspath(entries.toList, entries.to(Set))
 
 
   def apply[path: Abstractable across Paths to Text]

--- a/lib/hellenism/src/core/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/core/hellenism.LocalClasspath.scala
@@ -69,6 +69,18 @@ object LocalClasspath:
     new LocalClasspath(entries, entries.to(Set))
 
 
+  def apply[path: Abstractable across Paths to Text]
+    ( path: path )
+    ( using Tactic[PathError],
+            Tactic[IoError],
+            Tactic[NameError],
+            Navigable,
+            DereferenceSymlinks )
+  :   LocalClasspath =
+
+    new LocalClasspath(Nil, Set.empty) + path
+
+
   given paths: [path: Abstractable across Paths to Text]
   =>  ( Tactic[PathError], Tactic[IoError], Tactic[NameError], Navigable, DereferenceSymlinks )
   =>  LocalClasspath is Addable by path to LocalClasspath =

--- a/lib/hellenism/src/test/hellenism_test.scala
+++ b/lib/hellenism/src/test/hellenism_test.scala
@@ -36,6 +36,15 @@ import soundness.*
 
 import classloaders.threadContext
 
+trait TestService:
+  def name: Text
+
+class TestServiceA extends TestService:
+  def name: Text = t"A"
+
+class TestServiceB extends TestService:
+  def name: Text = t"B"
+
 object Tests extends Suite(m"Proscenium Tests"):
   def run(): Unit =
     test(m"check that a classpath file is accessible"):
@@ -58,3 +67,9 @@ object Tests extends Suite(m"Proscenium Tests"):
     test(m"check that an invalid classpath path is an error"):
       demilitarize(cp"foobar").map(_.message)
     . assert(_ == List(t"hellenism: the path foobar is not a valid classpath path"))
+
+    test(m"load services from META-INF/services"):
+      import systems.java
+      val classpath = unsafely(System.properties.java.`class`.path().decode[LocalClasspath])
+      classpath.services[TestService].map(_.name)
+    . assert(_ == Set(t"A", t"B"))

--- a/lib/superlunary/src/core/superlunary.Rig.scala
+++ b/lib/superlunary/src/core/superlunary.Rig.scala
@@ -81,13 +81,14 @@ trait Rig(using classloader0: Classloader) extends Targetable, Formal, Transport
 
   protected val classloader = classloader0
 
-  def classpath(out: Path on Linux): LocalClasspath = LocalClasspath:
-    Classpath.Directory(out)
-    :: (classloaders.threadContext.classpath.match
+  def classpath(out: Path on Linux): LocalClasspath =
+    val entries = Classpath.Directory(out) :: (classloaders.threadContext.classpath.match
       case classpath: LocalClasspath => classpath.entries
 
       case _ =>
         unsafely(System.properties.java.`class`.path().decode[LocalClasspath]).entries)
+
+    LocalClasspath(entries*)
 
   lazy val settings2: staging.Compiler.Settings =
     staging.Compiler.Settings.make(None, scalac.commandLineArguments.map(_.s))


### PR DESCRIPTION
Adds a `services[T]` method to `Classpath` that locates `META-INF/services/<T>` provider entries and instantiates them as a `Set[T]`, and a convenience `LocalClasspath.apply(path)` constructor for building a classpath from a single path-like value. The existing entries-list `LocalClasspath.apply` is also switched to varargs.

### `Classpath.services[T]`

Find and instantiate Java service providers registered for a given type:

```scala
val classpath: Classpath = …
val services: Set[MyService] = classpath.services[MyService]
```

Internally this delegates to `java.util.ServiceLoader` against a `URLClassLoader` rooted at `T`'s defining classloader, so the cast to `T` works across classloader hierarchies. Providers are deduplicated by class to avoid double-instantiation when the same `META-INF/services` entry is reachable through more than one URL.

### `LocalClasspath.apply(path)`

A `LocalClasspath` can now be built from a single path-like value, complementing the existing `Addable` instance:

```scala
val classpath: LocalClasspath = LocalClasspath(myPath)
```

Previously this required `LocalClasspath(Nil) + myPath`.

### Varargs entries

The entries-list `LocalClasspath.apply` now takes varargs, so callers can write `LocalClasspath(entry1, entry2)` directly. Existing list-valued call sites can spread with `LocalClasspath(list*)`.