### PR TITLE
gastronomy: fix Long Digestible shift range

### DIFF
--- a/lib/gastronomy/src/core/gastronomy.Digestible.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestible.scala
@@ -101,7 +101,7 @@ object Digestible extends Derivable[Digestible]:
     digestion.append((24 to 0 by -8).map(value >> _).map(_.toByte).toArray.immutable(using Unsafe))
 
   given long: Long is Digestible = (digestion, value) =>
-    digestion.append((52 to 0 by -8).map(value >> _).map(_.toByte).toArray.immutable(using Unsafe))
+    digestion.append((56 to 0 by -8).map(value >> _).map(_.toByte).toArray.immutable(using Unsafe))
 
   given double: Double is Digestible = long.contramap(jl.Double.doubleToRawLongBits(_))
   given float: Float is Digestible = int.contramap(jl.Float.floatToRawIntBits(_))

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -85,3 +85,12 @@ object Tests extends Suite(m"Gastronomy tests"):
       import alphabets.binary.standard
       IArray[Byte](1, 2, 3, 4).serialize[Binary]
     . assert(_ == t"00000001000000100000001100000100")
+
+    test(m"Long digest covers the low nibble"):
+      0L.digest[Sha2[256]].serialize[Hex] != 0xfL.digest[Sha2[256]].serialize[Hex]
+    . assert(identity(_))
+
+    test(m"Long digest covers the high nibble"):
+      0L.digest[Sha2[256]].serialize[Hex]
+      != 0xf000000000000000L.digest[Sha2[256]].serialize[Hex]
+    . assert(identity(_))


### PR DESCRIPTION
The `Long is Digestible` instance used shift range `52 to 0 by -8`, producing only 7 non-byte-aligned shifts and dropping bits 60-63 and 0-3 of the input entirely. The fix uses `56 to 0 by -8` to produce eight aligned shifts covering the full 64-bit value, matching the structure of the `Int` instance.

Digests of `Long` values are now derived from all 64 bits of the input, in eight byte-aligned slices, matching the `Int` instance. Previously, two `Long` values that differed only in bits 0-3 or 60-63 hashed to the same digest, and other bits were misaligned across byte boundaries.

```scala
import soundness.*
import alphabets.hex.upperCase

0L.digest[Sha2[256]].serialize[Hex] == 0xfL.digest[Sha2[256]].serialize[Hex]
// was true, now false
```

Existing digests of `Long` (or `Double`, which derives from `long` via `contramap`) values will change. If you have persisted them, they will need to be recomputed.

Fixes #1057