### PR TITLE
telekinesis: back Context session store with ConcurrentHashMap

### DIFF
--- a/lib/telekinesis/src/core/telekinesis.Context.scala
+++ b/lib/telekinesis/src/core/telekinesis.Context.scala
@@ -32,18 +32,17 @@
                                                                                                   */
 package telekinesis
 
-import scala.collection.mutable as scm
+import java.util.concurrent as juc
 
-import rudiments.*
 import vacuous.*
 import beneficence.*
 
 object Context:
   def apply[value](): Context[value] = new Context[value]:
-    private val store: scm.HashMap[Session, value] = scm.HashMap()
+    private val store: juc.ConcurrentHashMap[Session, value] = juc.ConcurrentHashMap()
 
-    def apply()(using session: Session): Optional[value] = store.at(session)
-    def update(value: value)(using session: Session): Unit = store(session) = value
+    def apply()(using session: Session): Optional[value] = Optional(store.get(session))
+    def update(value: value)(using session: Session): Unit = store.put(session, value)
 
 trait Context[value] extends Findable:
   def apply()(using session: Session): Optional[value]


### PR DESCRIPTION
The `Context` session store, accessed concurrently from HTTP request threads, was backed by an unsynchronised `scala.collection.mutable.HashMap`. Swaps the backing in for a `java.util.concurrent.ConcurrentHashMap` so concurrent reads and writes are safe without coarse locking.

`telekinesis.Context` now uses a `ConcurrentHashMap` internally, so reading and writing the per-session store from multiple HTTP request threads is safe. Previously it used an unsynchronised `mutable.HashMap`, which under concurrent traffic could corrupt internal chains, drop updates, raise `ConcurrentModificationException` from iteration paths, or spin in an infinite loop when a `get` overlapped a rehashing `put`. The public API of `Context` is unchanged.

Fixes #1056