### PR TITLE
revolution: fix Semver ordering for equal and prerelease cases

### DIFF
--- a/lib/revolution/src/core/revolution.Semver.scala
+++ b/lib/revolution/src/core/revolution.Semver.scala
@@ -129,7 +129,9 @@ object Semver:
     if left.major == right.major then
       if left.minor == right.minor then
         if left.patch == right.patch then
-          right.prerelease.nil || compare(left.prerelease, right.prerelease)
+          if left.prerelease.nil then false
+          else if right.prerelease.nil then true
+          else compare(left.prerelease, right.prerelease)
         else left.patch < right.patch
       else left.minor < right.minor
     else left.major < right.major

--- a/lib/revolution/src/test/revolution_test.scala
+++ b/lib/revolution/src/test/revolution_test.scala
@@ -141,3 +141,15 @@ object Tests extends Suite(m"Revolution Tests"):
         test(m"Check that $left < $right"):
           left < right
         . assert(identity(_))
+
+      test(m"Equal versions are not less than each other"):
+        v"1.0.0" < v"1.0.0"
+      . assert(_ == false)
+
+      test(m"Equal prerelease versions are not less than each other"):
+        v"1.0.0-alpha" < v"1.0.0-alpha"
+      . assert(_ == false)
+
+      test(m"Release is not less than its prerelease"):
+        v"1.0.0" < v"1.0.0-alpha"
+      . assert(_ == false)


### PR DESCRIPTION
Fixes two bugs in `Ordering[Semver]` where major/minor/patch were equal: identical versions reported as less-than each other, and a release version reported as less-than its own prerelease. The comparison now spells out the four cases explicitly so that equal versions compare equal and release > prerelease, in line with SemVer 2.0.0 §11.

Sorting and comparing `Semver` values now matches the SemVer 2.0.0 precedence rules in two cases that previously gave wrong answers:

```scala
import soundness.*

v"1.0.0" < v"1.0.0"        // was true, now false
v"1.0.0" < v"1.0.0-alpha"  // was true, now false (a release outranks its prerelease)
```

If you were relying on `Ordering[Semver]` (directly, via `sorted`, or through a `SortedSet`/`TreeMap`), results around these cases will change.

Fixes #1061