### PR TITLE
Streaming CBOR: Aggregable, key relabelling, length-prefixed framing

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -421,7 +421,7 @@ object bitumen extends Library:
   object test extends Tests(core)
 
 object breviloquence extends Library:
-  object core extends Component(urticose.url, panopticon.core)
+  object core extends Component(urticose.url, panopticon.core, turbulence.core)
   object test extends Tests(core, sedentary.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):
     def mvnDeps = Seq(

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -45,6 +45,7 @@ import distillate.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
+import turbulence.*
 import vacuous.*
 import wisteria.*
 
@@ -223,6 +224,9 @@ object Cbor extends Cbor2, Dynamic:
   given string: Tactic[CborError] => String is Decodable in Cbor = _.root.string
   given byteString: Tactic[CborError] => IArray[Byte] is Decodable in Cbor = _.root.byteString
   given cbor: Cbor is Decodable in Cbor = identity(_)
+
+  given aggregable: Tactic[CborError] => Cbor is Aggregable by Data =
+    bytes => Cbor.ast(bytes.read[Cbor.Ast])
 
   given unit: Tactic[CborError] => Unit is Decodable in Cbor =
     value =>

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -101,7 +101,10 @@ trait Cbor2:
 
           build: [field] =>
             context =>
-              values.get(label.s) match
+              val key: Text = compiletime.summonFrom:
+                case relabelling: CborRelabelling[derivation] => relabelling(label).or(label)
+                case _                                        => label
+              values.get(key.s) match
                 case Some(value) => context.decoded(new Cbor(value))
                 case None        => default.or(context.decoded(new Cbor(Ast(Unset))))
 
@@ -121,6 +124,10 @@ trait Cbor2:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Encodable in Cbor =
 
+      val mapping: Map[Text, Text] = compiletime.summonFrom:
+        case relabelling: CborRelabelling[derivation] => relabelling.relabelling()
+        case _                                        => Map()
+
       value =>
         val labels: scm.ArrayBuffer[Any] = scm.ArrayBuffer()
         val values: scm.ArrayBuffer[Any] = scm.ArrayBuffer()
@@ -129,7 +136,7 @@ trait Cbor2:
           field =>
             val encoded = contextual.encode(field).root
             if !encoded.unset then
-              labels += label.s
+              labels += mapping.at(label).or(label).s
               values += encoded
 
         ast(Ast.map(IArray.from(labels), IArray.from(values)))

--- a/lib/breviloquence/src/core/breviloquence.CborRelabelling.scala
+++ b/lib/breviloquence/src/core/breviloquence.CborRelabelling.scala
@@ -30,7 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package breviloquence
 
-export breviloquence.{Cbor, Cbor2, CborPrinter, CborRelabelling, DynamicCborEnabler,
-    dynamicCborAccess}
+import anticipation.*
+import vacuous.*
+
+trait CborRelabelling[+target]:
+  def relabelling(): Map[Text, Text]
+  private lazy val labels: Map[Text, Text] = relabelling()
+
+  def apply(label: Text): Optional[Text] = if labels.contains(label) then labels(label) else Unset

--- a/lib/breviloquence/src/core/breviloquence_parser.scala
+++ b/lib/breviloquence/src/core/breviloquence_parser.scala
@@ -32,7 +32,13 @@
                                                                                                   */
 package breviloquence
 
+import anticipation.*
 import contingency.*
+import prepositional.*
+import turbulence.*
 
 extension (cbor: Cbor.Ast.type)
   def parse(source: IArray[Byte]): Cbor.Ast raises CborError = CborParser.parse(source)
+
+given parserAggregable: Tactic[CborError] => Cbor.Ast is Aggregable by Data =
+  source => Cbor.Ast.parse(source.read[Data])

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -234,3 +234,23 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val bytes = CborPrinter.encode(Cbor.unseal(cbor))
         Cbor.ast(Cbor.Ast.parse(bytes)).as[Wrapper] == original
       . assert(identity)
+
+    suite(m"Aggregable"):
+      test(m"Aggregate single-chunk Stream[Data] to Cbor"):
+        val original = Point(3, 4)
+        val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
+        Stream(bytes).read[Cbor].as[Point]
+      . assert(_ == Point(3, 4))
+
+      test(m"Aggregate split-chunk Stream[Data] to Cbor"):
+        val original = Person(t"Ada", 36)
+        val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
+        val half = bytes.length/2
+        Stream(bytes.slice(0, half), bytes.slice(half, bytes.length)).read[Cbor].as[Person]
+      . assert(_ == Person(t"Ada", 36))
+
+      test(m"Aggregate single-chunk Stream[Data] to Cbor.Ast"):
+        val original = Wrapper(List(1, 2, 3), t"hi")
+        val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
+        Cbor.ast(Stream(bytes).read[Cbor.Ast]).as[Wrapper]
+      . assert(_ == Wrapper(List(1, 2, 3), t"hi"))

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -39,6 +39,11 @@ import strategies.throwUnsafely
 case class Point(x: Int, y: Int) derives CanEqual
 case class Person(name: Text, age: Int) derives CanEqual
 case class Wrapper(values: List[Int], label: Text) derives CanEqual
+case class Renamed(dataFiles: List[Long], indexFiles: List[Long]) derives CanEqual
+
+given CborRelabelling[Renamed] = () => Map(
+  t"dataFiles"  -> t"data_files",
+  t"indexFiles" -> t"index_files")
 
 enum Shape derives CanEqual:
   case Circle(radius: Double)
@@ -254,3 +259,25 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
         Cbor.ast(Stream(bytes).read[Cbor.Ast]).as[Wrapper]
       . assert(_ == Wrapper(List(1, 2, 3), t"hi"))
+
+    suite(m"Relabelling"):
+      test(m"Encode renames fields to wire keys"):
+        val cbor = Renamed(List(1L, 2L), List(3L)).cbor
+        val ast = Cbor.unseal(cbor)
+        val keys = (0 until ast.entries).map(ast.key(_).string).toSet
+        keys == Set("data_files", "index_files")
+      . assert(identity)
+
+      test(m"Decode reads wire keys back into Scala fields"):
+        val original = Renamed(List(10L, 20L, 30L), List(99L))
+        val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
+        Cbor.ast(Cbor.Ast.parse(bytes)).as[Renamed]
+      . assert(_ == Renamed(List(10L, 20L, 30L), List(99L)))
+
+      test(m"No relabelling uses original field names"):
+        val original = Wrapper(List(1, 2, 3), t"x")
+        val cbor = original.cbor
+        val ast = Cbor.unseal(cbor)
+        val keys = (0 until ast.entries).map(ast.key(_).string).toSet
+        keys == Set("values", "label")
+      . assert(identity)

--- a/lib/turbulence/src/core/turbulence_framing.scala
+++ b/lib/turbulence/src/core/turbulence_framing.scala
@@ -1,0 +1,123 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+import java.lang as jl
+
+import anticipation.*
+import contingency.*
+import hypotenuse.*
+import proscenium.*
+import rudiments.*
+import vacuous.*
+
+extension (stream: Stream[Data])
+  inline def framed[width <: U16 | U32](terminator: Optional[width] = Unset)
+    ( using Tactic[StreamError] )
+  :   Stream[Data] =
+
+    inline compiletime.erasedValue[width] match
+      case _: U16 =>
+        framingImpl(stream, 2, terminator.asInstanceOf[Optional[U16]].let(_.long).or(-1L))
+
+      case _: U32 =>
+        framingImpl(stream, 4, terminator.asInstanceOf[Optional[U32]].let(_.long).or(-1L))
+
+private[turbulence] def framingImpl
+  ( stream: Stream[Data], width: Int, terminator: Long )
+  ( using Tactic[StreamError] )
+:   Stream[Data] =
+
+  def take
+    ( n: Int, buffer: IArray[Byte], offset: Int, tail: Stream[Data], totalSoFar: Long )
+  :   (IArray[Byte], IArray[Byte], Int, Stream[Data]) =
+
+    val out = new Array[Byte](n)
+    var taken = 0
+    var buf = buffer
+    var off = offset
+    var rest = tail
+
+    while taken < n do
+      val avail = buf.length - off
+      val need = n - taken
+      if avail >= need then
+        jl.System.arraycopy(buf, off, out, taken, need)
+        off += need
+        taken = n
+      else
+        if avail > 0 then
+          jl.System.arraycopy(buf, off, out, taken, avail)
+          taken += avail
+        rest match
+          case head #:: more =>
+            buf = head
+            off = 0
+            rest = more
+
+          case _ =>
+            abort(StreamError((totalSoFar + taken).b))
+
+    (out.immutable(using Unsafe), buf, off, rest)
+
+  def decodeBE(bytes: IArray[Byte]): Long =
+    var acc = 0L
+    var index = 0
+    while index < bytes.length do
+      acc = (acc << 8) | (bytes(index) & 0xFF)
+      index += 1
+    acc
+
+  def loop(buffer: IArray[Byte], offset: Int, tail: Stream[Data], totalSoFar: Long)
+  :   Stream[Data] =
+
+    val nonEmpty: Optional[(IArray[Byte], Int, Stream[Data])] =
+      if buffer.length - offset > 0 then (buffer, offset, tail)
+      else tail match
+        case head #:: more => (head, 0, more)
+        case _             => Unset
+
+    nonEmpty.let: (buf0, off0, rest0) =>
+      val (prefix, buf1, off1, rest1) = take(width, buf0, off0, rest0, totalSoFar)
+      val length = decodeBE(prefix)
+      if length == terminator then Stream()
+      else if length < 0 || length > Int.MaxValue then
+        abort(StreamError((totalSoFar + width).b))
+      else
+        val (frame, buf2, off2, rest2) =
+          take(length.toInt, buf1, off1, rest1, totalSoFar + width)
+        frame #:: loop(buf2, off2, rest2, totalSoFar + width + length)
+
+    . or(Stream())
+
+  loop(IArray.empty[Byte], 0, stream, 0L)

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -37,6 +37,7 @@ import soundness.*
 import charEncoders.utf8, charDecoders.utf8, textSanitizers.strict
 import threading.platform
 import strategies.throwUnsafely
+import errorDiagnostics.empty
 
 import scala.collection.mutable as scm
 
@@ -445,3 +446,46 @@ object Tests extends Suite(m"Turbulence tests"):
       test(m"Roundtrip a long repetitive Deflate stream"):
         longData.compress[Deflate].decompress[Deflate]
       . assert: stream => stream === longData
+
+    suite(m"Framing"):
+      test(m"Single 4-byte-prefixed frame in one chunk"):
+        Stream(Data(0, 0, 0, 3, 10, 20, 30)).framed[U32]().map(_.to(List)).to(List)
+      . assert(_ == List(List[Byte](10, 20, 30)))
+
+      test(m"Single 2-byte-prefixed frame in one chunk"):
+        Stream(Data(0, 3, 10, 20, 30)).framed[U16]().map(_.to(List)).to(List)
+      . assert(_ == List(List[Byte](10, 20, 30)))
+
+      test(m"Multiple 4-byte-prefixed frames in one chunk"):
+        val data = Data(0, 0, 0, 2, 1, 2, 0, 0, 0, 3, 3, 4, 5)
+        Stream(data).framed[U32]().map(_.to(List)).to(List)
+      . assert(_ == List(List[Byte](1, 2), List[Byte](3, 4, 5)))
+
+      test(m"Frame split across two chunks"):
+        val s = Stream(Data(0, 0, 0, 5, 1, 2), Data(3, 4, 5))
+        s.framed[U32]().map(_.to(List)).to(List)
+      . assert(_ == List(List[Byte](1, 2, 3, 4, 5)))
+
+      test(m"Length prefix split across chunks"):
+        val s = Stream(Data(0, 0), Data(0, 3, 7, 8, 9))
+        s.framed[U32]().map(_.to(List)).to(List)
+      . assert(_ == List(List[Byte](7, 8, 9)))
+
+      test(m"Terminator ends stream cleanly"):
+        val data = Data(0, 0, 0, 2, 1, 2, 0, 0, 255.toByte, 255.toByte)
+        Stream(data).framed[U32](U32(0xFFFF.bits)).map(_.to(List)).to(List)
+      . assert(_ == List(List[Byte](1, 2)))
+
+      test(m"Truncated frame raises StreamError"):
+        capture[StreamError]:
+          Stream(Data(0, 0, 0, 5, 1, 2)).framed[U32]().to(List)
+      . assert(_ == StreamError(6L.b))
+
+      test(m"Truncated length prefix raises StreamError"):
+        capture[StreamError]:
+          Stream(Data(0, 0)).framed[U32]().to(List)
+      . assert(_ == StreamError(2L.b))
+
+      test(m"Empty stream yields empty result"):
+        Stream[Data]().framed[U32]().to(List)
+      . assert(_ == Nil)


### PR DESCRIPTION
Adds three independent improvements that make Soundness CBOR usable for streaming workloads. Breviloquence gains `Aggregable by Data` instances so byte streams can be decoded with `.read[Cbor]`, and a `CborRelabelling` typeclass for mapping Scala field names to wire-format CBOR keys. Turbulence gains a `framed` extension on `Stream[Data]` that parses length-prefixed binary frames typed by Hypotenuse's `U16`/`U32` widths.

### Breviloquence: `.read[Cbor]` for streams

`Cbor` and `Cbor.Ast` now have `Aggregable by Data` instances, so any `Stream[Data]` carrying a CBOR document can be decoded directly:

```scala
val cbor: Cbor = myStream.read[Cbor]
val value: MyCase = cbor.as[MyCase]
```

### Breviloquence: rename CBOR map keys with `CborRelabelling`

A `CborRelabelling[T]` given in scope maps Scala field names to CBOR map keys for both encode and decode, mirroring `CodlRelabelling`:

```scala
case class Envelope(dataFiles: List[Long], indexFiles: List[Long])

given CborRelabelling[Envelope] = () => Map(
  t"dataFiles"  -> t"data_files",
  t"indexFiles" -> t"index_files")
```

### Turbulence: parse length-prefixed binary streams with `framed`

A `framed[U16 | U32]` extension on `Stream[Data]` yields one frame per length prefix, buffering across chunk boundaries. An optional sentinel prefix terminates the stream:

```scala
// 32-bit big-endian prefix, end on prefix == 0x0000FFFF
val frames: Stream[Data] = bytes.framed[U32](U32(0xFFFF.bits))

frames.map(_.read[Cbor].as[Record])
```

A truncated frame (or prefix) raises `StreamError`.