### PR TITLE
exoskeleton: classify TmuxError reasons and detect missing shells

### DIFF
--- a/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
@@ -43,7 +43,7 @@ object Tmux:
     import logging.silent
 
     mitigate:
-      case ExecError(_, _, _) => TmuxError()
+      case ExecError(_, _, _) => TmuxError(TmuxError.Reason.ExecFailed)
 
     . within:
         keypresses.each:
@@ -51,16 +51,22 @@ object Tmux:
           case char: Char => sh"tmux send-keys -t ${tmux.id} '$char'".exec[Unit]()
           case _          => panic(m"unreachable case")
 
-  def screenshot()(using tmux: Tmux)(using WorkingDirectory): Screenshot = unsafely:
+  def screenshot()(using tmux: Tmux)(using WorkingDirectory): Screenshot raises TmuxError =
     import logging.silent
 
-    val content = IArray.from(sh"tmux capture-pane -pt ${tmux.id}".exec[List[Text]]())
-    val x = sh"tmux display-message -pt ${tmux.id} '#{cursor_x}'".exec[Text]().trim.decode[Int].z
-    val y = sh"tmux display-message -pt ${tmux.id} '#{cursor_y}'".exec[Text]().trim.decode[Int].z
+    mitigate:
+      case ExecError(_, _, _)   => TmuxError(TmuxError.Reason.SessionDied)
+      case NumberError(_, _, _) => TmuxError(TmuxError.Reason.SessionDied)
 
-    Screenshot(content, (tmux.width, tmux.height), (x, y))
+    . within:
+        val content = IArray.from(sh"tmux capture-pane -pt ${tmux.id}".exec[List[Text]]())
+        val x = sh"tmux display-message -pt ${tmux.id} '#{cursor_x}'".exec[Text]().trim.decode[Int].z
+        val y = sh"tmux display-message -pt ${tmux.id} '#{cursor_y}'".exec[Text]().trim.decode[Int].z
 
-  def attend(using tmux: Tmux)[result](block: => result)(using Monitor, WorkingDirectory): result =
+        Screenshot(content, (tmux.width, tmux.height), (x, y))
+
+  def attend(using tmux: Tmux)[result](block: => result)(using Monitor, WorkingDirectory)
+  :   result raises TmuxError =
     val init = screenshot().screen
 
     var count = 0
@@ -134,7 +140,19 @@ object Tmux:
     screenshot().currentLine(decorate).sub(t"> ${tool.command} ", t"")
 
 
-case class TmuxError()(using Diagnostics) extends Error(271, 0)(m"can't execute tmux")
+object TmuxError:
+  enum Reason(val number: Int):
+    case ShellNotInstalled(shell: Text) extends Reason(1)
+    case SessionDied                    extends Reason(2)
+    case ExecFailed                     extends Reason(3)
+
+  given Reason is Communicable =
+    case Reason.ShellNotInstalled(shell) => m"the shell binary `$shell` is not installed"
+    case Reason.SessionDied              => m"the tmux session terminated unexpectedly"
+    case Reason.ExecFailed               => m"could not execute tmux"
+
+case class TmuxError(reason: TmuxError.Reason)(using Diagnostics)
+extends Error(271, reason.number)(m"can't drive tmux: $reason")
 case class Tmux(id: Text, workingDirectory: WorkingDirectory, width: Int, height: Int, shell: Shell)
 extends Findable
 

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -43,8 +43,8 @@ extension (shell: Shell)
   :   result raises TmuxError logs ExecEvent =
 
     mitigate:
-      case ExecError(_, _, _) => TmuxError()
-      case NumberError(_, _, _) => TmuxError()
+      case ExecError(_, _, _)   => TmuxError(TmuxError.Reason.ExecFailed)
+      case NumberError(_, _, _) => TmuxError(TmuxError.Reason.SessionDied)
 
     . within:
         given tmux: Tmux = Tmux(Uuid().show, summon[WorkingDirectory], width, height, shell)
@@ -52,6 +52,17 @@ extension (shell: Shell)
         val path = summon[Enclave.Tool].path.parent.vouch.encode
 
         var psFile: Optional[Path on Linux] = Unset
+
+        val shellBinary = shell match
+          case Shell.Zsh        => t"zsh"
+          case Shell.Fish       => t"fish"
+          case Shell.Bash       => t"bash"
+          case Shell.Powershell => t"pwsh"
+
+        locally:
+          import logging.silent
+          if sh"which $shellBinary".exec[Exit]() != Exit.Ok
+          then abort(TmuxError(TmuxError.Reason.ShellNotInstalled(shellBinary)))
 
         val shellInvocation = shell match
           case Shell.Zsh        => t"zsh -l"

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -108,11 +108,12 @@ object Tests extends Suite(m"Exoskeleton Tests"):
         }
 
     . sandbox:
-        // Warmup runs to avoid timing issues in CI
-        Bash.tmux()(Tmux.completions(t""))
-        Zsh.tmux()(Tmux.completions(t""))
-        Fish.tmux(width = 120)(Tmux.completions(t""))
-        Powershell.tmux()(Tmux.completions(t""))
+        // Warmup runs to avoid timing issues in CI. A missing shell binary on the host
+        // should not abort the suite — individual tests will surface a `TmuxError`.
+        safely(Bash.tmux()(Tmux.completions(t"")))
+        safely(Zsh.tmux()(Tmux.completions(t"")))
+        safely(Fish.tmux(width = 120)(Tmux.completions(t"")))
+        safely(Powershell.tmux()(Tmux.completions(t"")))
 
         test(m"Test subcommands on bash"):
           Bash.tmux()(Tmux.completions(t""))


### PR DESCRIPTION
When using the Exoskeleton test rig, a missing shell binary such as `pwsh` no longer aborts the entire test suite with an opaque `NumberError` — the rig now detects the missing shell up front and raises a `TmuxError` with a descriptive reason, while still allowing tests for available shells to run.

The `Tmux` rig now reports failures with structured reasons. `TmuxError` carries a `Reason` enum:

```scala
TmuxError.Reason.ShellNotInstalled(shell: Text)
TmuxError.Reason.SessionDied
TmuxError.Reason.ExecFailed
```

When a shell binary is not on `PATH`, the rig fails immediately with `TmuxError(ShellNotInstalled(shell))` and a message like *"the shell binary `pwsh` is not installed"*. Internal tmux operations (`screenshot`, `attend`) propagate failures via the contingency mechanism rather than via `unsafely:` panics, so surrounding `mitigate` blocks can intercept them as expected.