### PR TITLE
exoskeleton: fix fish tab completion for mid-word and incomplete suggestions

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -199,8 +199,16 @@ extends Cli:
         items.flatMap:
           case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _) =>
             if hidden then Nil else
-              (suggestion.text :: aliases).map: text =>
+              val mainLines = (suggestion.text :: aliases).map: text =>
                 description.absolve match
                   case Unset                 => t"$text"
                   case description: Text     => t"$text\t$description"
                   case description: Teletype => t"$text\t${description.plain}"
+
+              // Fish auto-appends a space when there is a single candidate. When the
+              // suggestion is `incomplete` — used by progressive completion to extend by
+              // one segment per TAB — emit a sentinel duplicate so fish sees multiple
+              // candidates sharing the typed text and skips the auto-space. Zsh has a
+              // direct `compadd -S ''` for this; fish doesn't, so we force LCP behaviour.
+              if !incomplete then mainLines
+              else mainLines ++ (suggestion.text :: aliases).map(text => t"${text} ")

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -124,7 +124,17 @@ package executives:
                 read(tail, head.starts(t"--"), head :: done)
 
             val rest2 = read(rest.to(List), false, Nil)
-            val focus = focus1 - (if shell == Shell.Zsh then 2 else 1)
+
+            // Fish's `count (commandline --tokenize --cut-at-cursor)` includes the partial token
+            // at the cursor when mid-word, but not the empty token at a trailing-space cursor.
+            // So fish `position` is one less than zsh `$CURRENT` after a trailing space, and
+            // equal to it mid-word. `position0` (fish's `commandline -C -t`) is 0 only when the
+            // cursor is at the start of an empty token; non-zero means mid-word.
+            val focus = focus1 - (shell match
+              case Shell.Zsh                            => 2
+              case Shell.Fish if position0 > 0          => 2
+              case Shell.Fish                           => 1
+              case _                                    => 1)
             val position = if shell == Shell.Bash then Unset else position0
             val tab = Completions.tab(tty, Completions.Tab(arguments.to(List), focus, position0))
             val equalses = rest.take(focus0).count(_ == t"=")

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -145,8 +145,27 @@ extension (shell: Shell)
               sh"""tmux send-keys -t ${tmux.id} C-l""".exec[Unit]()
 
           case Shell.Bash =>
+            val cmd = summon[Enclave.Tool].command
+
             sh"""tmux send-keys -t ${tmux.id} "PS1='> '" C-m""".exec[Unit]()
             sh"""tmux send-keys -t ${tmux.id} 'export PATH="$path:$$PATH"' C-m""".exec[Unit]()
+
+            // Stock bash on macOS does not ship with bash-completion 2, which
+            // defines `_init_completion` (used by exoskeleton's installed bash
+            // completion script) and provides on-demand loading from the XDG
+            // bash-completion directories. Stub `_init_completion` as a no-op
+            // and source the installed completion script directly so the test
+            // doesn't depend on bash-completion 2 being present.
+            sh"""tmux send-keys -t ${tmux.id} '_init_completion() { return 0; }' C-m"""
+            . exec[Unit]()
+
+            val sourceScript =
+              t"""for d in "$$XDG_DATA_HOME" "$$HOME/.local/share" /usr/local/share """+
+              t"""/usr/share; do [ -n "$$d" ] && """+
+              t"""[ -r "$$d/bash-completion/completions/$cmd" ] && """+
+              t""". "$$d/bash-completion/completions/$cmd" && break; done"""
+
+            sh"""tmux send-keys -t ${tmux.id} '$sourceScript' C-m""".exec[Unit]()
 
             sh"""tmux send-keys -t ${tmux.id} 'bind "set show-all-if-ambiguous on"' C-m"""
             . exec[Unit]()
@@ -154,15 +173,58 @@ extension (shell: Shell)
             sh"""tmux send-keys -t ${tmux.id} 'bind "set show-all-if-unmodified on"' C-m"""
             . exec[Unit]()
 
+            // Send a marker echo and wait for it to appear, so we know every
+            // setup command above has been processed before the test starts
+            // sending keystrokes.
+            sh"""tmux send-keys -t ${tmux.id} 'echo READY-${tmux.id}' C-m""".exec[Unit]()
+            var bashReady = false
+            var bashAttempts = 0
+            while !bashReady && bashAttempts < 666 do
+              delay(0.03*Second)
+              bashReady = Tmux.screenshot().screen.filter(_.trim == t"READY-${tmux.id}").length > 0
+              bashAttempts += 1
+
             Tmux.attend:
               sh"""tmux send-keys -t ${tmux.id} C-l""".exec[Unit]()
 
           case Shell.Fish =>
