### PR TITLE
hypotenuse: detect negative overflow in addS64/addS32/addS16/addS8

### DIFF
--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -576,8 +576,9 @@ package arithmeticOptions:
         then raise(OverflowError()) yet U64(result) else U64(result)
 
       inline def addS64(left: S64, right: S64): S64 raises OverflowError =
-        val result: S64 = S64((left.long + right.long).bits)
-        if result < left || result < right then raise(OverflowError()) yet result else result
+        val sum: Long = left.long + right.long
+        if ((left.long^sum) & (right.long^sum)) < 0L
+        then raise(OverflowError()) yet S64(sum.bits) else S64(sum.bits)
 
       inline def addU32(left: U32, right: U32): U32 raises OverflowError =
         val result: B32 = (Int(left.bits) + Int(right.bits)).bits
@@ -586,8 +587,9 @@ package arithmeticOptions:
         then raise(OverflowError()) yet U32(result) else U32(result)
 
       inline def addS32(left: S32, right: S32): S32 raises OverflowError =
-        val result: S32 = S32((left.int + right.int).bits)
-        if result < left || result < right then raise(OverflowError()) yet result else result
+        val sum: Int = left.int + right.int
+        if ((left.int^sum) & (right.int^sum)) < 0
+        then raise(OverflowError()) yet S32(sum.bits) else S32(sum.bits)
 
       inline def addU16(left: U16, right: U16): U16 raises OverflowError =
         val result: B16 = (Short(left.bits) + Short(right.bits)).toShort.bits
@@ -596,8 +598,9 @@ package arithmeticOptions:
         then U16(raise(OverflowError()) yet result) else U16(result)
 
       inline def addS16(left: S16, right: S16): S16 raises OverflowError =
-        val result: S16 = S16((left.short + right.short).toShort.bits)
-        if result < left || result < right then raise(OverflowError()) yet result else result
+        val sum: Short = (left.short + right.short).toShort
+        if ((left.short^sum) & (right.short^sum)) < 0
+        then raise(OverflowError()) yet S16(sum.bits) else S16(sum.bits)
 
       inline def addU8(left: U8, right: U8): U8 raises OverflowError =
         val result: B8 = (left.short + right.short).toByte.bits
@@ -606,5 +609,6 @@ package arithmeticOptions:
         then U8(raise(OverflowError()) yet result) else U8(result)
 
       inline def addS8(left: S8, right: S8): S8 raises OverflowError =
-        val result: S8 = S8((left.short + right.short).toByte.bits)
-        if result < left || result < right then raise(OverflowError()) yet result else result
+        val sum: Byte = (left.short + right.short).toByte
+        if ((left.short^sum) & (right.short^sum)) < 0
+        then raise(OverflowError()) yet S8(sum.bits) else S8(sum.bits)

--- a/lib/hypotenuse/src/test/hypotenuse_test.scala
+++ b/lib/hypotenuse/src/test/hypotenuse_test.scala
@@ -158,6 +158,56 @@ object Tests extends Suite(m"Hypotenuse tests"):
         (-1: Short).octal
       . assert(_ == t"177777")
 
+    suite(m"Signed overflow detection"):
+      import arithmeticOptions.overflow.checked
+      val co = summon[CheckOverflow]
+
+      test(m"S64.MinValue + S64(-1) overflows"):
+        safely(co.addS64(S64(Long.MinValue.bits), S64((-1L).bits)))
+      . assert(_.absent)
+
+      test(m"S64.MinValue + S64.MinValue overflows"):
+        safely(co.addS64(S64(Long.MinValue.bits), S64(Long.MinValue.bits)))
+      . assert(_.absent)
+
+      test(m"S64.MaxValue + S64(1) overflows"):
+        safely(co.addS64(S64(Long.MaxValue.bits), S64(1L.bits)))
+      . assert(_.absent)
+
+      test(m"S64(5) + S64(3) does not overflow"):
+        import strategies.throwUnsafely
+        co.addS64(S64(5L.bits), S64(3L.bits)).long
+      . assert(_ == 8L)
+
+      test(m"S64(-5) + S64(-3) does not overflow"):
+        import strategies.throwUnsafely
+        co.addS64(S64((-5L).bits), S64((-3L).bits)).long
+      . assert(_ == -8L)
+
+      test(m"S32.MinValue + S32(-1) overflows"):
+        safely(co.addS32(S32(Int.MinValue.bits), S32((-1).bits)))
+      . assert(_.absent)
+
+      test(m"S32.MaxValue + S32(1) overflows"):
+        safely(co.addS32(S32(Int.MaxValue.bits), S32(1.bits)))
+      . assert(_.absent)
+
+      test(m"S16.MinValue + S16(-1) overflows"):
+        safely(co.addS16(S16(Short.MinValue.bits), S16((-1: Short).bits)))
+      . assert(_.absent)
+
+      test(m"S16.MaxValue + S16(1) overflows"):
+        safely(co.addS16(S16(Short.MaxValue.bits), S16((1: Short).bits)))
+      . assert(_.absent)
+
+      test(m"S8.MinValue + S8(-1) overflows"):
+        safely(co.addS8(S8(Byte.MinValue.bits), S8((-1: Byte).bits)))
+      . assert(_.absent)
+
+      test(m"S8.MaxValue + S8(1) overflows"):
+        safely(co.addS8(S8(Byte.MaxValue.bits), S8((1: Byte).bits)))
+      . assert(_.absent)
+
     suite(m"Inequality tests"):
       test(m"1.2 < x < 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ < 1.4)


### PR DESCRIPTION
The `addS*` overflow predicates used `result < left || result < right`, which only fires for two-positives-wrapping-to-negative overflow. Two-negatives-wrapping-to-positive overflow (e.g. `S64(MinValue) + S64(-1) = MaxValue`) silently slipped through, and so did `MinValue + MinValue` (which wraps to `0`). Swaps in the XOR predicate `((left ^ sum) & (right ^ sum)) < 0`, which is true iff the operands share a sign that differs from the wrapped result — exactly the signed-overflow condition. All four widths get the same shape; the unsigned siblings already use a comparable XOR check.

Checked signed addition on `S64`, `S32`, `S16`, and `S8` now correctly raises `OverflowError` for *all* overflow cases, not just two-positives-wrapping-to-negative. Specifically, negative overflow is now detected:

```scala
import soundness.*, arithmeticOptions.overflow.checked

summon[CheckOverflow].addS64(S64(Long.MinValue.bits), S64((-1L).bits))
// was silently MaxValue, now raises OverflowError
```

The same fix lands on `addS32`, `addS16`, and `addS8`. No change to no-overflow or positive-overflow behaviour.

Fixes #1041