### PR TITLE
parasite: drop dead daemon parameter from Task.apply

### DIFF
--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -43,7 +43,7 @@ import prepositional.*
 import vacuous.*
 
 object Task:
-  def apply[result](evaluate: Worker => result, daemon: Boolean, name: Optional[Text])
+  def apply[result](evaluate: Worker => result, name: Optional[Text])
     ( using monitor: Monitor, codepoint: Codepoint, codicil: Codicil )
   :   Task[result] =
 

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -84,14 +84,14 @@ def daemon(using Codepoint)(evaluate: Worker ?=> Unit)(using Monitor, Codicil): 
 def async[result](using Codepoint)(evaluate: Worker ?=> result)(using Monitor, Codicil)
 :   Task[result] =
 
-  Task(evaluate(using _), daemon = false, name = Unset)
+  Task(evaluate(using _), name = Unset)
 
 
 def task[result](using Codepoint)(name: Text)(evaluate: Worker ?=> result)
   ( using Monitor, Codicil )
 :   Task[result] =
 
-  Task(evaluate(using _), daemon = false, name = name)
+  Task(evaluate(using _), name = name)
 
 
 def relent[result]()(using Worker): Unit = monitor.relent()


### PR DESCRIPTION
`Task.apply` accepted a `daemon: Boolean` parameter that was silently ignored — the anonymous `Worker` subclass hardcoded `def daemon: Boolean = false`. The issue (#1051) suggests honouring the argument, but daemon tasks already have their own entry point: `Daemon.apply` constructs a `Worker` with `daemon = true` directly and exposes a `Daemon` trait distinct from `Task`. Neither caller of `Task.apply` (`async` and `task` in `parasite_core.scala`) ever passed `daemon = true`. So the parameter is dead: remove it, and update the two call sites.

`parasite.Task.apply` no longer takes a `daemon: Boolean` argument. The parameter was already silently ignored — every `Task` created through `Task.apply` reported `daemon = false` regardless. For daemon tasks, continue to use `Daemon.apply` (or the top-level `daemon { … }` helper), which is the dedicated path:

```scala
import soundness.*

// before
val t = Task(work, daemon = false, name = Unset)

// now
val t = Task(work, name = Unset)
```

Callers that constructed a `Task` directly will need to drop the `daemon` argument. Any code that relied on `Task(..., daemon = true, ...)` was already getting a non-daemon worker — switch to `Daemon` instead.

Closes #1051