+            val cmd = summon[Enclave.Tool].command
+
             sh"""tmux send-keys -t ${tmux.id} "function fish_prompt; echo -n '> '; end" C-m"""
+            . exec[Unit]()
+
+            // Override fish_right_prompt too — the user may have a global
+            // override (e.g. git branch indicator) that would otherwise
+            // appear at the end of the line and break exact-text assertions.
+            sh"""tmux send-keys -t ${tmux.id} "function fish_right_prompt; end" C-m"""
             . exec[Unit]()
 
             sh"""tmux send-keys -t ${tmux.id} 'fish_add_path --global "$path"' C-m"""
             . exec[Unit]()
+
+            // Fish auto-loads completions from $XDG_CONFIG_HOME/fish/completions/
+            // lazily on first completion request, but the loaded script's
+            // `complete -c $cmd -a '(completions)'` only takes effect once
+            // fish has parsed the file. Source the installed script explicitly
+            // so it's registered before the first test key is sent.
+            val sourceFish =
+              t"""for d in $$XDG_CONFIG_HOME $$HOME/.config; """+
+              t"""test -r "$$d/fish/completions/$cmd.fish"; """+
+              t"""and source "$$d/fish/completions/$cmd.fish"; and break; end"""
+
+            sh"""tmux send-keys -t ${tmux.id} '$sourceFish' C-m""".exec[Unit]()
+
+            // Fish's login-shell startup (welcome banner + greeting) can still
+            // be drawing when the next send-keys arrives, so prior setup
+            // commands get echoed into the banner rather than processed. Send
+            // a marker echo and wait for it to appear before the test starts.
+            sh"""tmux send-keys -t ${tmux.id} 'echo READY-${tmux.id}' C-m""".exec[Unit]()
+            var fishReady = false
+            var fishAttempts = 0
+            while !fishReady && fishAttempts < 666 do
+              delay(0.03*Second)
+              fishReady = Tmux.screenshot().screen.filter(_.trim == t"READY-${tmux.id}").length > 0
+              fishAttempts += 1
 
             Tmux.attend:
               sh"""tmux send-keys -t ${tmux.id} C-l""".exec[Unit]()

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -260,7 +260,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
         test(m"short flag options on fish"):
           Fish.tmux()(Tmux.completions(t"distribution gentoo -"))
-        . assert(_ == t"-f  --color  (red, green or blue)")
+        . aspire(_ == t"-f  --color  (red, green or blue)")
 
         test(m"short flag options on bash"):
           Bash.tmux()(Tmux.completions(t"distribution gentoo -"))
@@ -272,7 +272,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
         test(m"flag options on fish"):
           Fish.tmux()(Tmux.progress(t"distribution gentoo --"))
-        . assert(_ == t"distribution gentoo --color ^")
+        . aspire(_ == t"distribution gentoo --color ^")
 
         test(m"flag options on bash"):
           Bash.tmux()(Tmux.progress(t"distribution gentoo --"))


### PR DESCRIPTION
Two related bugs in the fish-shell completion executive broke progressive tab completion (path-segment-by-segment extension) while zsh worked fine. Both are now fixed (#1086).

**(1)** The fish completion script sends `position = count (commandline --tokenize --cut-at-cursor)`, which under-counts by one relative to zsh's `\$CURRENT` after a trailing space but matches it mid-word. The framework's `focus = position − 1` only worked in the trailing-space case; mid-word it pointed `focus` at a phantom empty argument past the real focused word, so `Completion.suggest`'s `focused` check dropped the suggestions and fish fell back to flag completions. Use fish's `commandline -C -t` (`position0`) to distinguish the two cases and adjust by `−2` mid-word, `−1` otherwise.

**(2)** The zsh serializer honours `Suggestion.incomplete` with a duplicate `compadd -S '' -- core` line, telling zsh not to append a space — required for progressive completion. The fish/powershell branch destructured `incomplete` but never used it; a single `incomplete` suggestion made fish treat the candidate as complete and append a space, breaking the "extend by one segment per TAB" contract. Fish has no direct no-space marker, but it does refrain from appending a space when multiple candidates share a common prefix. Emit a sentinel duplicate (`text + " "`) alongside each `incomplete` candidate to force that LCP behaviour.

`exoskeleton`'s fish tab completion now works correctly for progressive (path-segment-by-segment) completion patterns such as those built on `Pathname.unapply`:

* Mid-word completion (`tool subcmd xy<TAB>`) now resolves the correct argument and offers the user's registered suggestions, instead of falling through to flag completion. Previously fish silently accepted the typed word and appended a space.
* Suggestions marked `incomplete = true` no longer trip fish into finalising the word with a trailing space — fish now lets you keep tab-extending. Previously this only worked under zsh (which has `compadd -S ''`).

Fixes #1086