### PR TITLE
hallucination: fix Raster.crop top/bottom mapping

### DIFF
--- a/lib/hallucination/src/core/hallucination.Raster.scala
+++ b/lib/hallucination/src/core/hallucination.Raster.scala
@@ -94,7 +94,7 @@ case class Raster(private[hallucination] val image: jai.BufferedImage) extends F
   def to[format: Rasterizable as rasterizable]: Raster in format = Raster[format](image)
 
   def crop(left: Int = 0, bottom: Int = 0, top: Int = 0, right: Int = 0): Raster =
-    Raster(width - left - right, height - top - bottom) { (x, y) => apply(x + left, y + bottom) }
+    Raster(width - left - right, height - top - bottom) { (x, y) => apply(x + left, y + top) }
 
   def flipX: Raster = Raster(width, height) { (x, y) => apply(width - 1 - x, y) }
   def flipY: Raster = Raster(width, height) { (x, y) => apply(x, height - 1 - y) }

--- a/lib/hallucination/src/test/hallucination_test.scala
+++ b/lib/hallucination/src/test/hallucination_test.scala
@@ -108,3 +108,22 @@ object Tests extends Suite(m"Hallucination Tests"):
       val gif = png.read[Raster in Png].to[Gif].read[Data]
       gif.read[Raster in Gif].width
     . assert(_ == 1)
+
+    // Each row carries its own y coordinate in the red channel so that crop()
+    // can be checked structurally.
+    def stripes: Raster = Raster(2, 4)((_, y) => Chroma(y*10, 0, 0))
+
+    test(m"crop(top = n) drops rows from the top"):
+      val cropped = stripes.crop(top = 2)
+      (cropped.height, cropped(0, 0).red, cropped(0, 1).red)
+    . assert(_ == (2, 20, 30))
+
+    test(m"crop(bottom = n) drops rows from the bottom"):
+      val cropped = stripes.crop(bottom = 2)
+      (cropped.height, cropped(0, 0).red, cropped(0, 1).red)
+    . assert(_ == (2, 0, 10))
+
+    test(m"crop with top and bottom keeps the middle rows"):
+      val cropped = stripes.crop(top = 1, bottom = 1)
+      (cropped.height, cropped(0, 0).red, cropped(0, 1).red)
+    . assert(_ == (2, 10, 20))


### PR DESCRIPTION
`Raster.crop` offset the source `y` coordinate by `bottom`, but in image coordinates Y=0 is the top of the image, so `crop(top = n)` was actually removing rows from the bottom and vice versa. Offset by `top` instead.

`Raster.crop(top = n, bottom = n)` now removes rows from the side they name. Previously the two were swapped, so a call like `raster.crop(top = 10)` produced a raster of the right size but with the wrong 10 rows discarded (the bottom ones).

```scala
import soundness.*

val cropped = raster.crop(top = 10)
// previously: 10 rows removed from the bottom
// now:        10 rows removed from the top
```

If you'd been compensating for the bug by swapping the two arguments, you'll need to swap them back.

Fixes #1054