### PR TITLE
hypotenuse: mask Byte/Short before bit-pattern formatting

### DIFF
--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -244,16 +244,16 @@ extension (byte: Byte)
   inline infix def ** (exponent: Double): Double = math.pow(byte.toDouble, exponent)
 
   @targetName("octalByte")
-  inline def octal: Text = JInt.toOctalString(byte).nn.tt
+  inline def octal: Text = JInt.toOctalString(byte & 0xff).nn.tt
 
   @targetName("hexByte")
-  inline def hex: Text = JInt.toHexString(byte).nn.tt
+  inline def hex: Text = JInt.toHexString(byte & 0xff).nn.tt
 
   @targetName("base32Byte")
   inline def base32: Text = JInt.toString(byte, 32).tt
 
   @targetName("binaryByte")
-  inline def binary: Text = JInt.toBinaryString(byte).nn.tt
+  inline def binary: Text = JInt.toBinaryString(byte & 0xff).nn.tt
 
   @targetName("floorModByte")
   inline infix def %% (right: Int): Int = math.floorMod(byte, right)
@@ -281,16 +281,16 @@ extension (short: Short)
   inline infix def ** (exponent: Double): Double = math.pow(short.toDouble, exponent)
 
   @targetName("octalShort")
-  inline def octal: Text = JInt.toOctalString(short).nn.tt
+  inline def octal: Text = JInt.toOctalString(short & 0xffff).nn.tt
 
   @targetName("hexShort")
-  inline def hex: Text = JInt.toHexString(short).nn.tt
+  inline def hex: Text = JInt.toHexString(short & 0xffff).nn.tt
 
   @targetName("base32Short")
   inline def base32: Text = JInt.toString(short, 32).tt
 
   @targetName("binaryShort")
-  inline def binary: Text = JInt.toBinaryString(short).nn.tt
+  inline def binary: Text = JInt.toBinaryString(short & 0xffff).nn.tt
 
   @targetName("floorModShort")
   inline infix def %% (right: Short): Short = math.floorMod(short, right).toShort

--- a/lib/hypotenuse/src/test/hypotenuse_test.scala
+++ b/lib/hypotenuse/src/test/hypotenuse_test.scala
@@ -129,6 +129,35 @@ object Tests extends Suite(m"Hypotenuse tests"):
         2L ** 0.5
       . assert(_ == math.sqrt(2.0))
 
+    suite(m"Bit-pattern formatting"):
+      test(m"Byte.hex of -1 is two characters"):
+        (-1: Byte).hex
+      . assert(_ == t"ff")
+
+      test(m"Byte.hex of 0x80 is two characters"):
+        (0x80.toByte).hex
+      . assert(_ == t"80")
+
+      test(m"Byte.binary of -1 is eight characters"):
+        (-1: Byte).binary
+      . assert(_ == t"11111111")
+
+      test(m"Byte.octal of -1 is three characters"):
+        (-1: Byte).octal
+      . assert(_ == t"377")
+
+      test(m"Short.hex of -1 is four characters"):
+        (-1: Short).hex
+      . assert(_ == t"ffff")
+
+      test(m"Short.binary of -1 is sixteen characters"):
+        (-1: Short).binary
+      . assert(_ == t"1111111111111111")
+
+      test(m"Short.octal of -1 is six characters"):
+        (-1: Short).octal
+      . assert(_ == t"177777")
+
     suite(m"Inequality tests"):
       test(m"1.2 < x < 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ < 1.4)


### PR DESCRIPTION
`Byte.hex`/`octal`/`binary` and `Short.hex`/`octal`/`binary` passed their values straight to `JInt.toHexString`/`toOctalString`/`toBinaryString`, which take an `Int`. The implicit widening sign-extends negative values, so any `Byte` with the top bit set rendered as eight hex digits and any negative `Short` as four hex digits instead of two and four respectively. Masks each value to its natural width before formatting.

`hex`, `octal`, and `binary` on `Byte` and `Short` now produce strings whose width matches the underlying type. Previously, any value with the top bit set was sign-extended to `Int` width before formatting:

```scala
import soundness.*

(-1: Byte).hex      // was "ffffffff", now "ff"
(0x80.toByte).hex   // was "ffffff80", now "80"
(-1: Byte).binary   // was 32 ones,   now "11111111"
(-1: Byte).octal    // was "37777777377", now "377"

(-1: Short).hex     // was "ffffffff", now "ffff"
(-1: Short).binary  // was 32 ones,   now "1111111111111111"
(-1: Short).octal   // was "37777777777", now "177777"
```

`base32` is unchanged: it uses `JInt.toString(_, 32)`, a signed numeric formatter, so the conventional `-` prefix for negative values is preserved.

Fixes #1043