### PR TITLE
Restore visual diffs in test reports and fix failure ribbon styling

### DIFF
--- a/lib/chiaroscuro/src/core/chiaroscuro.Juxtaposition.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Juxtaposition.scala
@@ -66,9 +66,8 @@ object Juxtaposition:
       val positive = Fg(palette.positive)
       val negative = Fg(palette.negative)
       val informative = Fg(palette.informative)
-      val dim = Bg(palette.subdued)
-      val positiveBg = Bg(palette.positive)
-      val negativeBg = Bg(palette.negative.chroma)
+      val positiveBg = Bg(palette.subdue(palette.positive, 0.5))
+      val negativeBg = Bg(palette.subdue(palette.negative, 0.5))
 
       value match
         case Juxtaposition.Collation(name, comparison, _, _) =>
@@ -93,14 +92,14 @@ object Juxtaposition:
               val last = index == comparison.length/columns
 
               val observed = comparison2.map:
-                case (_, Same(char))            => e"$dim($informative(${pad(char)}))"
+                case (_, Same(char))            => e"$informative(${pad(char)})"
                 case (_, Different(char, _, _)) => e"$positiveBg(${pad(char)})"
                 case _                          => e""
 
               . join
 
               val expected = comparison2.map:
-                case (_, Same(char))            => e"$dim($informative(${pad(char)}))"
+                case (_, Same(char))            => e"$informative(${pad(char)})"
                 case (_, Different(_, char, _)) => e"$negativeBg(${pad(char)})"
                 case _                          => e""
 

--- a/lib/escapade/src/core/escapade.Ribbon.scala
+++ b/lib/escapade/src/core/escapade.Ribbon.scala
@@ -40,14 +40,12 @@ object Ribbon:
 
 case class Ribbon(colors: Bg*):
   def fill(parts: Teletype*): Teletype =
-    import escapes.*
-
     if colors.isEmpty then parts.join(e" ") else
       val array = IArray.from(colors.zip(parts))
       array.indices.map: index =>
         val (background, text) = array(index)
 
-        val arrow = if index >= (array.length - 1) then e"$Reset${background.fg}()" else
+        val arrow = if index >= (array.length - 1) then e"${background.fg}()" else
           e"${background.fg}(${array(index + 1)(0)}())"
 
         e"$background( ${background.highContrast}($text) )$arrow"

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -81,6 +81,9 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       def background:  Color in Srgb = theme.background.in[Srgb]
       def foreground:  Color in Srgb = theme.foreground.in[Srgb]
       def subdued:     Color in Srgb = subdue(theme.foreground.in[Srgb], 0.5)
+      def unaccented:  Color in Srgb = subdued
+      def positive:    Color in Srgb = pass
+      def negative:    Color in Srgb = fail
 
     try Runner() catch case error: EnvironmentError =>
       jl.System.out.nn.println(StackTrace(error).teletype.render)

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -676,7 +676,7 @@ class Report(using Environment)(using palette: TestPalette):
         case _ => ()
 
     details.to(List).sortBy(_(0).timestamp).each: (id, info) =>
-      val ribbon = Ribbon(palette.pass, palette.subdue(palette.pass, 0.5), palette.subdue(palette.pass, 0.75))
+      val ribbon = Ribbon(palette.fail, palette.subdue(palette.fail, 0.5), palette.subdue(palette.fail, 0.75))
 
       if githubActions then GithubActions.group(t"Failure: ${id.name.text} (${id.id})")
 

--- a/lib/probably/src/core/probably_core.scala
+++ b/lib/probably/src/core/probably_core.scala
@@ -67,6 +67,9 @@ type TestPalette = Palette:
   def aspirePass: Color in Srgb
   def aspireFail: Color in Srgb
   def subdued: Color in Srgb
+  def unaccented: Color in Srgb
+  def positive: Color in Srgb
+  def negative: Color in Srgb
 
 extension [left](left: left)
   infix def === [right](right: right)(using checkable: left is Checkable against right): Boolean =


### PR DESCRIPTION
Two regressions in `probably`'s human-readable failure output, plus related contrast and rendering tweaks. The character-grid and tree-view diffs produced by `chiaroscuro` for failing equality tests had stopped appearing in test reports — instead, an inspection of the underlying `Juxtaposition.Collation` value was being printed. While restoring the diff, the per-failure ribbon that introduces it was also rendering in green (with a white trailing arrow) rather than the expected red.

### `probably`

`TestPalette` now declares `unaccented`, `positive`, and `negative` members, so it satisfies chiaroscuro's `JuxtapositionPalette` refinement and the visual diff renders again. The default `Suite` palette maps these to the existing `subdued`, `pass`, and `fail` colours.

The per-failure ribbon now uses `palette.fail` (red) instead of `palette.pass` (green) for its three background tones.

### `chiaroscuro`

The character-grid diff now subdues the `positive` and `negative` highlight backgrounds (mixed 50% with the palette background) so they read clearly under the terminal's default foreground in both light and dark themes, and "same" cells render on the terminal default background instead of a quantised stand-in.

### `escapade`

`Ribbon.fill` no longer emits a `Reset` before the last arrow. The reset was clobbering the foreground colour set for the arrow glyph, so it rendered in the terminal default foreground rather than the previous segment's background colour.