### PR TITLE
iridescence: reinstate model-specific color methods

### DIFF
--- a/lib/iridescence/src/core/iridescence.Cielab.scala
+++ b/lib/iridescence/src/core/iridescence.Cielab.scala
@@ -32,7 +32,6 @@
                                                                                                   */
 package iridescence
 
-import hypotenuse.*
 import prepositional.*
 
 object Cielab:
@@ -51,8 +50,14 @@ object Cielab:
 case class Cielab(lightness: Double, blueYellow: Double, greenRed: Double) extends Color:
   type Form = Cielab
 
-  def delta(left: Cielab, right: Cielab): Double =
-    ( hyp(F64(right.blueYellow), F64(right.greenRed))
-      - hyp(F64(left.blueYellow), F64(left.greenRed)) )
+  def delta(that: Cielab): Double =
+    val dl = lightness - that.lightness
+    val da = greenRed - that.greenRed
+    val db = blueYellow - that.blueYellow
+    math.sqrt(dl*dl + da*da + db*db)
 
-    . double
+  def mix(that: Cielab, ratio: Double = 0.5): Cielab =
+    Cielab
+      ( lightness*(1 - ratio) + that.lightness*ratio,
+        blueYellow*(1 - ratio) + that.blueYellow*ratio,
+        greenRed*(1 - ratio) + that.greenRed*ratio )

--- a/lib/iridescence/src/core/iridescence.Hsl.scala
+++ b/lib/iridescence/src/core/iridescence.Hsl.scala
@@ -57,8 +57,11 @@ object Hsl:
 case class Hsl(hue: Double, saturation: Double, lightness: Double) extends Color:
   type Form = Hsl
 
-// case class Hsl(hue: Double, saturation: Double, lightness: Double) extends Color:
-//   def saturate: Hsv = Hsv(hue, 1, lightness)
-//   def desaturate: Hsv = Hsv(hue, 0, lightness)
-//   def rotate(degrees: Double): Hsv = Hsv(unitary(hue + degrees/360), saturation, lightness)
-//   def pure: Hsv = Hsv(hue, 1, 0)
+  def saturate: Hsl                = Hsl(hue, 1, lightness)
+  def desaturate: Hsl              = Hsl(hue, 0, lightness)
+  def rotate(degrees: Double): Hsl = Hsl(unitary(hue + degrees/360), saturation, lightness)
+  def complement: Hsl              = rotate(180)
+  def pure: Hsl                    = Hsl(hue, 1, 0.5)
+
+  def lighten(amount: Double): Hsl = Hsl(hue, saturation, lightness + (1 - lightness)*amount)
+  def darken(amount: Double): Hsl  = Hsl(hue, saturation, lightness*(1 - amount))

--- a/lib/iridescence/src/core/iridescence.Hsv.scala
+++ b/lib/iridescence/src/core/iridescence.Hsv.scala
@@ -51,10 +51,12 @@ object Hsv:
 case class Hsv(hue: Double, saturation: Double, value: Double) extends Color:
   type Form = Hsv
 
-//   def saturate: Hsv = Hsv(hue, 1, value)
-//   def desaturate: Hsv = Hsv(hue, 0, value)
-//   def rotate(degrees: Double): Hsv = Hsv(unitary(hue + degrees/360), saturation, value)
-//   def pure: Hsv = Hsv(hue, 1, 0)
-//   def tone(black: Double = 0, white: Double = 0) = shade(black).tint(white)
-//   def shade(black: Double = 0): Hsv = Hsv(hue, saturation, value*(1 - black) + (1 - value)*black)
-//   def tint(white: Double = 0): Hsv = Hsv(hue, saturation*(1 - white) + (1 - saturation)*white, value)
+  def saturate: Hsv                = Hsv(hue, 1, value)
+  def desaturate: Hsv              = Hsv(hue, 0, value)
+  def rotate(degrees: Double): Hsv = Hsv(unitary(hue + degrees/360), saturation, value)
+  def complement: Hsv              = rotate(180)
+  def pure: Hsv                    = Hsv(hue, 1, 1)
+
+  def shade(black: Double = 0): Hsv = Hsv(hue, saturation, value*(1 - black))
+  def tint(white: Double = 0): Hsv  = Hsv(hue, saturation*(1 - white), value)
+  def tone(black: Double = 0, white: Double = 0): Hsv = shade(black).tint(white)

