### PR TITLE
Add Dag.lineage and typed DagError failures in acyclicity

### DIFF
--- a/lib/acyclicity/src/core/acyclicity.Dag.scala
+++ b/lib/acyclicity/src/core/acyclicity.Dag.scala
@@ -35,6 +35,7 @@ package acyclicity
 import scala.collection.mutable as scm
 
 import anticipation.*
+import contingency.*
 import denominative.*
 import proscenium.*
 import rudiments.*
@@ -65,23 +66,28 @@ case class Dag[node] private[acyclicity](edgeMap: Map[node, Set[node]] = Map()):
 
   def subgraph(keep: Set[node]): Dag[node] = (keys &~ keep).fuse(this)(state.remove(next))
   def apply(key: node): Set[node] = edgeMap.getOrElse(key, Set())
-  def descendants(key: node): Dag[node] = subgraph(reachable(key))
+
+  def descendants(key: node): Dag[node] raises DagError = subgraph(reachable(key))
+  def ancestors(key: node): Dag[node] raises DagError = subgraph(invert.reachable(key))
+
+  def lineage(key: node): Dag[node] raises DagError =
+    subgraph(reachable(key) ++ invert.reachable(key))
 
   @targetName("removeKey")
   infix def - (key: node): Dag[node] = Dag(edgeMap - key)
 
   def sources: Set[node] = edgeMap.collect { case (k, v) if v.nil => k }.to(Set)
   def edges: Set[(node, node)] = edgeMap.to(Set).flatMap { (k, vs) => vs.map(k -> _) }
-  def closure: Dag[node] = Dag(keys.map { k => k -> (reachable(k) - k) }.to(Map))
-  def sorted: List[node] = sort(edgeMap, Nil).reverse
-  def hasCycle(start: node): Boolean = findCycle(start).isDefined
+  def closure: Dag[node] = Dag(keys.map { k => k -> (reach(k) - k) }.to(Map))
+  def sorted: List[node] raises DagError = sort(edgeMap, Nil).reverse
+  def hasCycle(start: node): Boolean raises DagError = findCycle(start).isDefined
 
   def remove(key: node, value: node): Dag[node] =
     Dag(edgeMap.updated(key, edgeMap.get(key).fold(Set())(_ - value)))
 
   def has(key: node): Boolean = edgeMap.contains(key)
 
-  def traversal[node2](lambda: (Set[node2], node) => node2): Map[node, node2] =
+  def traversal[node2](lambda: (Set[node2], node) => node2): Map[node, node2] raises DagError =
 
     sorted.fuse(Map[node, node2]()):
       state.updated(next, lambda(apply(next).map(state), next))
@@ -102,31 +108,49 @@ case class Dag[node] private[acyclicity](edgeMap: Map[node, Set[node]] = Map()):
 
   def reduction: Dag[node] =
     val allEdges = closure.edgeMap
-    val removals = for i <- keys; j <- edgeMap(i); k <- edgeMap(j) if allEdges(i)(k) yield (i, k)
+
+    val removals = for
+      i <- keys
+      j <- edgeMap(i)
+      k <- edgeMap.getOrElse(j, Set())
+        if allEdges(i)(k)
+    yield (i, k)
 
     Dag:
       removals.foldLeft(edgeMap):
         case (m, (k, v)) => m.updated(k, m(k) - v)
 
-  def reachable(node: node): Set[node] =
-    reachableCache.getOrElseUpdate(node, edgeMap(node).flatMap(reachable) + node)
+  def reachable(node: node): Set[node] raises DagError =
+    if !edgeMap.contains(node)
+    then abort(DagError(DagError.Reason.NodeMissing(node.toString.tt)))
+    else reach(node)
+
+  private def reach(node: node): Set[node] =
+    reachableCache.getOrElseUpdate(node, edgeMap.getOrElse(node, Set()).flatMap(reach) + node)
 
   def invert: Dag[node] = Dag:
     edgeMap.foldLeft(Map[node, Set[node]]()):
       case (acc, (k, vs)) =>
         vs.fuse(acc)(state.updated(next, state.get(next).fold(Set(k))(_ + k)))
 
-  def remove(element: node): Dag[node] = Dag:
-    (edgeMap - element).view.mapValues:
-      map => if map(element) then map ++ edgeMap(element) - element else map
+  def remove(element: node): Dag[node] =
+    val outgoing = edgeMap.getOrElse(element, Set())
 
-    . to(Map)
+    Dag:
+      (edgeMap - element).view.mapValues:
+        map => if map(element) then map ++ outgoing - element else map
 
-  private def sort(todo: Map[node, Set[node]], done: List[node]): List[node] =
+      . to(Map)
+
+  private def sort(todo: Map[node, Set[node]], done: List[node])
+  :   List[node] raises DagError =
+
     if todo.nil then done
-    else
-      val (node, _) = todo.find { (k, vs) => (vs -- done).nil }.get
-      sort((todo - node).view.mapValues(_.filter(_ != node)).to(Map), node :: done)
+    else todo.find { (k, vs) => (vs -- done).nil } match
+      case None => abort(DagError(DagError.Reason.Cyclic))
+
+      case Some((node, _)) =>
+        sort((todo - node).view.mapValues(_.filter(_ != node)).to(Map), node :: done)
 
   def filter(predicate: node => Boolean): Dag[node] =
     val deletions = keys.filter(!predicate(_))
@@ -138,7 +162,10 @@ case class Dag[node] private[acyclicity](edgeMap: Map[node, Set[node]] = Map()):
           (acc2, ref) => acc2.updated(ref, acc2(ref) - next ++ acc(next))
       } -- deletions
 
