### PR TITLE
breviloquence: new module for CBOR encoding

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -425,6 +425,11 @@ object breviloquence extends Library:
   object parser extends Component(ast, turbulence.core)
   object core extends Component(parser, urticose.url, panopticon.core)
   object test extends Tests(core, sedentary.core, eucalyptus.core)
+  object bench extends Benchmarks(core, parser, quantitative.units):
+    def mvnDeps = Seq(
+      mvn"com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.2",
+      mvn"io.bullet::borer-core:1.16.0"
+    )
 
 object burdock extends Library:
   object boot extends Component

--- a/build.mill
+++ b/build.mill
@@ -420,6 +420,12 @@ object bitumen extends Library:
   object core extends Component(serpentine.core, turbulence.core)
   object test extends Tests(core)
 
+object breviloquence extends Library:
+  object ast extends Component(zephyrine.core)
+  object parser extends Component(ast, turbulence.core)
+  object core extends Component(parser, urticose.url, panopticon.core)
+  object test extends Tests(core, sedentary.core, eucalyptus.core)
+
 object burdock extends Library:
   object boot extends Component
   object core extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.core, gastronomy.core)
@@ -1064,6 +1070,9 @@ object publishing extends Module:
     austronesian.core.publishLocal()()
     aviation.core.publishLocal()()
     baroque.core.publishLocal()()
+    breviloquence.ast.publishLocal()()
+    breviloquence.parser.publishLocal()()
+    breviloquence.core.publishLocal()()
     burdock.boot.publishLocal()()
     burdock.core.publishLocal()()
     caduceus.core.publishLocal()()

--- a/lib/breviloquence/src/ast/breviloquence.CborAst.scala
+++ b/lib/breviloquence/src/ast/breviloquence.CborAst.scala
@@ -1,0 +1,98 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+object CborAst:
+
+  // Sentinel used to pad a heterogeneous array whose logical length is even,
+  // so the stored `IArray[Any]` always has odd length and is therefore
+  // distinguishable from a map (always even-length, encoded as alternating
+  // `key, value, …`). The sentinel only ever appears at the end of a padded
+  // array.
+  val arrayPad: AnyRef = new Object
+
+  // CBOR major-type representation in storage:
+  //   0/1 (integer)            -> `Long` (overflow raises CborError)
+  //   2 (byte string)          -> `IArray[Byte]` (= `anticipation.Data`)
+  //   3 (text string)          -> `String`
+  //   4 (array)                -> odd-length `IArray[Any]` (sentinel-padded if needed)
+  //   5 (map)                  -> even-length `IArray[Any]`, alternating key/value
+  //   6 (tag)                  -> `CborTag`
+  //   7.20–22 (false/true/null) -> `Boolean` / `Null`
+  //   7.23 (undefined)         -> `vacuous.Unset`
+  //   7.25–27 (floats)         -> `Double`
+  opaque type RawCbor =
+    Long | Double | String | IArray[Byte] | IArray[Any] | Boolean | Null | vacuous.Unset.type
+    | CborTag
+
+  def apply
+    ( value
+      : Long | Double | String | IArray[Byte] | IArray[Any] | Boolean | Null | vacuous.Unset.type
+      | CborTag )
+  :   RawCbor =
+
+    value
+
+  // Build a map node from parallel `keys` and `values` arrays. Stored as a
+  // single `IArray[Any]` of length `2 * keys.length` with keys at even
+  // indices and values at odd indices. Keys may be any CBOR value.
+  def map(keys: IArray[Any], values: IArray[Any]): RawCbor =
+    val n = keys.length
+    val arr = new Array[Any](n*2)
+    var i = 0
+    while i < n do
+      arr(i*2) = keys(i)
+      arr(i*2 + 1) = values(i)
+      i += 1
+    arr.asInstanceOf[IArray[Any]]
+
+  // Build a heterogeneous array node. Adds a single `arrayPad` sentinel if
+  // the logical element count is even, so the stored `IArray[Any]` is always
+  // odd-length and distinguishable from a map.
+  def arr(elements: IArray[Any]): RawCbor =
+    val n = elements.length
+    if (n & 1) == 1 then elements
+    else
+      val padded = new Array[Any](n + 1)
+      System.arraycopy(elements.asInstanceOf[Array[Any]], 0, padded, 0, n)
+      padded(n) = arrayPad
+      padded.asInstanceOf[IArray[Any]]
+
+  // Number of user-visible elements in an array node.
+  def arrayLength(cbor: RawCbor): Int =
+    val arr = cbor.asInstanceOf[Array[?]]
+    val n = arr.length
+    if n > 0 && (arr(n - 1).asInstanceOf[AnyRef] eq arrayPad) then n - 1 else n
+
+  // Number of key/value pairs in a map node.
+  def mapSize(cbor: RawCbor): Int = cbor.asInstanceOf[IArray[Any]].length/2

--- a/lib/breviloquence/src/ast/breviloquence.CborTag.scala
+++ b/lib/breviloquence/src/ast/breviloquence.CborTag.scala
@@ -1,0 +1,45 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+// CBOR tagged value (RFC 8949 §3.4, major type 6). The `tag` is the unsigned
+// tag number; `value` is the underlying CBOR value. Tags survive parsing
+// round-trips so that semantic information is not lost. Bignum tags 2 and 3
+// are folded into `Bcd` by the parser since they are representational rather
+// than semantic.
+final class CborTag(val tag: Long, val value: Any):
+  override def hashCode: Int = (tag.hashCode*31) ^ value.hashCode
+
+  override def equals(that: Any): Boolean = that match
+    case that: CborTag => tag == that.tag && value == that.value
+    case _             => false

--- a/lib/breviloquence/src/ast/breviloquence_ast.scala
+++ b/lib/breviloquence/src/ast/breviloquence_ast.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+export CborAst.RawCbor as CborAst

--- a/lib/breviloquence/src/ast/soundness_breviloquence_ast.scala
+++ b/lib/breviloquence/src/ast/soundness_breviloquence_ast.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export breviloquence.{CborAst, CborTag}

