### PR TITLE
revolution: fix Specifacation typo in manifest attributes

### DIFF
--- a/lib/revolution/src/core/revolution_core.scala
+++ b/lib/revolution/src/core/revolution_core.scala
@@ -49,5 +49,5 @@ package manifestAttributes:
   object Sealed                extends ManifestAttribute["Sealed"]()
   object SignatureVersion      extends ManifestAttribute["Signature-Version"]()
   object SpecificationTitle    extends ManifestAttribute["Specification-Title"]()
-  object SpecifacationVendor   extends ManifestAttribute["Specification-Vendor"]()
-  object SpecifacationVersion  extends ManifestAttribute["Specification-Version"]()
+  object SpecificationVendor   extends ManifestAttribute["Specification-Vendor"]()
+  object SpecificationVersion  extends ManifestAttribute["Specification-Version"]()

--- a/lib/revolution/src/core/soundness_revolution_core.scala
+++ b/lib/revolution/src/core/soundness_revolution_core.scala
@@ -42,4 +42,4 @@ package manifestAttributes:
     revolution.manifestAttributes
     . { ClassPath, ContentType, CreatedBy, ExtensionList, ExtensionName, ImplementationTitle,
         ImplementationVendor, ImplementationVersion, MainClass, ManifestVersion, Sealed,
-        SignatureVersion, SpecifacationVendor, SpecifacationVersion, SpecificationTitle }
+        SignatureVersion, SpecificationTitle, SpecificationVendor, SpecificationVersion }


### PR DESCRIPTION
Renames the misspelled `SpecifacationVendor` and `SpecifacationVersion` manifest-attribute objects to `SpecificationVendor` and `SpecificationVersion`, matching the adjacent `SpecificationTitle` and the correct type-level keys they already carried.

`revolution.manifestAttributes.SpecifacationVendor` and `SpecifacationVersion` have been renamed to `SpecificationVendor` and `SpecificationVersion`. The generated JAR manifest output is unchanged — the type-level attribute names (`"Specification-Vendor"` / `"Specification-Version"`) were always spelled correctly. Any Scala code referring to the old identifiers will need updating:

```scala
import revolution.manifestAttributes.{SpecificationVendor, SpecificationVersion}
```

Fixes #1059