### PR TITLE
profanity: fix Signal.id POSIX numbering

### DIFF
--- a/lib/profanity/src/core/profanity.TerminalEvent.scala
+++ b/lib/profanity/src/core/profanity.TerminalEvent.scala
@@ -58,7 +58,7 @@ enum Signal extends TerminalEvent:
 
   def shortName: Text = this.toString.show.upper
   def name: Text = t"SIG${this.toString.show.upper}"
-  def id: Int = if ordinal < 15 then ordinal - 1 else ordinal
+  def id: Int = if ordinal < 15 then ordinal + 1 else ordinal + 2
 
 type UnixSignal = Signal
 val UnixSignal = Signal

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -324,3 +324,23 @@ object Tests extends Suite(m"Profanity Tests"):
         edited
           ( Keypress.CharKey('h'), Keypress.CharKey('i'), Keypress.Ctrl('U'), Keypress.Enter )
       . assert(_ == t"")
+
+    suite(m"Signal POSIX numbering"):
+      test(m"SIGHUP is 1")  (Signal.Hup.id)   .assert(_ == 1)
+      test(m"SIGINT is 2")  (Signal.Int.id)   .assert(_ == 2)
+      test(m"SIGQUIT is 3") (Signal.Quit.id)  .assert(_ == 3)
+      test(m"SIGKILL is 9") (Signal.Kill.id)  .assert(_ == 9)
+      test(m"SIGTERM is 15")(Signal.Term.id)  .assert(_ == 15)
+      test(m"SIGCHLD is 17")(Signal.Chld.id)  .assert(_ == 17)
+      test(m"SIGCONT is 18")(Signal.Cont.id)  .assert(_ == 18)
+      test(m"SIGSTOP is 19")(Signal.Stop.id)  .assert(_ == 19)
+      test(m"SIGSYS is 31") (Signal.Sys.id)   .assert(_ == 31)
+
+      test(m"every signal id is positive"):
+        Signal.values.toList.map(_.id).forall(_ > 0)
+      . assert(identity(_))
+
+      test(m"signal ids are distinct"):
+        val ids = Signal.values.toList.map(_.id)
+        ids.length == ids.distinct.length
+      . assert(identity(_))


### PR DESCRIPTION
`Signal.id` was computed as `if ordinal < 15 then ordinal - 1 else ordinal`, which returned `-1` for `Hup` and was off by 2 from the POSIX number for every other entry. The enum already lists the POSIX signals in their standard order (with Linux's signal 16, `SIGSTKFLT`, omitted between `Term` and `Chld`), so `ordinal + 1` below the gap and `ordinal + 2` at and above it produces the right numbers.

`Signal.id` now returns the POSIX signal number for each entry. Previously the values were shifted: `Hup.id` returned `-1` (not even a valid signal number) and the rest of the enum was off by 2.

```scala
import soundness.*

Signal.Hup.id   // was -1, now 1
Signal.Int.id   // was 0,  now 2
Signal.Term.id  // was 13, now 15
Signal.Chld.id  // was 15, now 17
Signal.Sys.id   // was 29, now 31
```

Code that compared `Signal.id` against `ordinal` or against any literal number will need updating, but any code that handed `Signal.id` to a system call (`kill(2)`, etc.) was already broken.

Fixes #1055