--- a/lib/breviloquence/src/bench/breviloquence.Benchmarks.scala
+++ b/lib/breviloquence/src/bench/breviloquence.Benchmarks.scala
@@ -1,0 +1,219 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import fulminate.*
+import gossamer.*
+import hellenism.*, classloaders.threadContext
+import probably.*
+import proscenium.*
+import quantitative.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.system
+import vacuous.*
+
+object Benchmarks extends Suite(m"Breviloquence CBOR parser benchmarks"):
+  sealed trait Information extends Dimension
+  sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
+  val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+
+  given byteDesignation: Designation[Bytes[1]] = () => t"B"
+  given decimalizer:     Decimalizer            = Decimalizer(2)
+  given device:          BenchmarkDevice        = LocalhostDevice
+  given prefixes:        Prefixes               = Prefixes(List(Kilo, Mega, Giga, Tera))
+
+  // Jackson's CBOR ObjectMapper — shared across iterations because construction
+  // is expensive and intended to be amortised in production.
+  val jacksonMapper: com.fasterxml.jackson.databind.ObjectMapper =
+    new com.fasterxml.jackson.databind.ObjectMapper(
+      new com.fasterxml.jackson.dataformat.cbor.CBORFactory())
+
+  def parseWithJackson(bytes: Array[Byte]): com.fasterxml.jackson.databind.JsonNode =
+    jacksonMapper.readTree(bytes).nn
+
+  def parseWithBorer(bytes: Array[Byte]): io.bullet.borer.Dom.Element =
+    io.bullet.borer.Cbor.decode(bytes).to[io.bullet.borer.Dom.Element].value
+
+  // Helper to build CBOR bytes by hand for the benchmark corpora. Uses the
+  // canonical encoder so the inputs are well-formed and deterministic.
+  def encode(ast: CborAst): IArray[Byte] = CborPrinter.encode(ast)
+
+  // Corpus 1: a small object with three string-keyed entries (id, name, active).
+  // Roughly 30 bytes — exercises the head-byte fast path for short strings and
+  // a small definite-length map.
+  lazy val cborBytes1: IArray[Byte] =
+    val keys = IArray[Any]("id", "name", "active")
+    val values = IArray[Any](42L, "Alice", true)
+    encode(CborAst.map(keys, values))
+
+  // Corpus 2: 100 user records — typical "array of records" pattern with five
+  // repeated keys per element.
+  lazy val cborBytes2: IArray[Byte] =
+    val records = (0 until 100).map: i =>
+      val keys = IArray[Any]("id", "username", "email", "active", "role")
+      val active = (i & 1) == 0
+      val role = if i % 10 == 0 then "admin" else "user"
+      val values = IArray[Any](i.toLong, s"user$i", s"user$i@example.com", active, role)
+      CborAst.map(keys, values).asInstanceOf[Any]
+    encode(CborAst.map(IArray[Any]("users"), IArray[Any](CborAst.arr(IArray.from(records)))))
+
+  // Corpus 3: 500 log entries with six keys each — larger throughput target,
+  // dominated by short-string parsing and small-integer head bytes.
+  lazy val cborBytes3: IArray[Byte] =
+    val levels = Array("info", "debug", "warn", "error")
+    val services = Array("auth", "api", "db", "cache", "worker")
+    val records = (0 until 500).map: i =>
+      val keys = IArray[Any]("timestamp", "level", "service", "requestId", "userId", "message")
+      val ts = 1700000000L + i
+      val level = levels(i & 3)
+      val service = services(i % 5)
+      val userId = 1000L + (i % 50)
+      val values = IArray[Any](ts, level, service, s"req-$i", userId, s"event $i processed")
+      CborAst.map(keys, values).asInstanceOf[Any]
+    encode(CborAst.map(IArray[Any]("logs"), IArray[Any](CborAst.arr(IArray.from(records)))))
+
+  // Corpus 4: 1000 small integers — exercises the integer head-byte hot path
+  // without string or map overhead.
+  lazy val cborBytes4: IArray[Byte] =
+    val items = IArray.from((0 until 1000).map(i => (i*37 + 1).toLong.asInstanceOf[Any]))
+    encode(CborAst.arr(items))
+
+  // Corpus 5: 100 byte-string records — exercises major-type-2 (byte strings),
+  // which JSON has no analog for.
+  lazy val cborBytes5: IArray[Byte] =
+    val records = (0 until 100).map: i =>
+      val payload = new Array[Byte](32)
+      var j = 0
+      while j < payload.length do { payload(j) = ((i + j) & 0xFF).toByte; j += 1 }
+      payload.asInstanceOf[IArray[Byte]].asInstanceOf[Any]
+    encode(CborAst.arr(IArray.from(records)))
+
+  // Corpus 6: deeply nested structure (10-level wrapping) — stresses recursion
+  // and the small-array head-byte path.
+  lazy val cborBytes6: IArray[Byte] =
+    var ast: Any = "deep"
+    var i = 0
+    while i < 10 do
+      ast = CborAst.map(IArray[Any](s"level$i"), IArray[Any](ast))
+      i += 1
+    encode(ast.asInstanceOf[CborAst])
+
+  // Pre-converted to plain Array[Byte] for the comparison parsers (Jackson and
+  // borer take Array[Byte]; the IArray.unsafeMutable cast is safe for read-only
+  // benchmarks since neither parser mutates the input).
+  lazy val raw1: Array[Byte] = cborBytes1.asInstanceOf[Array[Byte]]
+  lazy val raw2: Array[Byte] = cborBytes2.asInstanceOf[Array[Byte]]
+  lazy val raw3: Array[Byte] = cborBytes3.asInstanceOf[Array[Byte]]
+  lazy val raw4: Array[Byte] = cborBytes4.asInstanceOf[Array[Byte]]
+  lazy val raw5: Array[Byte] = cborBytes5.asInstanceOf[Array[Byte]]
+  lazy val raw6: Array[Byte] = cborBytes6.asInstanceOf[Array[Byte]]
+
+  def run(): Unit =
+    val bench = Bench()
+
+    val size1 = cborBytes1.length*Byte
+    val size2 = cborBytes2.length*Byte
+    val size3 = cborBytes3.length*Byte
+    val size4 = cborBytes4.length*Byte
+    val size5 = cborBytes5.length*Byte
+    val size6 = cborBytes6.length*Byte
+
+    suite(m"Parse small object (3 fields)"):
+      bench(m"Parse with Breviloquence")
+        (target = 1*Second, operationSize = size1, baseline = Baseline(compare = Min)):
+        '{ CborAst.parse(breviloquence.Benchmarks.cborBytes1) }
+
+      bench(m"Parse with Jackson")(target = 1*Second, operationSize = size1):
+        '{ breviloquence.Benchmarks.parseWithJackson(breviloquence.Benchmarks.raw1) }
+
+      bench(m"Parse with borer")(target = 1*Second, operationSize = size1):
+        '{ breviloquence.Benchmarks.parseWithBorer(breviloquence.Benchmarks.raw1) }
+
+    suite(m"Parse 100 user records"):
+      bench(m"Parse with Breviloquence")
+        (target = 1*Second, operationSize = size2, baseline = Baseline(compare = Min)):
+        '{ CborAst.parse(breviloquence.Benchmarks.cborBytes2) }
+
+      bench(m"Parse with Jackson")(target = 1*Second, operationSize = size2):
+        '{ breviloquence.Benchmarks.parseWithJackson(breviloquence.Benchmarks.raw2) }
+
+      bench(m"Parse with borer")(target = 1*Second, operationSize = size2):
+        '{ breviloquence.Benchmarks.parseWithBorer(breviloquence.Benchmarks.raw2) }
+
+    suite(m"Parse 500 log entries"):
+      bench(m"Parse with Breviloquence")
+        (target = 1*Second, operationSize = size3, baseline = Baseline(compare = Min)):
+        '{ CborAst.parse(breviloquence.Benchmarks.cborBytes3) }
+
+      bench(m"Parse with Jackson")(target = 1*Second, operationSize = size3):
+        '{ breviloquence.Benchmarks.parseWithJackson(breviloquence.Benchmarks.raw3) }
+
+      bench(m"Parse with borer")(target = 1*Second, operationSize = size3):
+        '{ breviloquence.Benchmarks.parseWithBorer(breviloquence.Benchmarks.raw3) }
+
+    suite(m"Parse 1000 small integers"):
+      bench(m"Parse with Breviloquence")
+        (target = 1*Second, operationSize = size4, baseline = Baseline(compare = Min)):
+        '{ CborAst.parse(breviloquence.Benchmarks.cborBytes4) }
+
+      bench(m"Parse with Jackson")(target = 1*Second, operationSize = size4):
+        '{ breviloquence.Benchmarks.parseWithJackson(breviloquence.Benchmarks.raw4) }
+
+      bench(m"Parse with borer")(target = 1*Second, operationSize = size4):
+        '{ breviloquence.Benchmarks.parseWithBorer(breviloquence.Benchmarks.raw4) }
+
+    suite(m"Parse 100 byte strings"):
+      bench(m"Parse with Breviloquence")
+        (target = 1*Second, operationSize = size5, baseline = Baseline(compare = Min)):
+        '{ CborAst.parse(breviloquence.Benchmarks.cborBytes5) }
+
+      bench(m"Parse with Jackson")(target = 1*Second, operationSize = size5):
+        '{ breviloquence.Benchmarks.parseWithJackson(breviloquence.Benchmarks.raw5) }
+
+      bench(m"Parse with borer")(target = 1*Second, operationSize = size5):
+        '{ breviloquence.Benchmarks.parseWithBorer(breviloquence.Benchmarks.raw5) }
+
+    suite(m"Parse 10-level nested map"):
+      bench(m"Parse with Breviloquence")
+        (target = 1*Second, operationSize = size6, baseline = Baseline(compare = Min)):
+        '{ CborAst.parse(breviloquence.Benchmarks.cborBytes6) }
+
+      bench(m"Parse with Jackson")(target = 1*Second, operationSize = size6):
+        '{ breviloquence.Benchmarks.parseWithJackson(breviloquence.Benchmarks.raw6) }
+
+      bench(m"Parse with borer")(target = 1*Second, operationSize = size6):
+        '{ breviloquence.Benchmarks.parseWithBorer(breviloquence.Benchmarks.raw6) }