--- a/lib/iridescence/src/core/iridescence.Srgb.scala
+++ b/lib/iridescence/src/core/iridescence.Srgb.scala
@@ -96,3 +96,9 @@ object Srgb:
 
 case class Srgb(red: Double, green: Double, blue: Double) extends Color:
   type Form = Srgb
+
+  def mix(that: Srgb, ratio: Double = 0.5): Srgb =
+    Srgb
+      ( red*(1 - ratio) + that.red*ratio,
+        green*(1 - ratio) + that.green*ratio,
+        blue*(1 - ratio) + that.blue*ratio )

--- a/lib/iridescence/src/test/iridescence_test.scala
+++ b/lib/iridescence/src/test/iridescence_test.scala
@@ -91,3 +91,95 @@ object Tests extends Suite(m"Iridescence tests"):
       test(m"Read white"):
         rgb"#ffffff"
       . assert(_ == Chroma(255, 255, 255))
+
+    suite(m"Hsl manipulation"):
+      test(m"saturate stays in Hsl"):
+        Hsl(0.5, 0.3, 0.4).saturate
+      . assert(_ == Hsl(0.5, 1.0, 0.4))
+
+      test(m"desaturate stays in Hsl"):
+        Hsl(0.5, 0.3, 0.4).desaturate
+      . assert(_ == Hsl(0.5, 0.0, 0.4))
+
+      test(m"rotate wraps around 360 degrees"):
+        Hsl(0.5, 0.3, 0.4).rotate(360).hue
+      . assert(_ == 0.5)
+
+      test(m"rotate by 180 produces the complement"):
+        Hsl(0.25, 0.3, 0.4).rotate(180).hue
+      . assert(_ == 0.75)
+
+      test(m"complement matches a 180-degree rotation"):
+        Hsl(0.25, 0.3, 0.4).complement
+      . assert(_ == Hsl(0.25, 0.3, 0.4).rotate(180))
+
+      test(m"pure has maximum saturation at mid lightness"):
+        Hsl(0.3, 0.2, 0.7).pure
+      . assert(_ == Hsl(0.3, 1.0, 0.5))
+
+      test(m"lighten moves halfway toward 1"):
+        Hsl(0.5, 0.3, 0.4).lighten(0.5).lightness
+      . assert(_ == 0.7)
+
+      test(m"darken moves halfway toward 0"):
+        Hsl(0.5, 0.3, 0.4).darken(0.5).lightness
+      . assert(_ == 0.2)
+
+    suite(m"Hsv manipulation"):
+      test(m"saturate stays in Hsv"):
+        Hsv(0.5, 0.3, 0.4).saturate
+      . assert(_ == Hsv(0.5, 1.0, 0.4))
+
+      test(m"desaturate stays in Hsv"):
+        Hsv(0.5, 0.3, 0.4).desaturate
+      . assert(_ == Hsv(0.5, 0.0, 0.4))
+
+      test(m"complement matches a 180-degree rotation"):
+        Hsv(0.25, 0.3, 0.4).complement
+      . assert(_ == Hsv(0.25, 0.3, 0.4).rotate(180))
+
+      test(m"pure has maximum saturation and value"):
+        Hsv(0.3, 0.2, 0.7).pure
+      . assert(_ == Hsv(0.3, 1.0, 1.0))
+
+      test(m"shade(0) is a no-op"):
+        Hsv(0.5, 0.3, 0.4).shade(0)
+      . assert(_ == Hsv(0.5, 0.3, 0.4))
+
+      test(m"shade(1) drives value to 0"):
+        Hsv(0.5, 0.3, 0.4).shade(1).value
+      . assert(_ == 0.0)
+
+      test(m"tint(0) is a no-op"):
+        Hsv(0.5, 0.3, 0.4).tint(0)
+      . assert(_ == Hsv(0.5, 0.3, 0.4))
+
+      test(m"tint(1) drives saturation to 0"):
+        Hsv(0.5, 0.3, 0.4).tint(1).saturation
+      . assert(_ == 0.0)
+
+    suite(m"Srgb manipulation"):
+      test(m"mix at 0 returns the receiver"):
+        Srgb(0.2, 0.4, 0.6).mix(Srgb(0.8, 0.6, 0.4), 0)
+      . assert(_ == Srgb(0.2, 0.4, 0.6))
+
+      test(m"mix at 1 returns the argument"):
+        Srgb(0.2, 0.4, 0.6).mix(Srgb(0.8, 0.6, 0.4), 1)
+      . assert(_ == Srgb(0.8, 0.6, 0.4))
+
+      test(m"mix at 0.5 averages the channels"):
+        Srgb(0.2, 0.4, 0.6).mix(Srgb(0.8, 0.6, 0.4))
+      . assert(_ == Srgb(0.5, 0.5, 0.5))
+
+    suite(m"Cielab manipulation"):
+      test(m"delta to self is zero"):
+        Cielab(50, 10, -20).delta(Cielab(50, 10, -20))
+      . assert(_ == 0.0)
+
+      test(m"delta is a 3-D Euclidean distance"):
+        Cielab(0, 0, 0).delta(Cielab(3, 4, 12))
+      . assert(_ == 13.0)
+
+      test(m"mix at 0.5 averages all axes"):
+        Cielab(0, 0, 0).mix(Cielab(40, 20, 10))
+      . assert(_ == Cielab(20, 10, 5))


