### PR TITLE
geodesy: fix Compass.points8 NW slot returning Southwest

### DIFF
--- a/lib/geodesy/src/core/geodesy.Compass.scala
+++ b/lib/geodesy/src/core/geodesy.Compass.scala
@@ -39,7 +39,7 @@ object Compass:
     IArray(North, East, South, West)
 
   val points8: IArray[CardinalWind | IntercardinalWind] =
-    IArray(North, Northeast, East, Southeast, South, Southwest, West, Southwest)
+    IArray(North, Northeast, East, Southeast, South, Southwest, West, Northwest)
 
   val points16: IArray[CardinalWind | IntercardinalWind | HalfWind] =
     IArray

--- a/lib/geodesy/src/test/geodesy_test.scala
+++ b/lib/geodesy/src/test/geodesy_test.scala
@@ -65,3 +65,20 @@ object Tests extends Suite(m"Geodesy tests"):
       angle.canonical.show
 
     . assert(_ == t"-5.0°")
+
+    suite(m"Compass.points8"):
+      test(m"contains eight points"):
+        Compass.points8.length
+      . assert(_ == 8)
+
+      test(m"index 7 is Northwest"):
+        Compass.points8(7)
+      . assert(_ == Northwest)
+
+      test(m"contains no duplicates"):
+        Compass.points8.toSet.size
+      . assert(_ == 8)
+
+      test(m"315 degrees maps to Northwest"):
+        Compass[8](Angle.degrees(315))
+      . assert(_ == Northwest)


### PR DESCRIPTION
`Compass.points8` listed `Southwest` twice at indices 5 and 7, so any clockwise traversal landing in the NW quadrant returned `Southwest` instead of `Northwest`. Replaces the duplicate with `Northwest`.

`Compass[8]` (and direct indexing into `Compass.points8`) now returns `Northwest` for angles in the NW quadrant. Previously it returned `Southwest`:

```scala
import soundness.*

Compass[8](Angle.degrees(315))  // was Southwest, now Northwest
Compass.points8(7)              // was Southwest, now Northwest
```

Fixes #1049