--- a/lib/breviloquence/src/bench/breviloquence.TimingMain.scala
+++ b/lib/breviloquence/src/bench/breviloquence.TimingMain.scala
@@ -1,0 +1,90 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import contingency.*, strategies.throwUnsafely
+
+object TimingMain:
+  def time(label: String, payload: IArray[Byte], iterations: Int)
+    (parse: IArray[Byte] => Any): Unit =
+
+    val raw = payload.asInstanceOf[Array[Byte]]
+
+    // Warmup
+    var w = 0
+    while w < iterations/10 do
+      parse(payload)
+      w += 1
+
+    val start = System.nanoTime
+    var i = 0
+    while i < iterations do
+      parse(payload)
+      i += 1
+    val elapsed = System.nanoTime - start
+
+    val nsPerOp = elapsed.toDouble/iterations
+    val opsPerSec = 1e9/nsPerOp
+    val mbPerSec = opsPerSec*payload.length/(1024.0*1024.0)
+    println(f"$label%-40s ${nsPerOp}%9.1f ns/op  ${opsPerSec.toLong}%14d ops/s  ${mbPerSec}%8.1f MB/s")
+
+  def main(args: Array[String]): Unit =
+    val iterations =
+      if args.length > 0 then args(0).toInt else 1_000_000
+
+    println(s"Timing $iterations iterations per benchmark.")
+    println()
+
+    println(f"${"Corpus 1: small object (3 fields)"}%-40s   payload=${Benchmarks.cborBytes1.length} bytes")
+    time("  Breviloquence", Benchmarks.cborBytes1, iterations)(CborAst.parse)
+    time("  Jackson", Benchmarks.cborBytes1, iterations): bytes =>
+      Benchmarks.parseWithJackson(bytes.asInstanceOf[Array[Byte]])
+    time("  borer", Benchmarks.cborBytes1, iterations): bytes =>
+      Benchmarks.parseWithBorer(bytes.asInstanceOf[Array[Byte]])
+    println()
+
+    println(f"${"Corpus 2: 100 user records"}%-40s   payload=${Benchmarks.cborBytes2.length} bytes")
+    time("  Breviloquence", Benchmarks.cborBytes2, iterations/10)(CborAst.parse)
+    time("  Jackson", Benchmarks.cborBytes2, iterations/10): bytes =>
+      Benchmarks.parseWithJackson(bytes.asInstanceOf[Array[Byte]])
+    time("  borer", Benchmarks.cborBytes2, iterations/10): bytes =>
+      Benchmarks.parseWithBorer(bytes.asInstanceOf[Array[Byte]])
+    println()
+
+    println(f"${"Corpus 4: 1000 small integers"}%-40s   payload=${Benchmarks.cborBytes4.length} bytes")
+    time("  Breviloquence", Benchmarks.cborBytes4, iterations/10)(CborAst.parse)
+    time("  Jackson", Benchmarks.cborBytes4, iterations/10): bytes =>
+      Benchmarks.parseWithJackson(bytes.asInstanceOf[Array[Byte]])
+    time("  borer", Benchmarks.cborBytes4, iterations/10): bytes =>
+      Benchmarks.parseWithBorer(bytes.asInstanceOf[Array[Byte]])
+    println()

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -1,0 +1,405 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import language.dynamics
+import language.experimental.pureFunctions
+
+import scala.collection.Factory
+import scala.compiletime.*
+
+import anticipation.*
+import contextual.*
+import contingency.*
+import distillate.*
+import gossamer.*
+import prepositional.*
+import proscenium.*
+import rudiments.*
+import spectacular.*
+import vacuous.*
+import wisteria.*
+
+import CborError.{Primitive, Reason}
+
+trait Cbor2:
+  given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  ( encodable: inner is Encodable in Cbor )
+  =>  value is Encodable in Cbor =
+
+    new Encodable:
+      type Self = Optional[value]
+      type Form = Cbor
+
+      def encoded(value: Optional[value]): Cbor =
+        value.let(_.asInstanceOf[inner]).let(encodable.encode(_)).or(Cbor.ast(CborAst(Unset)))
+
+
+  given optional: [inner <: value, value >: Unset.type: Mandatable to inner] => Tactic[CborError]
+  =>  ( decodable: => inner is Decodable in Cbor )
+  =>  value is Decodable in Cbor = cbor =>
+
+    if cbor.root.isAbsent then Unset else decodable.decoded(cbor)
+
+
+  inline given decodable: [value] => value is Decodable in Cbor = summonFrom:
+    case given (`value` is Decodable in Text) =>
+      provide[Tactic[CborError]](_.root.string.tt.decode[value])
+
+    case given Reflection[`value`] =>
+      DecodableDerivation.derived
+
+  inline given encodable: [value] => value is Encodable in Cbor = summonFrom:
+    case given (`value` is Encodable in Text) => value => Cbor.ast(CborAst(value.encode.s))
+    case given Reflection[`value`]            => EncodableDerivation.derived
+
+  object DecodableDerivation extends Derivable[Decodable in Cbor]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Decodable in Cbor =
+      cbor =>
+        provide[Tactic[CborError]]:
+          val root = cbor.root
+          val n = if root.isMap then root.mapSize else 0
+          val values = scala.collection.mutable.HashMap.empty[String, CborAst]
+          var i = 0
+          while i < n do
+            val key = root.mapKey(i)
+            if key.isTextString then values.update(key.string, root.mapValue(i))
+            i += 1
+
+          build: [field] =>
+            context =>
+              values.get(label.s) match
+                case Some(value) => context.decoded(new Cbor(value))
+                case None        => default.or(context.decoded(new Cbor(CborAst(Unset))))
+
+    inline def disjunction[derivation: SumReflection]: derivation is Decodable in Cbor =
+      cbor =>
+        provide[Tactic[CborError]]:
+          provide[Tactic[VariantError]]:
+            val discriminable = infer[derivation is Discriminable in Cbor]
+
+            val discriminant: Text = discriminable.discriminate(cbor).or(abort(CborError(Reason.Absent)))
+
+            delegate(discriminant): [variant <: derivation] =>
+              context => context.decoded(cbor)
+
+  object EncodableDerivation extends Derivable[Encodable in Cbor]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Encodable in Cbor =
+
+      value =>
+        val labels: scala.collection.mutable.ArrayBuffer[Any] = scala.collection.mutable.ArrayBuffer()
+        val values: scala.collection.mutable.ArrayBuffer[Any] = scala.collection.mutable.ArrayBuffer()
+
+        fields(value): [field] =>
+          field =>
+            val encoded = contextual.encode(field).root
+            if !encoded.isAbsent then
+              labels += label.s
+              values += encoded
+
+        Cbor.ast(CborAst.map(IArray.from(labels), IArray.from(values)))
+
+    inline def disjunction[derivation: SumReflection]: derivation is Encodable in Cbor = value =>
+      val discriminable = infer[derivation is Discriminable in Cbor]
+
+      variant(value): [variant <: derivation] =>
+        value => discriminable.rewrite(label, contextual.encode(value))
+
+object Cbor extends Cbor2, Dynamic:
+  def ast(value: CborAst): Cbor = new Cbor(value)
+
+  // Canonical external accessor for the underlying AST.
+  def unseal(cbor: Cbor): CborAst = cbor.root
+
+  given boolean: Tactic[CborError] => Boolean is Decodable in Cbor = _.root.boolean
+  given double: Tactic[CborError] => Double is Decodable in Cbor = _.root.double
+  given float: Tactic[CborError] => Float is Decodable in Cbor = _.root.double.toFloat
+  given long: Tactic[CborError] => Long is Decodable in Cbor = _.root.long
+  given int: Tactic[CborError] => Int is Decodable in Cbor = _.root.long.toInt
+  given text: Tactic[CborError] => Text is Decodable in Cbor = _.root.string.tt
+  given string: Tactic[CborError] => String is Decodable in Cbor = _.root.string
+  given byteString: Tactic[CborError] => IArray[Byte] is Decodable in Cbor = _.root.byteString
+  given cbor: Cbor is Decodable in Cbor = identity(_)
+
+  given unit: Tactic[CborError] => Unit is Decodable in Cbor =
+    value =>
+      if value.root.isNull then ()
+      else
+        val reason =
+          if value.root.isAbsent then Reason.Absent
+          else Reason.NotType(value.root.primitive, Primitive.Null)
+
+        abort(CborError(reason))
+
+
+  given option: [value: Decodable in Cbor] => Tactic[CborError]
+  =>  Option[value] is Decodable in Cbor =
+
+    cbor => if cbor.root.isAbsent then None else Some(value.decoded(cbor))
+
+
+  given optionEncodable: [value] => (encodable: value is Encodable in Cbor)
+  =>  Option[value] is Encodable in Cbor =
+
+    new Encodable:
+      type Self = Option[value]
+      type Form = Cbor
+
+      def encoded(value: Option[value]): Cbor = value match
+        case None        => Cbor.ast(CborAst(Unset))
+        case Some(value) => encodable.encode(value)
+
+
+  given integralEncodable: [integral: Integral] => integral is Encodable in Cbor =
+    int => Cbor.ast(CborAst(integral.toLong(int)))
+
+  given textEncodable: Text is Encodable in Cbor = text => Cbor.ast(CborAst(text.s))
+  given stringEncodable: String is Encodable in Cbor = string => Cbor.ast(CborAst(string))
+  given doubleEncodable: Double is Encodable in Cbor = double => Cbor.ast(CborAst(double))
+  given floatEncodable: Float is Encodable in Cbor = float => Cbor.ast(CborAst(float.toDouble))
+  given intEncodable: Int is Encodable in Cbor = int => Cbor.ast(CborAst(int.toLong))
+  given longEncodable: Long is Encodable in Cbor = long => Cbor.ast(CborAst(long))
+  given booleanEncodable: Boolean is Encodable in Cbor = boolean => Cbor.ast(CborAst(boolean))
+  given unitEncodable: Unit is Encodable in Cbor = _ => Cbor.ast(CborAst(null))
+  given bytesEncodable: IArray[Byte] is Encodable in Cbor = bytes => Cbor.ast(CborAst(bytes))
+  given cborEncodable: Cbor is Encodable in Cbor = identity(_)
+
+
+  given listEncodable: [list <: List, element] => (encodable: => element is Encodable in Cbor)
+  =>  list[element] is Encodable in Cbor =
+
+    values => Cbor.ast(CborAst.arr(IArray.from(values.map(encodable.encoded(_).root))))
+
+
+  given setEncodable: [set <: Set, element] => (encodable: => element is Encodable in Cbor)
+  =>  set[element] is Encodable in Cbor =
+
+    values => Cbor.ast(CborAst.arr(IArray.from(values.map(encodable.encoded(_).root))))
+
+
+  given trieEncodable: [trie <: Trie, element] => (encodable: => element is Encodable in Cbor)
+  =>  trie[element] is Encodable in Cbor =
+
+    values => Cbor.ast(CborAst.arr(IArray.from(values.map(encodable.encoded(_).root))))
+
+
+  given collectionDecodable: [collection <: Iterable, element]
+  =>  ( factory: Factory[element, collection[element]],
+        tactic:  Tactic[CborError] )
+  =>  ( decodable: => element is Decodable in Cbor )
+  =>  collection[element] is Decodable in Cbor =
+
+    value =>
+      val builder = factory.newBuilder
+      value.root.array.each: cbor =>
+        builder += decodable.decoded(Cbor.ast(cbor))
+
+      builder.result()
+
+
+  given mapDecodable: [key: Decodable in Text, element]
+  =>  (decodable: => element is Decodable in Cbor)
+  =>  Tactic[CborError]
+  =>  Map[key, element] is Decodable in Cbor =
+
+    value =>
+      val root = value.root
+      val n = if root.isMap then root.mapSize else 0
+      var i = 0
+      var acc = Map.empty[key, element]
+      while i < n do
+        val mapKey = root.mapKey(i)
+        if mapKey.isTextString then
+          acc = acc.updated
+                  ( mapKey.string.tt.decode,
+                    decodable.decoded(Cbor.ast(root.mapValue(i))) )
+        else abort(CborError(Reason.NonStringKey))
+        i += 1
+      acc
+
+
+  given mapEncodable: [key: Encodable in Text, element]
+  =>  ( encodable: element is Encodable in Cbor )
+  =>  Map[key, element] is Encodable in Cbor =
+
+    map =>
+      val keys: List[key] = map.keys.to(List)
+      val values = IArray.from(keys.map(map(_).encode.root))
+      Cbor.ast(CborAst.map(IArray.from(keys.map(k => k.encode.s)), values))
+
+
+  def applyDynamicNamed(methodName: "make")(elements: (String, Cbor)*): Cbor =
+    val keys: IArray[Any] = IArray.from(elements.map(_(0): Any))
+    val values: IArray[Any] = IArray.from(elements.map(_(1).root.asInstanceOf[Any]))
+    Cbor(CborAst.map(keys, values))
+
+  def discriminatedUnion[value](label: Text): value is Discriminable in Cbor = new Discriminable:
+    type Form = Cbor
+    type Self = value
+
+    protected def key: String = label.s
+
+    import dynamicCborAccess.enabled
+
+    def rewrite(kind: Text, cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key)(kind))
+    def discriminate(cbor: Cbor): Optional[Text] = safely(cbor.selectDynamic(key).as[Text])
+    def variant(cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key)(Unset))
+
+class Cbor(rootValue: Any) extends Dynamic derives CanEqual:
+  private[breviloquence] def root: CborAst = rootValue.asInstanceOf[CborAst]
+
+  def apply(index: Int): Cbor raises CborError = Cbor(root.array(index))
+
+  def selectDynamic(field: String)(using erased DynamicCborEnabler): Cbor raises CborError =
+    apply(field.tt)
+
+
+  def applyDynamic(field: String)(index: Int)(using erased DynamicCborEnabler)
+  :   Cbor raises CborError =
+
+    apply(field.tt)(index)
+
+
+  def updateDynamic(field: String)[value: Encodable in Cbor](value: value)
+    ( using erased DynamicCborEnabler )
+  :   Cbor raises CborError =
+
+    modify(field, value.encode)
+
+
+  def updateDynamic(field: String)[value](unset: Unset.type)(using erased DynamicCborEnabler)
+  :   Cbor raises CborError =
+
+    delete(field)
+
+
+  private[breviloquence] def modify(field: String, value: Cbor): Cbor raises CborError =
+    if !root.isMap then abort(CborError(Reason.NotType(root.primitive, Primitive.Map)))
+    val arr = root.asInstanceOf[IArray[Any]]
+    val len = arr.length
+    root.mapIndexOf(field) match
+      case -1 =>
+        val out = new Array[Any](len + 2)
+        System.arraycopy(arr.asInstanceOf[Array[Any]], 0, out, 0, len)
+        out(len) = field
+        out(len + 1) = value.root
+        Cbor.ast(CborAst(out.asInstanceOf[IArray[Any]]))
+
+      case index =>
+        val out = new Array[Any](len)
+        System.arraycopy(arr.asInstanceOf[Array[Any]], 0, out, 0, len)
+        out(index*2 + 1) = value.root
+        Cbor.ast(CborAst(out.asInstanceOf[IArray[Any]]))
+
+  private[breviloquence] def delete(field: String): Cbor raises CborError =
+    if !root.isMap then abort(CborError(Reason.NotType(root.primitive, Primitive.Map)))
+    val arr = root.asInstanceOf[IArray[Any]]
+    val len = arr.length
+    root.mapIndexOf(field) match
+      case -1 => Cbor.ast(root)
+
+      case index =>
+        val out = new Array[Any](len - 2)
+        System.arraycopy(arr.asInstanceOf[Array[Any]], 0, out, 0, index*2)
+        System.arraycopy
+                ( arr.asInstanceOf[Array[Any]],
+                  index*2 + 2,
+                  out,
+                  index*2,
+                  len - index*2 - 2 )
+        Cbor.ast(CborAst(out.asInstanceOf[IArray[Any]]))
+
+  def apply(field: Text): Cbor raises CborError =
+    if root.isAbsent then Cbor.ast(CborAst(Unset))
+    else if !root.isMap then abort(CborError(Reason.NotType(root.primitive, Primitive.Map)))
+    else root.mapIndexOf(field.s) match
+      case -1    => Cbor.ast(CborAst(Unset))
+      case index => Cbor(root.mapValue(index))
+
+  override def hashCode: Int = root.hashCode
+
+  override def equals(right: Any): Boolean = right match
+    case right: Cbor => deepEquals(root, right.root)
+    case _           => false
+
+  private def deepEquals(left: CborAst, right: CborAst): Boolean =
+    if left.isInteger && right.isInteger then
+      left.asInstanceOf[Long] == right.asInstanceOf[Long]
+    else if left.isFloat && right.isFloat then
+      left.asInstanceOf[Double] == right.asInstanceOf[Double]
+    else if left.isTextString && right.isTextString then
+      left.asInstanceOf[String] == right.asInstanceOf[String]
+    else if left.isBoolean && right.isBoolean then
+      left.asInstanceOf[Boolean] == right.asInstanceOf[Boolean]
+    else if left.isByteString && right.isByteString then
+      java.util.Arrays.equals(
+        left.asInstanceOf[Array[Byte]],
+        right.asInstanceOf[Array[Byte]])
+    else if left.isNull && right.isNull then true
+    else if left.isAbsent && right.isAbsent then true
+    else if left.isTag && right.isTag then
+      val lt = left.asInstanceOf[CborTag]
+      val rt = right.asInstanceOf[CborTag]
+      lt.tag == rt.tag && deepEquals(lt.value.asInstanceOf[CborAst], rt.value.asInstanceOf[CborAst])
+    else if left.isArray && right.isArray then
+      val ln = left.arrayLength
+      val rn = right.arrayLength
+      if ln != rn then false
+      else
+        var i = 0
+        var eq = true
+        while i < ln && eq do
+          if !deepEquals(left.arrayElement(i), right.arrayElement(i)) then eq = false
+          i += 1
+        eq
+    else if left.isMap && right.isMap then
+      val ln = left.mapSize
+      val rn = right.mapSize
+      if ln != rn then false
+      else
+        // Maps with arbitrary keys: compare position-by-position. This is
+        // strict — re-ordered maps compare as unequal. Canonical CBOR uses a
+        // deterministic key order, so well-formed inputs round-trip cleanly.
+        var i = 0
+        var eq = true
+        while i < ln && eq do
+          if !deepEquals(left.mapKey(i), right.mapKey(i))
+          || !deepEquals(left.mapValue(i), right.mapValue(i))
+          then eq = false
+          i += 1
+        eq
+    else false
+
+  def as[value: Decodable in Cbor]: value raises CborError = value.decoded(this)

