### PR TITLE
hypotenuse: fix Float/Double %% for negative divisors

### DIFF
--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -159,7 +159,8 @@ extension (float: Float)
   @targetName("floorModFloat")
   inline infix def %% (right: Float): Float =
     val remainder: Float = float%right
-    if remainder < 0.0f then remainder + right else remainder
+    if remainder != 0.0f && (remainder > 0.0f) != (right > 0.0f) then remainder + right
+    else remainder
 
 extension (double: Double)
   @targetName("mantissaDouble")
@@ -222,7 +223,8 @@ extension (double: Double)
   @targetName("floorModDouble")
   inline infix def %% (right: Double): Double =
     val remainder = double%right
-    if remainder < 0.0 then remainder + right else remainder
+    if remainder != 0.0 && (remainder > 0.0) != (right > 0.0) then remainder + right
+    else remainder
 
 extension (byte: Byte)
   @targetName("bitsByte")

--- a/lib/hypotenuse/src/test/hypotenuse_test.scala
+++ b/lib/hypotenuse/src/test/hypotenuse_test.scala
@@ -208,6 +208,47 @@ object Tests extends Suite(m"Hypotenuse tests"):
         safely(co.addS8(S8(Byte.MaxValue.bits), S8((1: Byte).bits)))
       . assert(_.absent)
 
+    suite(m"Floor-mod tests"):
+      test(m"Float %% positive divisor with positive dividend"):
+        7.0f %% 3.0f
+      . assert(_ == 1.0f)
+
+      test(m"Float %% positive divisor with negative dividend"):
+        -7.0f %% 3.0f
+      . assert(_ == 2.0f)
+
+      test(m"Float %% negative divisor with positive dividend"):
+        7.0f %% -3.0f
+      . assert(_ == -2.0f)
+
+      test(m"Float %% negative divisor with negative dividend"):
+        -7.0f %% -3.0f
+      . assert(_ == -1.0f)
+
+      test(m"Float %% with exact zero remainder"):
+        6.0f %% -3.0f
+      . assert(_ == 0.0f)
+
+      test(m"Double %% positive divisor with positive dividend"):
+        7.0 %% 3.0
+      . assert(_ == 1.0)
+
+      test(m"Double %% positive divisor with negative dividend"):
+        -7.0 %% 3.0
+      . assert(_ == 2.0)
+
+      test(m"Double %% negative divisor with positive dividend"):
+        7.0 %% -3.0
+      . assert(_ == -2.0)
+
+      test(m"Double %% negative divisor with negative dividend"):
+        -7.0 %% -3.0
+      . assert(_ == -1.0)
+
+      test(m"Double %% with exact zero remainder"):
+        6.0 %% -3.0
+      . assert(_ == 0.0)
+
     suite(m"Inequality tests"):
       test(m"1.2 < x < 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ < 1.4)


### PR DESCRIPTION
`%%` on `Float`/`Double` is intentionally the floor-mod counterpart to `%` — the `@targetName` is literally `floorModFloat`/`floorModDouble`, and the `Byte`/`Short`/`Int`/`Long` siblings delegate to `math.floorMod`. The hand-rolled adjustment for floats — `if remainder < 0 then remainder + right` — only handled positive divisors. With a negative divisor a positive truncated remainder was returned unadjusted, and a negative one had the divisor added on top, doubling the swing. Adjusts whenever the truncated remainder's sign differs from the divisor's.

`Float.%%` and `Double.%%` now compute floor-mod correctly for negative divisors. The result always shares the sign of the divisor, matching `math.floorMod` and the integer overloads:

```scala
import soundness.*

 7.0f %% -3.0f  // was  1.0f, now -2.0f
-7.0f %% -3.0f  // was -4.0f, now -1.0f
 7.0  %% -3.0   // was  1.0,  now -2.0
-7.0  %% -3.0   // was -4.0,  now -1.0
```

The positive-divisor behaviour is unchanged.

Fixes #1044