### PR TITLE
hellenism: drop vestigial Navigable and NameError constraints

### DIFF
--- a/lib/hellenism/src/core/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/core/hellenism.LocalClasspath.scala
@@ -72,8 +72,6 @@ object LocalClasspath:
     ( path: path )
     ( using Tactic[PathError],
             Tactic[IoError],
-            Tactic[NameError],
-            Navigable,
             DereferenceSymlinks )
   :   LocalClasspath =
 
@@ -81,7 +79,7 @@ object LocalClasspath:
 
 
   given paths: [path: Abstractable across Paths to Text]
-  =>  ( Tactic[PathError], Tactic[IoError], Tactic[NameError], Navigable, DereferenceSymlinks )
+  =>  ( Tactic[PathError], Tactic[IoError], DereferenceSymlinks )
   =>  LocalClasspath is Addable by path to LocalClasspath =
 
     (classpath, path) =>


### PR DESCRIPTION
`LocalClasspath.apply[path: Abstractable across Paths to Text]` (and the
companion `paths` Addable given) required `Navigable` and `Tactic[NameError]`
in their `using` lists, but the bodies don't reference either. Worse, bare
`Navigable` is unsummonable — every concrete given in `serpentine.Navigable`'s
companion is parameterised (`X is Navigable on plane`), so callers hit
ambiguous-given errors between `Navigable.label` and `Navigable.text`.

This trims both signatures to the constraints the bodies actually use:
`Tactic[PathError]` (needed by `Radical.linux` for the `decode[Path on Linux]`),
`Tactic[IoError]` and `DereferenceSymlinks` (needed by `entry()`).

### Release notes

`LocalClasspath(path)` for a single path can now be called without supplying
`Navigable` or `Tactic[NameError]` instances — the previous signature asked
for both, but neither was actually used and `Navigable` (unparameterised)
couldn't be supplied in practice. Code that already builds:

```scala
LocalClasspath(myPath).services[MyService]
```

will now compile with just the surrounding `Tactic[PathError]`,
`Tactic[IoError]`, and `DereferenceSymlinks` in scope.