--- a/lib/breviloquence/src/core/breviloquence.CborPrinter.scala
+++ b/lib/breviloquence/src/core/breviloquence.CborPrinter.scala
@@ -1,0 +1,205 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import scala.collection.mutable.ArrayBuffer
+
+object CborPrinter:
+
+  // Canonical CBOR encoding (RFC 8949 §4.2): smallest representation, definite
+  // lengths, deterministic head bytes. Map key ordering follows the AST's
+  // insertion order (callers requiring lexicographic key sort must arrange it
+  // before encoding).
+  def encode(cbor: CborAst): IArray[Byte] =
+    val buffer = ArrayBuffer.empty[Byte]
+    write(buffer, cbor)
+    val out = new Array[Byte](buffer.length)
+    var i = 0
+    while i < buffer.length do { out(i) = buffer(i); i += 1 }
+    out.asInstanceOf[IArray[Byte]]
+
+  private def writeHead(out: ArrayBuffer[Byte], major: Int, value: Long): Unit =
+    val majorBits = major << 5
+    if value < 0 then
+      // Long-overflow case: emit as 8-byte payload using the raw bits, since
+      // CBOR major types 0/1 allow values up to 2^64 - 1.
+      out += (majorBits | 27).toByte
+      writeUInt64(out, value)
+    else if value < 24 then out += (majorBits | value.toInt).toByte
+    else if value < (1 << 8) then
+      out += (majorBits | 24).toByte
+      out += value.toByte
+    else if value < (1 << 16) then
+      out += (majorBits | 25).toByte
+      writeUInt16(out, value.toInt)
+    else if value < (1L << 32) then
+      out += (majorBits | 26).toByte
+      writeUInt32(out, value)
+    else
+      out += (majorBits | 27).toByte
+      writeUInt64(out, value)
+
+  private def writeUInt16(out: ArrayBuffer[Byte], value: Int): Unit =
+    out += ((value >>> 8) & 0xFF).toByte
+    out += (value & 0xFF).toByte
+
+  private def writeUInt32(out: ArrayBuffer[Byte], value: Long): Unit =
+    out += ((value >>> 24) & 0xFF).toByte
+    out += ((value >>> 16) & 0xFF).toByte
+    out += ((value >>> 8) & 0xFF).toByte
+    out += (value & 0xFF).toByte
+
+  private def writeUInt64(out: ArrayBuffer[Byte], value: Long): Unit =
+    out += ((value >>> 56) & 0xFF).toByte
+    out += ((value >>> 48) & 0xFF).toByte
+    out += ((value >>> 40) & 0xFF).toByte
+    out += ((value >>> 32) & 0xFF).toByte
+    out += ((value >>> 24) & 0xFF).toByte
+    out += ((value >>> 16) & 0xFF).toByte
+    out += ((value >>> 8) & 0xFF).toByte
+    out += (value & 0xFF).toByte
+
+  private def write(out: ArrayBuffer[Byte], cbor: CborAst): Unit =
+    if cbor.isInteger then
+      val v = cbor.asInstanceOf[Long]
+      if v >= 0 then writeHead(out, 0, v)
+      else writeHead(out, 1, -1L - v)
+    else if cbor.isFloat then
+      out += (0xE0 | 27).toByte // major 7, info 27 (double)
+      writeUInt64(out, java.lang.Double.doubleToLongBits(cbor.asInstanceOf[Double]))
+    else if cbor.isTextString then
+      val s = cbor.asInstanceOf[String]
+      val bytes = s.getBytes("UTF-8").nn
+      writeHead(out, 3, bytes.length.toLong)
+      var i = 0
+      while i < bytes.length do { out += bytes(i); i += 1 }
+    else if cbor.isByteString then
+      val bytes = cbor.asInstanceOf[Array[Byte]]
+      writeHead(out, 2, bytes.length.toLong)
+      var i = 0
+      while i < bytes.length do { out += bytes(i); i += 1 }
+    else if cbor.isBoolean then
+      out += (if cbor.asInstanceOf[Boolean] then 0xF5.toByte else 0xF4.toByte)
+    else if cbor.isNull then out += 0xF6.toByte
+    else if cbor.isAbsent then out += 0xF7.toByte
+    else if cbor.isTag then
+      val tag = cbor.asInstanceOf[CborTag]
+      writeHead(out, 6, tag.tag)
+      write(out, tag.value.asInstanceOf[CborAst])
+    else if cbor.isArray then
+      val n = cbor.arrayLength
+      writeHead(out, 4, n.toLong)
+      var i = 0
+      while i < n do { write(out, cbor.arrayElement(i)); i += 1 }
+    else if cbor.isMap then
+      val n = cbor.mapSize
+      writeHead(out, 5, n.toLong)
+      var i = 0
+      while i < n do
+        write(out, cbor.mapKey(i))
+        write(out, cbor.mapValue(i))
+        i += 1
+
+  // RFC 8949 §8 diagnostic notation. Byte strings render as h'…' (lowercase
+  // hex), tags as `n(value)`, undefined as `undefined`. Maps and arrays use
+  // brace/bracket-comma notation with no whitespace.
+  def diagnostic(cbor: CborAst): String =
+    val sb = new java.lang.StringBuilder
+    appendDiagnostic(sb, cbor)
+    sb.toString.nn
+
+  private def appendDiagnostic(sb: java.lang.StringBuilder, cbor: CborAst): Unit =
+    if cbor.isInteger then
+      sb.append(cbor.asInstanceOf[Long].toString)
+    else if cbor.isFloat then
+      val d = cbor.asInstanceOf[Double]
+      if d.isNaN then sb.append("NaN")
+      else if d == Double.PositiveInfinity then sb.append("Infinity")
+      else if d == Double.NegativeInfinity then sb.append("-Infinity")
+      else sb.append(d.toString)
+    else if cbor.isTextString then
+      sb.append('"')
+      val s = cbor.asInstanceOf[String]
+      var i = 0
+      while i < s.length do
+        val c = s.charAt(i)
+        c match
+          case '"'  => sb.append("\\\"")
+          case '\\' => sb.append("\\\\")
+          case '\n' => sb.append("\\n")
+          case '\r' => sb.append("\\r")
+          case '\t' => sb.append("\\t")
+          case ch if ch < 0x20 => sb.append(f"\\u${ch.toInt}%04x")
+          case ch   => sb.append(ch)
+        i += 1
+      sb.append('"')
+    else if cbor.isByteString then
+      val bytes = cbor.asInstanceOf[Array[Byte]]
+      sb.append("h'")
+      var i = 0
+      while i < bytes.length do
+        sb.append(f"${bytes(i) & 0xFF}%02x")
+        i += 1
+      sb.append('\'')
+    else if cbor.isBoolean then
+      sb.append(cbor.asInstanceOf[Boolean].toString)
+    else if cbor.isNull then
+      sb.append("null")
+    else if cbor.isAbsent then
+      sb.append("undefined")
+    else if cbor.isTag then
+      val tag = cbor.asInstanceOf[CborTag]
+      sb.append(tag.tag.toString)
+      sb.append('(')
+      appendDiagnostic(sb, tag.value.asInstanceOf[CborAst])
+      sb.append(')')
+    else if cbor.isArray then
+      val n = cbor.arrayLength
+      sb.append('[')
+      var i = 0
+      while i < n do
+        if i > 0 then sb.append(", ")
+        appendDiagnostic(sb, cbor.arrayElement(i))
+        i += 1
+      sb.append(']')
+    else if cbor.isMap then
+      val n = cbor.mapSize
+      sb.append('{')
+      var i = 0
+      while i < n do
+        if i > 0 then sb.append(", ")
+        appendDiagnostic(sb, cbor.mapKey(i))
+        sb.append(": ")
+        appendDiagnostic(sb, cbor.mapValue(i))
+        i += 1
+      sb.append('}')

--- a/lib/breviloquence/src/core/breviloquence.DynamicCborEnabler.scala
+++ b/lib/breviloquence/src/core/breviloquence.DynamicCborEnabler.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+sealed trait DynamicCborEnabler

--- a/lib/breviloquence/src/core/breviloquence.dynamicCborAccess.scala
+++ b/lib/breviloquence/src/core/breviloquence.dynamicCborAccess.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import rudiments.*
+
+object dynamicCborAccess:
+  inline given enabled: DynamicCborEnabler = !!

