### PR TITLE
quantitative: invert Rankine→Kelvin factor in Temperature ± Quantity

### DIFF
--- a/lib/quantitative/src/core/quantitative.internal.scala
+++ b/lib/quantitative/src/core/quantitative.internal.scala
@@ -73,13 +73,13 @@ object internal extends protointernal:
       _ + _.value
 
     given addable2: Temperature is Addable by Quantity[Rankines[1]] to Temperature =
-      _ + _.value*9/5
+      _ + _.value*5/9
 
     given subtractable: Temperature is Subtractable by Quantity[Kelvins[1]] to Temperature =
       _ - _.value
 
     given subtractable2: Temperature is Subtractable by Quantity[Rankines[1]] to Temperature =
-      _ - _.value*9/5
+      _ - _.value*5/9
 
     given subtractable3: Temperature is Subtractable by Temperature to Quantity[Kelvins[1]] =
       (left, right) => Quantity(left.kelvin - right.kelvin)

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -377,6 +377,17 @@ object Tests extends Suite(m"Quantitative Tests"):
         Fahrenheit(100).show
       . assert(_ == t"37.8 °C")
 
+      test(m"Add a Rankine quantity to a Temperature"):
+        import temperatureScales.kelvin
+        // (9*Kelvin).in[Rankines] is 16.2 R, equivalent to 9 K
+        (zero[Temperature] + (9.0*Kelvin).in[Rankines]).show
+      . assert(_ == t"9.00 K")
+
+      test(m"Subtract a Rankine quantity from a Temperature"):
+        import temperatureScales.kelvin
+        ((zero[Temperature] + 20.0*Kelvin) - (9.0*Kelvin).in[Rankines]).show
+      . assert(_ == t"11.0 K")
+
     suite(m"Aggregation tests"):
       test(m"Total some values"):
         List(1*Second, 2*Second, 3*Second).total


### PR DESCRIPTION
The `Addable`/`Subtractable` instances for `Temperature` with `Quantity[Rankines[1]]` converted the Rankine delta into Kelvin using `*9/5`, but `Temperature` is stored in Kelvin and 1 R = 5/9 K (matching the `Ratio[Rankines[1] & Kelvins[-1], 1.8]` in `Rankines.scala`). The factor went the wrong way, so the added delta was 3.24× too large. Inverts the factor to `*5/9`.

Adding or subtracting a `Quantity[Rankines[1]]` to/from a `Temperature` now contributes the same physical temperature change as the equivalent `Quantity[Kelvins[1]]`. Previously the result was 3.24× too large:

```scala
import soundness.*, temperatureScales.kelvin

// (9 * Kelvin).in[Rankines] is 16.2 R, equivalent to 9 K
(zero[Temperature] + (9.0 * Kelvin).in[Rankines]).show
// was "29.2 K", now "9.00 K"
```

Fixes #1045