### PR TITLE
probably: render benchmarks under Claude Code

### DIFF
--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -160,6 +160,11 @@ class Report(using Environment)(using palette: TestPalette):
   def addDetail(testId: TestId, info: Verdict.Detail): Report =
     this.also(details(testId) = details(testId).append(info))
 
+  private def benches(line: ReportLine): Iterable[ReportLine.Bench] = line match
+    case bench@ReportLine.Bench(_, _) => Iterable(bench)
+    case ReportLine.Suite(_, tests)   => tests.list.flatMap((_, line) => benches(line))
+    case _                            => Nil
+
   enum Status:
     case Pass, Fail, Throws, CheckThrows, Mixed, Suite, Bench, AspirePass, AspireFail
 
@@ -251,22 +256,19 @@ class Report(using Environment)(using palette: TestPalette):
       val ln = frame.line.let(_.toString.tt).or(t"?")
       t"  at ${frame.method.cls}.${frame.method.method} (${frame.file}:$ln)"
 
-    def benches(line: ReportLine): Iterable[ReportLine.Bench] = line match
-      case bench@ReportLine.Bench(_, _) => Iterable(bench)
-      case ReportLine.Suite(_, tests)   => tests.list.map(_(1)).flatMap(benches(_))
-      case _                            => Nil
+    val bySuite = benches(lines).to(List).groupBy(_.test.suite).to(List)
+                                . sortBy(_(1).iterator.map(_.test.timestamp).min)
 
-    val allBenches = benches(lines).to(List)
-
-    if allBenches.nonEmpty then
+    bySuite.each: (suite, benchmarks) =>
+      val suiteName = suite.let(_.name.text).or(t"")
       Out.println(t"")
+      if suiteName.length > 0 then Out.println(suiteName)
 
       Scaffold[ReportLine.Bench]
         ( Column(e"Hash"): b =>
             e"${b.test.id}",
-          Column(e"Test"): b =>
-            val depth = b.test.suite.let(_.id.depth).or(0)
-            e"${t"  "*depth}${b.test.name}",
+          Column(e"Benchmark"): b =>
+            e"${b.test.name}",
           Column(e"n", textAlign = TextAlignment.Right): b =>
             e"${b.benchmark.iterations.toLong}",
           Column(e"Mean", textAlign = TextAlignment.Right): b =>
@@ -274,10 +276,10 @@ class Report(using Environment)(using palette: TestPalette):
           Column(e"SD", textAlign = TextAlignment.Right): b =>
             showTime(b.benchmark.sd.toLong),
           Column(e"Throughput", textAlign = TextAlignment.Right): b =>
-            if b.benchmark.throughput == 0 then e""
-            else e"${b.benchmark.throughput} op/s" )
+            val tp = b.benchmark.throughput
+            if tp == 0 then e"" else e"$tp op/s" )
 
-      . tabulate(allBenches.sortBy(-_.benchmark.throughput)).grid(columns).render
+      . tabulate(benchmarks.sortBy(_.test.timestamp)).grid(columns).render
       . each(Out.println(_))
 
     val failureStatuses: Set[Status] =
@@ -549,12 +551,6 @@ class Report(using Environment)(using palette: TestPalette):
         Out.println(e"$Italic(No tests were run.)")
 
     totals(true)
-
-    def benches(line: ReportLine): Iterable[ReportLine.Bench] =
-      line match
-        case bench@ReportLine.Bench(_, _) => Iterable(bench)
-        case ReportLine.Suite(_, tests)   => tests.list.map(_(1)).flatMap(benches(_))
-        case _                            => Nil
 
     benches(lines).groupBy(_.test.suite).each: (suite, benchmarks) =>
       val ribbon =

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -220,6 +220,7 @@ class Report(using Environment)(using palette: TestPalette):
   private def terseComplete()(using Stdio): Unit =
     import tableStyles.minimal
 
+    val columns: Int = safely(Environment.columns.decode[Int]).or(120)
     val summaryLines = lines.summaries
     val totals = summaryLines.groupBy(_.status).view.mapValues(_.size).to(Map) - Status.Suite
     val passed: Int = totals.getOrElse(Status.Pass, 0) + totals.getOrElse(Status.Bench, 0)
@@ -250,13 +251,41 @@ class Report(using Environment)(using palette: TestPalette):
       val ln = frame.line.let(_.toString.tt).or(t"?")
       t"  at ${frame.method.cls}.${frame.method.method} (${frame.file}:$ln)"
 
+    def benches(line: ReportLine): Iterable[ReportLine.Bench] = line match
+      case bench@ReportLine.Bench(_, _) => Iterable(bench)
+      case ReportLine.Suite(_, tests)   => tests.list.map(_(1)).flatMap(benches(_))
+      case _                            => Nil
+
+    val allBenches = benches(lines).to(List)
+
+    if allBenches.nonEmpty then
+      Out.println(t"")
+
+      Scaffold[ReportLine.Bench]
+        ( Column(e"Hash"): b =>
+            e"${b.test.id}",
+          Column(e"Test"): b =>
+            val depth = b.test.suite.let(_.id.depth).or(0)
+            e"${t"  "*depth}${b.test.name}",
+          Column(e"n", textAlign = TextAlignment.Right): b =>
+            e"${b.benchmark.iterations.toLong}",
+          Column(e"Mean", textAlign = TextAlignment.Right): b =>
+            showTime(b.benchmark.mean.toLong),
+          Column(e"SD", textAlign = TextAlignment.Right): b =>
+            showTime(b.benchmark.sd.toLong),
+          Column(e"Throughput", textAlign = TextAlignment.Right): b =>
+            if b.benchmark.throughput == 0 then e""
+            else e"${b.benchmark.throughput} op/s" )
+
+      . tabulate(allBenches.sortBy(-_.benchmark.throughput)).grid(columns).render
+      . each(Out.println(_))
+
     val failureStatuses: Set[Status] =
       Set(Status.Fail, Status.Throws, Status.CheckThrows, Status.Mixed)
 
     val failures = summaryLines.filter(s => failureStatuses.contains(s.status))
 
     if failures.nonEmpty then
-      val columns: Int = safely(Environment.columns.decode[Int]).or(120)
       Out.println(t"")
 
       Scaffold[Summary]


### PR DESCRIPTION
Probably's terse reporter — used when running under Claude Code — previously dropped benchmark results entirely, displaying only the test summary line and any failures. This restores benchmarks as a per-suite minimal-style table, mirroring the structure of the human report.

### Benchmarks under Claude Code

When `CLAUDE_CODE` is set in the environment, `Report.complete` now renders each parent suite's benchmarks as its own compact table, prefixed by the suite name, with rows in execution order:

```
Markdown parsing throughput
  Hash     Benchmark                                          n        Mean         SD    Throughput
╶────────────────────────────────────────────────────────────────────────────────────────────────────╴
  aa0a1d   parse small (~2 KB, mixed prose)              320920    3.083 µs   0.038 µs   324263 op/s
  ebdee3   parse medium (~19 KB, real README)             17870   55.872 µs   0.592 µs    17898 op/s
  …
```

Tables use `tableStyles.minimal` for readability in terse mode and are omitted entirely when no benchmarks ran. Suites appear in the order their first benchmark started, and benchmarks within a suite appear in the order they were recorded. The summary line and failure rendering are unchanged.