-  private def findCycle(start: node): Option[List[node]] =
+  private def findCycle(start: node): Option[List[node]] raises DagError =
+    if !edgeMap.contains(start)
+    then abort(DagError(DagError.Reason.NodeMissing(start.toString.tt)))
+
     @tailrec
     def recur(queue: List[(node, List[node])], finished: Set[node])
     :   Option[List[node]] =

--- a/lib/acyclicity/src/core/acyclicity.DagError.scala
+++ b/lib/acyclicity/src/core/acyclicity.DagError.scala
@@ -30,8 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package acyclicity
 
-export
-  acyclicity
-  . { Dag, DagError, Digraph, Dot, explore, Graph, PartiallyOrdered, Poset, Subgraph }
+import anticipation.*
+import fulminate.*
+
+object DagError:
+  enum Reason(val number: Int) extends Clarification:
+    case NodeMissing(node: Text) extends Reason(1)
+    case Cyclic                  extends Reason(2)
+
+  given communicable: Reason is Communicable =
+    case Reason.NodeMissing(node) => m"the node $node is not present in the graph"
+    case Reason.Cyclic            => m"the graph contains a cycle"
+
+case class DagError(reason: DagError.Reason)(using Diagnostics)
+extends Error(191, reason.number)(m"the DAG operation failed because $reason")

--- a/lib/dendrology/src/dag/dendrology.DagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.DagDiagram.scala
@@ -36,11 +36,12 @@ import scala.reflect.*
 
 import acyclicity.*
 import anticipation.*
+import contingency.*
 import gossamer.*
 import spectacular.*
 
 object DagDiagram:
-  def apply[node](dag: Dag[node]): DagDiagram[node] =
+  def apply[node](dag: Dag[node]): DagDiagram[node] raises DagError =
     val nodes = dag.sorted.to(Vector)
     val indexes: Map[node, Int] = nodes.zipWithIndex.to(Map)
 

--- a/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
@@ -36,6 +36,7 @@ import scala.collection.mutable as scm
 
 import acyclicity.*
 import anticipation.*
+import contingency.*
 import gossamer.*
 import spectacular.*
 import vacuous.*
@@ -73,7 +74,7 @@ object LaneDagDiagram:
         case (true,  true,  true,  true)  => Junction
         case _                            => Space
 
-  def apply[node](dag: Dag[node]): LaneDagDiagram[node] =
+  def apply[node](dag: Dag[node]): LaneDagDiagram[node] raises DagError =
     val nodes: Vector[node] = dag.sorted.to(Vector)
     val total: Int = nodes.length
 

--- a/lib/dendrology/src/dag/dendrology.LayeredDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LayeredDagDiagram.scala
@@ -36,6 +36,7 @@ import scala.collection.mutable as scm
 
 import acyclicity.*
 import anticipation.*
+import contingency.*
 import gossamer.*
 import spectacular.*
 import vacuous.*
@@ -77,7 +78,7 @@ object LayeredDagDiagram:
         case (true,  true,  true,  true)  => Junction
         case _                            => Space
 
-  def apply[node](dag: Dag[node]): LayeredDagDiagram[node] =
+  def apply[node](dag: Dag[node]): LayeredDagDiagram[node] raises DagError =
     val nodes: Vector[node] = dag.sorted.to(Vector)
     if nodes.isEmpty then LayeredDagDiagram(Nil) else
       val parents: Map[node, Set[node]] = dag.edgeMap

--- a/lib/dendrology/src/test/dendrology_test.scala
+++ b/lib/dendrology/src/test/dendrology_test.scala
@@ -34,6 +34,8 @@ package dendrology
 
 import soundness.*
 
+import strategies.throwUnsafely
+
 object Tests extends Suite(m"Dendrology tests"):
 
   case class Tree(value: Text, children: List[Tree] = Nil)


### PR DESCRIPTION
Adds a `lineage` method to `Dag` that returns the subgraph of a given node's ancestors and descendants, and replaces the unsafe failure paths in the acyclicity module with a typed `DagError`. Methods that can fail (node lookups, topological sort, traversal, cycle detection) now declare `raises DagError` and abort with `Reason.NodeMissing` or `Reason.Cyclic` instead of throwing `NoSuchElementException`. The change is also threaded through `dendrology`'s `DagDiagram`, `LaneDagDiagram`, and `LayeredDagDiagram` constructors, which now declare `raises DagError` because they call `Dag.sorted`. Fixes #1060.

### `Dag.lineage`

`Dag` gains a new method that returns the subgraph of a node's ancestors and descendants:

```scala
val dag = Dag("a" -> "b", "b" -> "c", "d" -> "b")
dag.lineage("b")  // contains a, b, c, d
```

A companion `ancestors` method is also added, for symmetry with the existing `descendants`.

### Typed failures via `DagError`

Operations that could previously fail with an opaque `NoSuchElementException` now declare `raises DagError`, with two reasons:

- `Reason.NodeMissing(node)` — the named node is not in the graph; raised by `reachable`, `descendants`, `ancestors`, `lineage`, `findCycle`, and `hasCycle`.
- `Reason.Cyclic` — the graph contains a cycle; raised by `sorted` and `traversal`.

```scala
import contingency.*, strategies.throwUnsafely
Dag("a" -> "b", "b" -> "a").sorted  // DagError(Reason.Cyclic)
```

Callers must now provide a `Tactic[DagError]` (e.g. via `mitigate`, `unhandled`, or `throwUnsafely`) for these methods. The `dendrology` diagram constructors `DagDiagram(...)`, `LaneDagDiagram(...)`, and `LayeredDagDiagram(...)` likewise propagate `raises DagError`.