### PR DESCRIPTION
A previous refactor of `iridescence`'s color types onto the `Color` trait stripped the manipulation methods off the case classes and left them as commented-out reminders, surfaced as issue #1048. Reinstates the methods on the active classes (correcting two pre-refactor formula bugs along the way) and adds a few natural analogues so each model has a reasonable working set of operations on its own axes.

`iridescence` now provides model-specific operations on the active color case classes:

```scala
import soundness.*

val red = Hsl(0.0, 1.0, 0.5)

red.saturate           // Hsl(0.0, 1.0, 0.5)
red.desaturate         // Hsl(0.0, 0.0, 0.5)
red.rotate(120)        // Hsl(1.0/3.0, 1.0, 0.5)
red.complement         // Hsl(0.5, 1.0, 0.5)
red.pure               // Hsl(0.0, 1.0, 0.5)
red.lighten(0.5)       // Hsl(0.0, 1.0, 0.75)
red.darken(0.5)        // Hsl(0.0, 1.0, 0.25)

Hsv(0.0, 0.5, 0.8).shade(0.5)   // Hsv(0.0, 0.5, 0.4)
Hsv(0.0, 0.5, 0.8).tint(0.5)    // Hsv(0.0, 0.25, 0.8)

Cielab(0, 0, 0).delta(Cielab(3, 4, 12))  // 13.0  (CIE76 ΔE)
Srgb(0.0, 0.0, 0.0).mix(Srgb(1.0, 1.0, 1.0))  // Srgb(0.5, 0.5, 0.5)
```

This previously-quoted code didn't compile (the methods were commented out). Behavioural changes worth knowing about if you're porting code from older revisions:

* The pre-refactor `Hsl.saturate` / `desaturate` / `rotate` / `pure` returned `Hsv` and constructed `Hsv(...)`, so the values landed in the wrong colour space and re-interpreted the third axis as `value` instead of `lightness`. They now return `Hsl` (#1048).
* `Hsv.shade` and `Hsv.tint` used a polynomial that didn't collapse to black or grey at the extremes; `shade(1)` and `tint(1)` now actually drive `value`/`saturation` to `0`.
* `Hsv.pure` now returns `Hsv(hue, 1, 1)` rather than `Hsv(hue, 1, 0)`, which was returning black.
* `Cielab.delta` was an instance method that took two arguments and ignored `this`, returning the difference of two arbitrary points' distances from the (a*, b*) origin. It is now `delta(that: Cielab): Double`, computing the standard CIE76 ΔE — a Euclidean distance in (L*, a*, b*) space.

Closes #1048