### PR TITLE
denominative: fix off-by-one in Ordinal.subsequent

### DIFF
--- a/lib/denominative/src/core/denominative.internal.scala
+++ b/lib/denominative/src/core/denominative.internal.scala
@@ -62,7 +62,7 @@ object internal:
 
     inline def n0: Int = ordinal
     inline def n1: Int = ordinal + 1
-    inline def subsequent(size: Int): Interval = Interval(ordinal + 1, ordinal + size + 1)
+    inline def subsequent(size: Int): Interval = Interval(ordinal + 1, ordinal + size)
     inline def preceding(size: Int): Interval = Interval((ordinal - size).max(0), ordinal - 1)
 
 

--- a/lib/denominative/src/test/denominative_test.scala
+++ b/lib/denominative/src/test/denominative_test.scala
@@ -35,4 +35,22 @@ package denominative
 import soundness.*
 
 object Tests extends Suite(m"Denominative Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    suite(m"Interval-construction tests"):
+      test(m"subsequent yields an Interval of the requested size"):
+        Prim.subsequent(3).size
+      . assert(_ == 3)
+
+      test(m"span yields an Interval of the requested size"):
+        (Prim span 3).size
+      . assert(_ == 3)
+
+      test(m"preceding yields an Interval of the requested size"):
+        Sept.preceding(3).size
+      . assert(_ == 3)
+
+      test(m"subsequent and span agree on size"):
+        val skip = Prim.subsequent(3).size
+        val full = (Prim span 3).size
+        skip == full
+      . assert(identity(_))


### PR DESCRIPTION
`Ordinal.subsequent(size)` was producing an `Interval` of size `size + 1`, because it passed an *exclusive* end to `Interval.apply` — which already converts the inclusive end it expects into the stored exclusive form by adding one. The fix passes `ordinal + size` instead of `ordinal + size + 1`, in line with the sibling `span` and `preceding` helpers.

`Ordinal.subsequent(size)` now returns an `Interval` containing exactly `size` ordinals (previously `size + 1`):

```scala
import soundness.*

Prim.subsequent(3).size  // was 4, now 3
```

If you were relying on the old behaviour — for example, in `B64`/bitmap layouts where this leaks into bit-field widths — you'll need to pass one fewer to `subsequent` (or one more to whatever you were subtracting). In particular, `escapade`'s `Foreground` and `Background` style bit fields now occupy 24 bits each instead of 25.

Fixes #1058