### PR TITLE
exoskeleton: trim shell output via Path Computable in Completions.install

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
@@ -123,10 +123,12 @@ object Completions:
       case ExecError(_, _, _) => InstallError(InstallError.Reason.Environment)
 
     . within:
-        val scriptPath = sh"sh -c 'command -v ${entrypoint.script}'".exec[Text]()
+        val scriptPath: Optional[Path on Local] =
+          safely(sh"sh -c 'command -v ${entrypoint.script}'".exec[Path on Local]())
+
         val command: Text = entrypoint.script
 
-        if !force && safely(scriptPath.decode[Path on Linux]) != entrypoint.executable
+        if !force && scriptPath != entrypoint.executable
         then Installation.CommandNotOnPath(entrypoint.script)
         else
           val zsh: Installation.InstallResult =


### PR DESCRIPTION
`Completions.install` invoked ``sh -c 'command -v $script'`` and captured stdout as `Text`. `Text is Computable` does *not* trim — it returns the raw process output — so `scriptPath` was `"/path/to/script\n"`. The newline then either failed `safely(_.decode[Path on Linux])` or landed on the last `descent` component, so the equality against `entrypoint.executable` never matched and the installer always reported `CommandNotOnPath`. Capture into `Path on Local` directly, which goes through `Computable.instantiable` — the one that trims — and also matches the type of `entrypoint.executable`.

`exoskeleton.Completions.install` now correctly recognises that the entrypoint script is on the `PATH` when it is. Previously every invocation tripped the `CommandNotOnPath` branch and skipped the completions install, because the path returned by `command -v` was captured with its trailing newline intact and never matched `entrypoint.executable`.