### PR TITLE
hypotenuse: drop stray .toShort from Short ** Double

### DIFF
--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -278,7 +278,7 @@ extension (short: Short)
   inline def abs: Short = math.abs(short).toShort
 
   @targetName("powerShort")
-  inline infix def ** (exponent: Double): Double = math.pow(short.toDouble, exponent).toShort
+  inline infix def ** (exponent: Double): Double = math.pow(short.toDouble, exponent)
 
   @targetName("octalShort")
   inline def octal: Text = JInt.toOctalString(short).nn.tt

--- a/lib/hypotenuse/src/test/hypotenuse_test.scala
+++ b/lib/hypotenuse/src/test/hypotenuse_test.scala
@@ -108,6 +108,27 @@ object Tests extends Suite(m"Hypotenuse tests"):
       //   Iterable[Quanta[Height]](Quanta[Height](6, 11), Quanta[Height](5, 10), Quanta[Height](6, 2)).median
       // . assert(_ == Quanta[Height](6, 2))
 
+    suite(m"Power tests"):
+      test(m"Short ** beyond Short range does not truncate"):
+        (200: Short) ** 2.0
+      . assert(_ == 40000.0)
+
+      test(m"Short ** preserves fractional results"):
+        (1000: Short) ** 1.5
+      . assert(_ == math.pow(1000.0, 1.5))
+
+      test(m"Byte ** beyond Byte range does not truncate"):
+        (50: Byte) ** 2.0
+      . assert(_ == 2500.0)
+
+      test(m"Int ** preserves fractional results"):
+        2 ** 0.5
+      . assert(_ == math.sqrt(2.0))
+
+      test(m"Long ** preserves fractional results"):
+        2L ** 0.5
+      . assert(_ == math.sqrt(2.0))
+
     suite(m"Inequality tests"):
       test(m"1.2 < x < 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ < 1.4)


### PR DESCRIPTION
The `Short.**(exponent: Double): Double` overload ended in `.toShort`, so its `Double` result was truncated through `Short` (overflowing for any value outside `Short` range, and dropping any fractional part) before being auto-widened back to `Double` for the declared return type. The `Byte`, `Int`, and `Long` siblings all return `math.pow(...)` directly. Drops the stray `.toShort`.

`Short.**` now returns the full `Double` result of the power operation, matching the `Byte`, `Int`, and `Long` overloads. Previously the result was silently truncated through `Short`:

```scala
import soundness.*

(200: Short)  ** 2.0  // was -25536.0, now 40000.0
(1000: Short) ** 1.5  // was 31622.0,  now 31622.776601683792
```

If you were relying on the truncated value, you'll need to add an explicit `.toShort` at the call site.

Fixes #1042