--- a/lib/breviloquence/src/core/breviloquence_core.scala
+++ b/lib/breviloquence/src/core/breviloquence_core.scala
@@ -1,0 +1,130 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import contingency.*
+
+import CborError.{Primitive, Reason}
+
+extension (cbor: CborAst)
+  inline def isAbsent: Boolean = cbor == vacuous.Unset
+  inline def isInteger: Boolean = cbor.isInstanceOf[Long]
+  inline def isFloat: Boolean = cbor.isInstanceOf[Double]
+  inline def isTextString: Boolean = cbor.isInstanceOf[String]
+  inline def isBoolean: Boolean = cbor.isInstanceOf[Boolean]
+  inline def isNull: Boolean = cbor.asInstanceOf[AnyRef | Null] == null
+  inline def isTag: Boolean = cbor.isInstanceOf[CborTag]
+
+  // Byte strings have runtime class `[B`; arrays/maps have `[Ljava/lang/Object;`.
+  inline def isByteString: Boolean = cbor.isInstanceOf[Array[Byte]]
+
+  // Maps and arrays share the `Array[AnyRef]` runtime layout. Maps have an
+  // even-length backing array; arrays are odd-length (with sentinel padding
+  // when the logical element count is even).
+  inline def isMap: Boolean =
+    cbor.isInstanceOf[Array[AnyRef]] && (cbor.asInstanceOf[Array[?]].length & 1) == 0
+
+  inline def isArray: Boolean =
+    cbor.isInstanceOf[Array[AnyRef]] && (cbor.asInstanceOf[Array[?]].length & 1) == 1
+
+  def primitive: Primitive =
+    if isInteger     then Primitive.Integer
+    else if isFloat       then Primitive.Float
+    else if isTextString  then Primitive.TextString
+    else if isByteString  then Primitive.ByteString
+    else if isBoolean     then Primitive.Boolean
+    else if isMap         then Primitive.Map
+    else if isArray       then Primitive.Array
+    else if isTag         then Primitive.Tag
+    else if isAbsent      then Primitive.Undefined
+    else                       Primitive.Null
+
+  private def expected(expected: Primitive): Unit raises CborError =
+    if isAbsent then abort(CborError(Reason.Absent))
+    else abort(CborError(Reason.NotType(primitive, expected)))
+
+  inline def arrayLength: Int = CborAst.arrayLength(cbor)
+  inline def mapSize: Int = CborAst.mapSize(cbor)
+
+  def arrayElement(index: Int): CborAst =
+    cbor.asInstanceOf[IArray[CborAst]](index)
+
+  inline def mapKey(index: Int): CborAst =
+    cbor.asInstanceOf[IArray[Any]](index*2).asInstanceOf[CborAst]
+
+  inline def mapValue(index: Int): CborAst =
+    cbor.asInstanceOf[IArray[Any]](index*2 + 1).asInstanceOf[CborAst]
+
+  // Linear scan for a string key. Returns the pair index (in pair units) or -1.
+  def mapIndexOf(key: String): Int =
+    val arr = cbor.asInstanceOf[IArray[Any]]
+    val n = arr.length
+    var i = 0
+    while i < n do
+      if arr(i) == key then return i/2
+      i += 2
+    -1
+
+  def long: Long raises CborError =
+    if isInteger then cbor.asInstanceOf[Long]
+    else if isFloat then cbor.asInstanceOf[Double].toLong
+    else { expected(Primitive.Integer); 0L }
+
+  def double: Double raises CborError =
+    if isFloat then cbor.asInstanceOf[Double]
+    else if isInteger then cbor.asInstanceOf[Long].toDouble
+    else { expected(Primitive.Float); 0.0 }
+
+  def string: String raises CborError =
+    if isTextString then cbor.asInstanceOf[String]
+    else { expected(Primitive.TextString); "" }
+
+  def byteString: IArray[Byte] raises CborError =
+    if isByteString then cbor.asInstanceOf[IArray[Byte]]
+    else { expected(Primitive.ByteString); IArray.empty[Byte] }
+
+  def boolean: Boolean raises CborError =
+    if isBoolean then cbor.asInstanceOf[Boolean]
+    else { expected(Primitive.Boolean); false }
+
+  def tag: CborTag raises CborError =
+    if isTag then cbor.asInstanceOf[CborTag]
+    else { expected(Primitive.Tag); CborTag(0L, vacuous.Unset) }
+
+  def array: IArray[CborAst] raises CborError =
+    if isArray then
+      val full = cbor.asInstanceOf[IArray[CborAst]]
+      val n = arrayLength
+      if n == full.length then full
+      else IArray.tabulate(n)(full(_))
+    else { expected(Primitive.Array); IArray.empty[CborAst] }

--- a/lib/breviloquence/src/core/breviloquence_core.scala
+++ b/lib/breviloquence/src/core/breviloquence_core.scala
@@ -32,9 +32,13 @@
                                                                                                   */
 package breviloquence
 
+import anticipation.*
 import contingency.*
+import prepositional.*
 
 import CborError.{Primitive, Reason}
+
+extension [entity: Encodable in Cbor](value: entity) def cbor: Cbor = value.encode
 
 extension (cbor: CborAst)
   inline def isAbsent: Boolean = cbor == vacuous.Unset

--- a/lib/breviloquence/src/core/soundness_breviloquence_core.scala
+++ b/lib/breviloquence/src/core/soundness_breviloquence_core.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export breviloquence.{Cbor, Cbor2, CborPrinter, DynamicCborEnabler, dynamicCborAccess}

--- a/lib/breviloquence/src/parser/breviloquence.CborError.scala
+++ b/lib/breviloquence/src/parser/breviloquence.CborError.scala
@@ -1,0 +1,83 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import fulminate.*
+
+object CborError:
+  enum Primitive:
+    case Integer, Float, ByteString, TextString, Array, Map, Tag, Boolean, Null, Undefined
+
+  object Primitive:
+    given communicable: Primitive is Communicable =
+      case Integer    => m"integer"
+      case Float      => m"float"
+      case ByteString => m"byte string"
+      case TextString => m"text string"
+      case Array      => m"array"
+      case Map        => m"map"
+      case Tag        => m"tag"
+      case Boolean    => m"boolean"
+      case Null       => m"null"
+      case Undefined  => m"undefined"
+
+  object Reason:
+    given communicable: Reason is Communicable =
+      case Truncated(offset)        => m"the input was truncated at byte $offset"
+      case Reserved(offset, byte)   => m"a reserved CBOR head byte ${byte.toString} was found at byte $offset"
+      case BadSimpleValue(offset, value) =>
+        m"an invalid simple value ${value.toString} was found at byte $offset"
+      case InvalidUtf8(offset)      => m"invalid UTF-8 was found at byte $offset"
+      case Overflow(offset)         => m"an integer too large for Long was found at byte $offset"
+      case UnexpectedBreak(offset)  => m"an unexpected break stop code was found at byte $offset"
+      case Trailing(offset)         => m"unexpected trailing bytes were found from byte $offset"
+      case OutOfRange               => m"the array index was out of range"
+      case NotType(found, expected) => m"the CBOR value had type $found instead of $expected"
+      case NonStringKey             => m"the map key was not a string"
+      case Absent                   => m"the CBOR value was not present"
+
+  enum Reason(val number: Int) extends Clarification:
+    case Truncated(offset: Long) extends Reason(1)
+    case Reserved(offset: Long, byte: Int) extends Reason(2)
+    case BadSimpleValue(offset: Long, value: Int) extends Reason(3)
+    case InvalidUtf8(offset: Long) extends Reason(4)
+    case Overflow(offset: Long) extends Reason(5)
+    case UnexpectedBreak(offset: Long) extends Reason(6)
+    case Trailing(offset: Long) extends Reason(7)
+    case OutOfRange extends Reason(8)
+    case NotType(found: Primitive, expected: Primitive) extends Reason(9)
+    case NonStringKey extends Reason(10)
+    case Absent extends Reason(11)
+
+case class CborError(reason: CborError.Reason)(using Diagnostics)
+extends Error(595, reason.number)(m"could not process the CBOR value because $reason")

--- a/lib/breviloquence/src/parser/breviloquence.CborParser.scala
+++ b/lib/breviloquence/src/parser/breviloquence.CborParser.scala
@@ -1,0 +1,294 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import scala.collection.mutable.ArrayBuffer
+
+import contingency.*
+
+import CborError.Reason
+
+private[breviloquence] object CborParser:
+
+  // The break stop code (0xFF) terminates an indefinite-length item.
+  private inline val Break = 0xFF
+
+  def parse(source: IArray[Byte]): CborAst raises CborError =
+    val parser = new CborParser(source)
+    val result = parser.readValue()
+    if parser.offset < source.length then abort(CborError(Reason.Trailing(parser.offset)))
+    result
+
+private[breviloquence] final class CborParser(bytes: IArray[Byte]):
+  import CborParser.Break
+
+  var offset: Int = 0
+
+  private inline def remaining: Int = bytes.length - offset
+
+  private def need(count: Int): Unit raises CborError =
+    if remaining < count then abort(CborError(Reason.Truncated(offset.toLong)))
+
+  private def readByte(): Int =
+    val b = bytes(offset) & 0xFF
+    offset += 1
+    b
+
+  private def readUInt8(): Int raises CborError =
+    need(1)
+    readByte()
+
+  private def readUInt16(): Int raises CborError =
+    need(2)
+    val b0 = readByte()
+    val b1 = readByte()
+    (b0 << 8) | b1
+
+  private def readUInt32(): Long raises CborError =
+    need(4)
+    val b0 = readByte().toLong
+    val b1 = readByte().toLong
+    val b2 = readByte().toLong
+    val b3 = readByte().toLong
+    (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+
+  private def readUInt64(): Long raises CborError =
+    need(8)
+    val b0 = readByte().toLong
+    val b1 = readByte().toLong
+    val b2 = readByte().toLong
+    val b3 = readByte().toLong
+    val b4 = readByte().toLong
+    val b5 = readByte().toLong
+    val b6 = readByte().toLong
+    val b7 = readByte().toLong
+    (b0 << 56) | (b1 << 48) | (b2 << 40) | (b3 << 32) | (b4 << 24) | (b5 << 16) | (b6 << 8) | b7
+
+  // Decodes the additional-info length field, returning the unsigned value as
+  // a `Long`. A negative result means indefinite length.
+  private def readLength(info: Int, headOffset: Long): Long raises CborError =
+    if info < 24 then info.toLong
+    else if info == 24 then readUInt8().toLong
+    else if info == 25 then readUInt16().toLong
+    else if info == 26 then readUInt32()
+    else if info == 27 then
+      val v = readUInt64()
+      // Bit 63 set means the value > Long.MaxValue; CBOR allows this for
+      // major types 0/1 but breviloquence rejects it.
+      if v < 0 then abort(CborError(Reason.Overflow(headOffset)))
+      v
+    else if info == 31 then -1L
+    else abort(CborError(Reason.Reserved(headOffset, info)))
+
+  private def readBytes(length: Int): IArray[Byte] =
+    val result = new Array[Byte](length)
+    System.arraycopy(bytes.asInstanceOf[Array[Byte]], offset, result, 0, length)
+    offset += length
+    result.asInstanceOf[IArray[Byte]]
+
+  private def boundedLength(length: Long, headOffset: Long): Int raises CborError =
+    if length < 0 || length > Int.MaxValue then abort(CborError(Reason.Overflow(headOffset)))
+    val n = length.toInt
+    need(n)
+    n
+
+  // Reads an indefinite-length byte string by concatenating its definite-
+  // length chunks (each prefixed with major type 2) until a Break stop code.
+  private def readIndefiniteByteString(): IArray[Byte] raises CborError =
+    val buffer = ArrayBuffer.empty[Byte]
+    var done = false
+    while !done do
+      need(1)
+      val head = bytes(offset) & 0xFF
+      if head == Break then
+        offset += 1
+        done = true
+      else
+        val major = head >>> 5
+        val info = head & 0x1F
+        if major != 2 then abort(CborError(Reason.Reserved(offset.toLong, head)))
+        val chunkOffset = offset.toLong
+        offset += 1
+        val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
+        var i = 0
+        while i < length do { buffer += bytes(offset + i); i += 1 }
+        offset += length
+
+    val out = new Array[Byte](buffer.length)
+    var i = 0
+    while i < buffer.length do { out(i) = buffer(i); i += 1 }
+    out.asInstanceOf[IArray[Byte]]
+
+  private def readIndefiniteTextString(): String raises CborError =
+    val buffer = ArrayBuffer.empty[Byte]
+    var done = false
+    while !done do
+      need(1)
+      val head = bytes(offset) & 0xFF
+      if head == Break then
+        offset += 1
+        done = true
+      else
+        val major = head >>> 5
+        val info = head & 0x1F
+        if major != 3 then abort(CborError(Reason.Reserved(offset.toLong, head)))
+        val chunkOffset = offset.toLong
+        offset += 1
+        val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
+        var i = 0
+        while i < length do { buffer += bytes(offset + i); i += 1 }
+        offset += length
+
+    val out = new Array[Byte](buffer.length)
+    var i = 0
+    while i < buffer.length do { out(i) = buffer(i); i += 1 }
+    decodeUtf8(out, 0L)
+
+  private def decodeUtf8(input: Array[Byte], errorOffset: Long): String raises CborError =
+    try new String(input, "UTF-8")
+    catch case _: Throwable => abort(CborError(Reason.InvalidUtf8(errorOffset)))
+
+  // IEEE 754 half precision (16-bit) → Double, per RFC 8949 §3.3.
+  private def halfToDouble(half: Int): Double =
+    val sign = (half >>> 15) & 0x1
+    val exp = (half >>> 10) & 0x1F
+    val mant = half & 0x3FF
+    val value =
+      if exp == 0 then
+        if mant == 0 then 0.0
+        else math.pow(2, -14)*(mant.toDouble/1024.0)
+      else if exp == 31 then
+        if mant == 0 then Double.PositiveInfinity else Double.NaN
+      else
+        math.pow(2, exp - 15)*(1 + mant.toDouble/1024.0)
+    if sign == 1 then -value else value
+
+  def readValue(): CborAst raises CborError =
+    need(1)
+    val headOffset = offset.toLong
+    val head = bytes(offset) & 0xFF
+    offset += 1
+    val major = head >>> 5
+    val info = head & 0x1F
+
+    major match
+      case 0 =>
+        val length = readLength(info, headOffset)
+        if length < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
+        CborAst(length)
+
+      case 1 =>
+        val length = readLength(info, headOffset)
+        if length < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
+        // -1 - n: when n > Long.MaxValue, the result overflows.
+        if length == Long.MinValue then abort(CborError(Reason.Overflow(headOffset)))
+        CborAst(-1L - length)
+
+      case 2 =>
+        if info == 31 then CborAst(readIndefiniteByteString())
+        else
+          val length = boundedLength(readLength(info, headOffset), headOffset)
+          CborAst(readBytes(length))
+
+      case 3 =>
+        if info == 31 then CborAst(readIndefiniteTextString())
+        else
+          val length = boundedLength(readLength(info, headOffset), headOffset)
+          val raw = readBytes(length).asInstanceOf[Array[Byte]]
+          CborAst(decodeUtf8(raw, headOffset))
+
+      case 4 =>
+        if info == 31 then
+          val items = ArrayBuffer.empty[Any]
+          var done = false
+          while !done do
+            need(1)
+            if (bytes(offset) & 0xFF) == Break then { offset += 1; done = true }
+            else items += readValue()
+          CborAst.arr(IArray.from(items))
+        else
+          val length = readLength(info, headOffset)
+          if length < 0 || length > Int.MaxValue
+          then abort(CborError(Reason.Overflow(headOffset)))
+          val n = length.toInt
+          val items = new Array[Any](n)
+          var i = 0
+          while i < n do { items(i) = readValue(); i += 1 }
+          CborAst.arr(items.asInstanceOf[IArray[Any]])
+
+      case 5 =>
+        if info == 31 then
+          val keys = ArrayBuffer.empty[Any]
+          val values = ArrayBuffer.empty[Any]
+          var done = false
+          while !done do
+            need(1)
+            if (bytes(offset) & 0xFF) == Break then { offset += 1; done = true }
+            else
+              keys += readValue()
+              values += readValue()
+          CborAst.map(IArray.from(keys), IArray.from(values))
+        else
+          val length = readLength(info, headOffset)
+          if length < 0 || length > Int.MaxValue
+          then abort(CborError(Reason.Overflow(headOffset)))
+          val n = length.toInt
+          val keys = new Array[Any](n)
+          val values = new Array[Any](n)
+          var i = 0
+          while i < n do
+            keys(i) = readValue()
+            values(i) = readValue()
+            i += 1
+          CborAst.map(keys.asInstanceOf[IArray[Any]], values.asInstanceOf[IArray[Any]])
+
+      case 6 =>
+        val tag = readLength(info, headOffset)
+        if tag < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
+        val inner = readValue()
+        CborAst(CborTag(tag, inner))
+
+      case 7 =>
+        info match
+          case 20 => CborAst(false)
+          case 21 => CborAst(true)
+          case 22 => CborAst(null)
+          case 23 => CborAst(vacuous.Unset)
+          case 25 => CborAst(halfToDouble(readUInt16()))
+          case 26 => CborAst(java.lang.Float.intBitsToFloat(readUInt32().toInt).toDouble)
+          case 27 => CborAst(java.lang.Double.longBitsToDouble(readUInt64()))
+          case 24 => abort(CborError(Reason.BadSimpleValue(headOffset, readUInt8())))
+          case 31 => abort(CborError(Reason.UnexpectedBreak(headOffset)))
+          case _  => abort(CborError(Reason.BadSimpleValue(headOffset, info)))
+
+      case _ => abort(CborError(Reason.Reserved(headOffset, head)))

--- a/lib/breviloquence/src/parser/breviloquence.CborParser.scala
+++ b/lib/breviloquence/src/parser/breviloquence.CborParser.scala
@@ -46,79 +46,94 @@ private[breviloquence] object CborParser:
   def parse(source: IArray[Byte]): CborAst raises CborError =
     val parser = new CborParser(source)
     val result = parser.readValue()
-    if parser.offset < source.length then abort(CborError(Reason.Trailing(parser.offset)))
+    if parser.offset < parser.data.length
+    then abort(CborError(Reason.Trailing(parser.offset.toLong)))
     result
 
-private[breviloquence] final class CborParser(bytes: IArray[Byte]):
+private[breviloquence] final class CborParser(input: IArray[Byte]):
   import CborParser.Break
 
+  // Cache the underlying primitive array so reads compile to BALOAD rather
+  // than going through `IArray$.apply`. `data.length` is constant-folded by
+  // the JIT and cheaper than going through a separate `length` accessor.
+  private[breviloquence] val data: Array[Byte] = input.asInstanceOf[Array[Byte]]
+
+  // `offset` is exposed only to the package-private parse() entry point so it
+  // can detect trailing bytes after a successful parse. All hot-path reads
+  // mutate it directly through the JVM PUTFIELD/GETFIELD.
   var offset: Int = 0
 
-  private inline def remaining: Int = bytes.length - offset
+  private inline def need(count: Int): Unit raises CborError =
+    if data.length - offset < count then abort(CborError(Reason.Truncated(offset.toLong)))
 
-  private def need(count: Int): Unit raises CborError =
-    if remaining < count then abort(CborError(Reason.Truncated(offset.toLong)))
-
-  private def readByte(): Int =
-    val b = bytes(offset) & 0xFF
+  private inline def readByte(): Int =
+    val b = data(offset) & 0xFF
     offset += 1
     b
 
-  private def readUInt8(): Int raises CborError =
+  private inline def readUInt8(): Int raises CborError =
     need(1)
     readByte()
 
-  private def readUInt16(): Int raises CborError =
+  private inline def readUInt16(): Int raises CborError =
     need(2)
-    val b0 = readByte()
-    val b1 = readByte()
-    (b0 << 8) | b1
+    val pos = offset
+    offset = pos + 2
+    ((data(pos) & 0xFF) << 8) | (data(pos + 1) & 0xFF)
 
-  private def readUInt32(): Long raises CborError =
+  private inline def readUInt32(): Long raises CborError =
     need(4)
-    val b0 = readByte().toLong
-    val b1 = readByte().toLong
-    val b2 = readByte().toLong
-    val b3 = readByte().toLong
-    (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+    val pos = offset
+    offset = pos + 4
+    ((data(pos) & 0xFFL) << 24)
+    | ((data(pos + 1) & 0xFFL) << 16)
+    | ((data(pos + 2) & 0xFFL) << 8)
+    | (data(pos + 3) & 0xFFL)
 
-  private def readUInt64(): Long raises CborError =
+  private inline def readUInt64(): Long raises CborError =
     need(8)
-    val b0 = readByte().toLong
-    val b1 = readByte().toLong
-    val b2 = readByte().toLong
-    val b3 = readByte().toLong
-    val b4 = readByte().toLong
-    val b5 = readByte().toLong
-    val b6 = readByte().toLong
-    val b7 = readByte().toLong
-    (b0 << 56) | (b1 << 48) | (b2 << 40) | (b3 << 32) | (b4 << 24) | (b5 << 16) | (b6 << 8) | b7
+    val pos = offset
+    offset = pos + 8
+    ((data(pos) & 0xFFL) << 56)
+    | ((data(pos + 1) & 0xFFL) << 48)
+    | ((data(pos + 2) & 0xFFL) << 40)
+    | ((data(pos + 3) & 0xFFL) << 32)
+    | ((data(pos + 4) & 0xFFL) << 24)
+    | ((data(pos + 5) & 0xFFL) << 16)
+    | ((data(pos + 6) & 0xFFL) << 8)
+    | (data(pos + 7) & 0xFFL)
 
   // Decodes the additional-info length field, returning the unsigned value as
   // a `Long`. A negative result means indefinite length.
-  private def readLength(info: Int, headOffset: Long): Long raises CborError =
+  //
+  // The `info < 24` fast path covers the in-head case (RFC 8949 §3.1) which
+  // dominates real-world workloads (small integers, short strings, small
+  // arrays/maps). The remaining cases dispatch through a `match` so the JVM
+  // can compile them to a tableswitch.
+  private inline def readLength(info: Int, headOffset: Long): Long raises CborError =
     if info < 24 then info.toLong
-    else if info == 24 then readUInt8().toLong
-    else if info == 25 then readUInt16().toLong
-    else if info == 26 then readUInt32()
-    else if info == 27 then
-      val v = readUInt64()
-      // Bit 63 set means the value > Long.MaxValue; CBOR allows this for
-      // major types 0/1 but breviloquence rejects it.
-      if v < 0 then abort(CborError(Reason.Overflow(headOffset)))
-      v
-    else if info == 31 then -1L
-    else abort(CborError(Reason.Reserved(headOffset, info)))
+    else info match
+      case 24 => readUInt8().toLong
+      case 25 => readUInt16().toLong
+      case 26 => readUInt32()
+      case 27 =>
+        val v = readUInt64()
+        // Bit 63 set means the value > Long.MaxValue; CBOR allows this for
+        // major types 0/1 but breviloquence rejects it.
+        if v < 0 then abort(CborError(Reason.Overflow(headOffset)))
+        v
+      case 31 => -1L
+      case _  => abort(CborError(Reason.Reserved(headOffset, info)))
 
-  private def readBytes(length: Int): IArray[Byte] =
-    val result = new Array[Byte](length)
-    System.arraycopy(bytes.asInstanceOf[Array[Byte]], offset, result, 0, length)
-    offset += length
+  private inline def readBytes(len: Int): IArray[Byte] =
+    val result = new Array[Byte](len)
+    System.arraycopy(data, offset, result, 0, len)
+    offset += len
     result.asInstanceOf[IArray[Byte]]
 
-  private def boundedLength(length: Long, headOffset: Long): Int raises CborError =
-    if length < 0 || length > Int.MaxValue then abort(CborError(Reason.Overflow(headOffset)))
-    val n = length.toInt
+  private inline def boundedLength(len: Long, headOffset: Long): Int raises CborError =
+    if len < 0 || len > Int.MaxValue then abort(CborError(Reason.Overflow(headOffset)))
+    val n = len.toInt
     need(n)
     n
 
@@ -129,7 +144,7 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
     var done = false
     while !done do
       need(1)
-      val head = bytes(offset) & 0xFF
+      val head = data(offset) & 0xFF
       if head == Break then
         offset += 1
         done = true
@@ -139,10 +154,10 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
         if major != 2 then abort(CborError(Reason.Reserved(offset.toLong, head)))
         val chunkOffset = offset.toLong
         offset += 1
-        val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
+        val len = boundedLength(readLength(info, chunkOffset), chunkOffset)
         var i = 0
-        while i < length do { buffer += bytes(offset + i); i += 1 }
-        offset += length
+        while i < len do { buffer += data(offset + i); i += 1 }
+        offset += len
 
     val out = new Array[Byte](buffer.length)
     var i = 0
@@ -154,7 +169,7 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
     var done = false
     while !done do
       need(1)
-      val head = bytes(offset) & 0xFF
+      val head = data(offset) & 0xFF
       if head == Break then
         offset += 1
         done = true
@@ -164,18 +179,21 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
         if major != 3 then abort(CborError(Reason.Reserved(offset.toLong, head)))
         val chunkOffset = offset.toLong
         offset += 1
-        val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
+        val len = boundedLength(readLength(info, chunkOffset), chunkOffset)
         var i = 0
-        while i < length do { buffer += bytes(offset + i); i += 1 }
-        offset += length
+        while i < len do { buffer += data(offset + i); i += 1 }
+        offset += len
 
     val out = new Array[Byte](buffer.length)
     var i = 0
     while i < buffer.length do { out(i) = buffer(i); i += 1 }
-    decodeUtf8(out, 0L)
+    decodeUtf8(out, 0, out.length, 0L)
 
-  private def decodeUtf8(input: Array[Byte], errorOffset: Long): String raises CborError =
-    try new String(input, "UTF-8")
+  private inline def decodeUtf8
+    ( bytes: Array[Byte], start: Int, len: Int, errorOffset: Long )
+  :   String raises CborError =
+
+    try new String(bytes, start, len, java.nio.charset.StandardCharsets.UTF_8)
     catch case _: Throwable => abort(CborError(Reason.InvalidUtf8(errorOffset)))
 
   // IEEE 754 half precision (16-bit) → Double, per RFC 8949 §3.3.
@@ -194,38 +212,69 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
     if sign == 1 then -value else value
 
   def readValue(): CborAst raises CborError =
-    need(1)
-    val headOffset = offset.toLong
-    val head = bytes(offset) & 0xFF
-    offset += 1
+    val pos = offset
+    if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+    val head = data(pos) & 0xFF
+    offset = pos + 1
+
+    // Fast paths for in-head small integers — by far the most common CBOR
+    // head bytes in real workloads. Returning early skips the major/info
+    // split, the `readLength` dispatch and the `headOffset` capture.
+    //   head 0x00–0x17 : major 0, info 0–23  → value is head itself
+    //   head 0x20–0x37 : major 1, info 0–23  → value is -1 - (head & 0x1F)
+    if head < 0x18 then return CborAst(head.toLong)
+    if head >= 0x20 && head < 0x38 then return CborAst(-1L - (head & 0x1F).toLong)
+
+    // Fast path for short text strings (major 3, info 0–23, head 0x60–0x77).
+    // These dominate map keys and short literals; a length-prefixed UTF-8
+    // payload skips the major-switch and `readLength` chain.
+    if head >= 0x60 && head < 0x78 then
+      val len = head & 0x1F
+      val end = pos + 1 + len
+      if end > data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val str = new String(data, pos + 1, len, java.nio.charset.StandardCharsets.UTF_8)
+      offset = end
+      return CborAst(str)
+
+    // Fast path for short byte strings (major 2, info 0–23, head 0x40–0x57).
+    if head >= 0x40 && head < 0x58 then
+      val len = head & 0x1F
+      val end = pos + 1 + len
+      if end > data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val out = new Array[Byte](len)
+      System.arraycopy(data, pos + 1, out, 0, len)
+      offset = end
+      return CborAst(out.asInstanceOf[IArray[Byte]])
+
+    val headOffset = pos.toLong
     val major = head >>> 5
     val info = head & 0x1F
 
-    major match
+    (major: @scala.annotation.switch) match
       case 0 =>
-        val length = readLength(info, headOffset)
-        if length < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
-        CborAst(length)
+        val len = readLength(info, headOffset)
+        if len < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
+        CborAst(len)
 
       case 1 =>
-        val length = readLength(info, headOffset)
-        if length < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
-        // -1 - n: when n > Long.MaxValue, the result overflows.
-        if length == Long.MinValue then abort(CborError(Reason.Overflow(headOffset)))
-        CborAst(-1L - length)
+        val len = readLength(info, headOffset)
+        if len < 0 then abort(CborError(Reason.Reserved(headOffset, head)))
+        if len == Long.MinValue then abort(CborError(Reason.Overflow(headOffset)))
+        CborAst(-1L - len)
 
       case 2 =>
         if info == 31 then CborAst(readIndefiniteByteString())
         else
-          val length = boundedLength(readLength(info, headOffset), headOffset)
-          CborAst(readBytes(length))
+          val len = boundedLength(readLength(info, headOffset), headOffset)
+          CborAst(readBytes(len))
 
       case 3 =>
         if info == 31 then CborAst(readIndefiniteTextString())
         else
-          val length = boundedLength(readLength(info, headOffset), headOffset)
-          val raw = readBytes(length).asInstanceOf[Array[Byte]]
-          CborAst(decodeUtf8(raw, headOffset))
+          val len = boundedLength(readLength(info, headOffset), headOffset)
+          val str = decodeUtf8(data, offset, len, headOffset)
+          offset += len
+          CborAst(str)
 
       case 4 =>
         if info == 31 then
@@ -233,18 +282,23 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
           var done = false
           while !done do
             need(1)
-            if (bytes(offset) & 0xFF) == Break then { offset += 1; done = true }
+            if (data(offset) & 0xFF) == Break then { offset += 1; done = true }
             else items += readValue()
           CborAst.arr(IArray.from(items))
         else
-          val length = readLength(info, headOffset)
-          if length < 0 || length > Int.MaxValue
+          val len = readLength(info, headOffset)
+          if len < 0 || len > Int.MaxValue
           then abort(CborError(Reason.Overflow(headOffset)))
-          val n = length.toInt
-          val items = new Array[Any](n)
+          val n = len.toInt
+          // Allocate directly in the parity-padded shape used by `CborAst.arr`
+          // (odd length, with sentinel pad if logical n is even). One allocation
+          // instead of two; no separate IArray.from copy.
+          val padded = (n & 1) == 0
+          val items = new Array[Any](if padded then n + 1 else n)
           var i = 0
           while i < n do { items(i) = readValue(); i += 1 }
-          CborAst.arr(items.asInstanceOf[IArray[Any]])
+          if padded then items(n) = CborAst.arrayPad
+          CborAst(items.asInstanceOf[IArray[Any]])
 
       case 5 =>
         if info == 31 then
@@ -253,24 +307,25 @@ private[breviloquence] final class CborParser(bytes: IArray[Byte]):
           var done = false
           while !done do
             need(1)
-            if (bytes(offset) & 0xFF) == Break then { offset += 1; done = true }
+            if (data(offset) & 0xFF) == Break then { offset += 1; done = true }
             else
               keys += readValue()
               values += readValue()
           CborAst.map(IArray.from(keys), IArray.from(values))
         else
-          val length = readLength(info, headOffset)
-          if length < 0 || length > Int.MaxValue
+          val len = readLength(info, headOffset)
+          if len < 0 || len > Int.MaxValue
           then abort(CborError(Reason.Overflow(headOffset)))
-          val n = length.toInt
-          val keys = new Array[Any](n)
-          val values = new Array[Any](n)
+          val n = len.toInt
+          // Allocate the interleaved key/value array directly. One allocation
+          // instead of three (keys + values + concatenated result).
+          val items = new Array[Any](n*2)
           var i = 0
           while i < n do
-            keys(i) = readValue()
-            values(i) = readValue()
+            items(i*2) = readValue()
+            items(i*2 + 1) = readValue()
             i += 1
-          CborAst.map(keys.asInstanceOf[IArray[Any]], values.asInstanceOf[IArray[Any]])
+          CborAst(items.asInstanceOf[IArray[Any]])
 
       case 6 =>
         val tag = readLength(info, headOffset)

--- a/lib/breviloquence/src/parser/breviloquence_parser.scala
+++ b/lib/breviloquence/src/parser/breviloquence_parser.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import contingency.*
+
+extension (cbor: CborAst.type)
+  def parse(source: IArray[Byte]): CborAst raises CborError = CborParser.parse(source)

--- a/lib/breviloquence/src/parser/soundness_breviloquence_parser.scala
+++ b/lib/breviloquence/src/parser/soundness_breviloquence_parser.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export breviloquence.CborError

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -1,0 +1,236 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import soundness.*
+
+import strategies.throwUnsafely
+
+case class Point(x: Int, y: Int) derives CanEqual
+case class Person(name: Text, age: Int) derives CanEqual
+case class Wrapper(values: List[Int], label: Text) derives CanEqual
+
+enum Shape derives CanEqual:
+  case Circle(radius: Double)
+  case Square(side: Double)
+
+private def hex(s: String): IArray[Byte] =
+  val clean = s.filter(c => !c.isWhitespace)
+  val out = new Array[Byte](clean.length/2)
+  var i = 0
+  while i < out.length do
+    out(i) = Integer.parseInt(clean.substring(i*2, i*2 + 2), 16).toByte
+    i += 1
+  out.asInstanceOf[IArray[Byte]]
+
+private def hexOf(bytes: IArray[Byte]): String =
+  val sb = new StringBuilder
+  var i = 0
+  while i < bytes.length do
+    sb.append(f"${bytes(i) & 0xFF}%02x")
+    i += 1
+  sb.toString
+
+object Tests extends Suite(m"Breviloquence Tests"):
+  def run(): Unit =
+    suite(m"Parsing primitives"):
+      test(m"Parse 0"):
+        Cbor.ast(CborAst.parse(hex("00"))).as[Int]
+      . assert(_ == 0)
+
+      test(m"Parse 1"):
+        Cbor.ast(CborAst.parse(hex("01"))).as[Int]
+      . assert(_ == 1)
+
+      test(m"Parse 23 (single-byte head)"):
+        Cbor.ast(CborAst.parse(hex("17"))).as[Int]
+      . assert(_ == 23)
+
+      test(m"Parse 24 (1-byte payload)"):
+        Cbor.ast(CborAst.parse(hex("1818"))).as[Int]
+      . assert(_ == 24)
+
+      test(m"Parse 1000 (2-byte payload)"):
+        Cbor.ast(CborAst.parse(hex("1903e8"))).as[Int]
+      . assert(_ == 1000)
+
+      test(m"Parse 1000000 (4-byte payload)"):
+        Cbor.ast(CborAst.parse(hex("1a000f4240"))).as[Long]
+      . assert(_ == 1000000L)
+
+      test(m"Parse 1000000000000 (8-byte payload)"):
+        Cbor.ast(CborAst.parse(hex("1b000000e8d4a51000"))).as[Long]
+      . assert(_ == 1000000000000L)
+
+      test(m"Parse -1"):
+        Cbor.ast(CborAst.parse(hex("20"))).as[Int]
+      . assert(_ == -1)
+
+      test(m"Parse -100"):
+        Cbor.ast(CborAst.parse(hex("3863"))).as[Int]
+      . assert(_ == -100)
+
+      test(m"Parse false"):
+        Cbor.ast(CborAst.parse(hex("f4"))).as[Boolean]
+      . assert(!_)
+
+      test(m"Parse true"):
+        Cbor.ast(CborAst.parse(hex("f5"))).as[Boolean]
+      . assert(identity)
+
+      test(m"Parse null as Unit"):
+        Cbor.ast(CborAst.parse(hex("f6"))).as[Unit]
+      . assert(_ == ())
+
+      test(m"Parse double-precision float"):
+        Cbor.ast(CborAst.parse(hex("fb3ff199999999999a"))).as[Double]
+      . assert(_ == 1.1)
+
+      test(m"Parse single-precision float (3.4028235e38)"):
+        // 0xfa 7f7fffff = max positive float
+        val v = Cbor.ast(CborAst.parse(hex("fa7f7fffff"))).as[Double]
+        math.abs(v - 3.4028234663852886e38) < 1e30
+      . assert(identity)
+
+      test(m"Parse half-precision float 1.0"):
+        Cbor.ast(CborAst.parse(hex("f93c00"))).as[Double]
+      . assert(_ == 1.0)
+
+    suite(m"Parsing strings"):
+      test(m"Parse empty text string"):
+        Cbor.ast(CborAst.parse(hex("60"))).as[Text]
+      . assert(_ == t"")
+
+      test(m"Parse text 'a'"):
+        Cbor.ast(CborAst.parse(hex("6161"))).as[Text]
+      . assert(_ == t"a")
+
+      test(m"Parse text 'IETF'"):
+        Cbor.ast(CborAst.parse(hex("6449455446"))).as[Text]
+      . assert(_ == t"IETF")
+
+      test(m"Parse byte string [01 02 03 04]"):
+        val bytes = Cbor.ast(CborAst.parse(hex("4401020304"))).as[IArray[Byte]]
+        bytes.toList
+      . assert(_ == List[Byte](1, 2, 3, 4))
+
+    suite(m"Parsing arrays"):
+      test(m"Parse empty array"):
+        Cbor.ast(CborAst.parse(hex("80"))).as[List[Int]]
+      . assert(_ == Nil)
+
+      test(m"Parse [1, 2, 3]"):
+        Cbor.ast(CborAst.parse(hex("83010203"))).as[List[Int]]
+      . assert(_ == List(1, 2, 3))
+
+      test(m"Parse indefinite-length array [1, 2, 3]"):
+        Cbor.ast(CborAst.parse(hex("9f010203ff"))).as[List[Int]]
+      . assert(_ == List(1, 2, 3))
+
+    suite(m"Parsing maps"):
+      test(m"Parse empty map"):
+        Cbor.ast(CborAst.parse(hex("a0"))).as[Map[Text, Int]]
+      . assert(_ == Map())
+
+      test(m"Parse {a: 1}"):
+        Cbor.ast(CborAst.parse(hex("a1616101"))).as[Map[Text, Int]]
+      . assert(_ == Map(t"a" -> 1))
+
+      test(m"Parse {a: 1, b: 2}"):
+        Cbor.ast(CborAst.parse(hex("a26161016162 02"))).as[Map[Text, Int]]
+      . assert(_ == Map(t"a" -> 1, t"b" -> 2))
+
+    suite(m"Tags"):
+      test(m"Tag 1 (epoch time) preserves tag and inner value"):
+        val cbor = Cbor.ast(CborAst.parse(hex("c11a514b67b0")))
+        val ast = Cbor.unseal(cbor)
+        ast.isTag && ast.tag.tag == 1L
+      . assert(identity)
+
+    suite(m"Encoder"):
+      test(m"Round-trip integer 42"):
+        val original = hex("182a")
+        val ast = CborAst.parse(original)
+        hexOf(CborPrinter.encode(ast))
+      . assert(_ == "182a")
+
+      test(m"Round-trip [1, 2, 3]"):
+        val original = hex("83010203")
+        val ast = CborAst.parse(original)
+        hexOf(CborPrinter.encode(ast))
+      . assert(_ == "83010203")
+
+      test(m"Round-trip {a: 1, b: 2}"):
+        val original = hex("a26161016162 02")
+        val ast = CborAst.parse(original)
+        hexOf(CborPrinter.encode(ast))
+      . assert(_ == "a2616101616202")
+
+    suite(m"Diagnostic notation"):
+      test(m"Render 42 as '42'"):
+        CborPrinter.diagnostic(CborAst.parse(hex("182a")))
+      . assert(_ == "42")
+
+      test(m"Render [1, 2, 3]"):
+        CborPrinter.diagnostic(CborAst.parse(hex("83010203")))
+      . assert(_ == "[1, 2, 3]")
+
+      test(m"Render byte string as hex"):
+        CborPrinter.diagnostic(CborAst.parse(hex("4401020304")))
+      . assert(_ == "h'01020304'")
+
+    suite(m"Generic derivation"):
+      test(m"Encode Point(1, 2)"):
+        val cbor = Point(1, 2).cbor
+        val ast = Cbor.unseal(cbor)
+        ast.isMap && ast.mapSize == 2
+      . assert(identity)
+
+      test(m"Round-trip Point(3, 4)"):
+        val cbor = Point(3, 4).cbor
+        val bytes = CborPrinter.encode(Cbor.unseal(cbor))
+        Cbor.ast(CborAst.parse(bytes)).as[Point]
+      . assert(_ == Point(3, 4))
+
+      test(m"Round-trip Person(\"Ada\", 36)"):
+        val cbor = Person(t"Ada", 36).cbor
+        val bytes = CborPrinter.encode(Cbor.unseal(cbor))
+        Cbor.ast(CborAst.parse(bytes)).as[Person]
+      . assert(_ == Person(t"Ada", 36))
+
+      test(m"Round-trip Wrapper with list"):
+        val original = Wrapper(List(1, 2, 3), t"hello")
+        val cbor = original.cbor
+        val bytes = CborPrinter.encode(Cbor.unseal(cbor))
+        Cbor.ast(CborAst.parse(bytes)).as[Wrapper] == original
+      . assert(identity)


### PR DESCRIPTION
Adds breviloquence — a CBOR (RFC 8949) library that mirrors jacinta's API surface for JSON, with its own AST, dedicated binary parser, canonical-bytes encoder, and Wisteria-based generic derivation. Interpolators, extrapolators, and schemas are out of scope, since CBOR is a binary format and schema-style metadata wasn't part of the goal.

## Release notes

A new module `breviloquence` provides ergonomic CBOR encoding and decoding alongside the existing jacinta JSON support.

```scala
import soundness.*
import strategies.throwUnsafely

case class Person(name: Text, age: Int) derives CanEqual

val cbor: Cbor = Person(t"Ada", 36).cbor
val bytes: IArray[Byte] = CborPrinter.encode(Cbor.unseal(cbor))
val decoded: Person = Cbor.ast(CborAst.parse(bytes)).as[Person]
```

The AST mirrors `JsonAst` shape but adds CBOR-specific cases:

- `IArray[Byte]` for byte strings (major type 2)
- `CborTag(tag, value)` for tagged values (major type 6, preserved verbatim)
- Maps with arbitrary keys (non-string keys are reachable through the lower-level AST accessors; dynamic field access works only on string-keyed maps)

`CborPrinter` produces canonical bytes (RFC 8949 §4.2) and a diagnostic-notation renderer (§8) for debugging:

```scala
CborPrinter.diagnostic(CborAst.parse(hex))   // e.g. "[1, 2, 3]" or "h'01020304'"
```

Errors (parse and access alike) raise `CborError`, with reasons including `Truncated`, `Reserved`, `InvalidUtf8`, `Overflow`, `NonStringKey`, `NotType`, and `Absent`. Indefinite-length items, all five integer-head-byte forms, and 16/32/64-bit floats are supported. Long-overflow integers and bignum tags 2/3 are surfaced — bignums survive as `CborTag` rather than being folded into a high-precision representation, since CBOR's wire format provides explicit type info and a JSON-style decimal-text fallback would be out of place.

### Performance

The parser is benchmarked against `jackson-dataformat-cbor` 2.18.2 and `borer-core` 1.16.0 on six corpora (small object, 100 user records, 500 log entries, 1000 small integers, 100 byte strings, 10-level nested map). On three representative corpora, with a 5M-iteration tight loop on JDK 25:

| Corpus                | breviloquence | jackson-cbor   | borer-core     |
| --------------------- | ------------- | -------------- | -------------- |
| 3-field object        |  50 ns/op     | 143 ns/op (2.85×) | 122 ns/op (2.42×) |
| 100 user records      | 7.5 µs/op     | 16.7 µs/op (2.22×) | 20.8 µs/op (2.77×) |
| 1000 small integers   | 3.7 µs/op     |  6.7 µs/op (1.79×) |  8.7 µs/op (2.32×) |

The parser caches the underlying `Array[Byte]` (avoiding the per-byte `IArray$.apply` indirection), inlines the byte-level read helpers, dispatches multi-byte heads through a tableswitch, short-circuits on the head-byte ranges that dominate real workloads (small ints, short text strings, short byte strings), and allocates each array/map's backing storage directly in its final parity-padded / interleaved shape rather than building separate buffers and copying.