### PR TITLE
exoskeleton: refix fish tab completion for mid-word value completion (#1086)

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -200,16 +200,8 @@ extends Cli:
         items.flatMap:
           case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _) =>
             if hidden then Nil else
-              val mainLines = (suggestion.text :: aliases).map: text =>
+              (suggestion.text :: aliases).map: text =>
                 description.absolve match
                   case Unset                 => t"$text"
                   case description: Text     => t"$text\t$description"
                   case description: Teletype => t"$text\t${description.plain}"
-
-              // Fish auto-appends a space when there is a single candidate. When the
-              // suggestion is `incomplete` — used by progressive completion to extend by
-              // one segment per TAB — emit a sentinel duplicate so fish sees multiple
-              // candidates sharing the typed text and skips the auto-space. Zsh has a
-              // direct `compadd -S ''` for this; fish doesn't, so we force LCP behaviour.
-              if !incomplete then mainLines
-              else mainLines ++ (suggestion.text :: aliases).map(text => t"${text} ")

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -200,8 +200,11 @@ extends Cli:
         items.flatMap:
           case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _) =>
             if hidden then Nil else
-              (suggestion.text :: aliases).map: text =>
+              val mainLines = (suggestion.text :: aliases).map: text =>
                 description.absolve match
                   case Unset                 => t"$text"
                   case description: Text     => t"$text\t$description"
                   case description: Teletype => t"$text\t${description.plain}"
+
+              if !incomplete then mainLines
+              else mainLines ++ (suggestion.text :: aliases).map(text => t"$text ")

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -124,7 +124,24 @@ package executives:
                 read(tail, head.starts(t"--"), head :: done)
 
             val rest2 = read(rest.to(List), false, Nil)
-            val focus = focus1 - (if shell == Shell.Zsh then 2 else 1)
+
+            // Fish's `count (commandline --tokenize --cut-at-cursor)` includes the
+            // partial token at the cursor when mid-word, but drops the empty token
+            // at a trailing-space cursor. `position0` (fish's `commandline -C -t`)
+            // is 0 only when the cursor is at the start of an empty token, non-zero
+            // mid-word. For mid-word completion of a *value* (not a flag prefix),
+            // we need `-2` like zsh to point `focus` at the partial. For mid-word
+            // typing of a flag prefix (`-` or `--`) we keep the original `-1` so
+            // the existing flag-completion fallback (which expects focus on the
+            // phantom past the prefix) continues to emit both long and short
+            // aliases.
+            val fishMidWordValue =
+              shell == Shell.Fish && position0 > 0
+              && rest.lastOption.exists(!_.starts(t"-"))
+
+            val focus = focus1 - (
+              if shell == Shell.Zsh || fishMidWordValue then 2 else 1
+            )
             val position = if shell == Shell.Bash then Unset else position0
             val tab = Completions.tab(tty, Completions.Tab(arguments.to(List), focus, position0))
             val equalses = rest.take(focus0).count(_ == t"=")

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -124,17 +124,7 @@ package executives:
                 read(tail, head.starts(t"--"), head :: done)
 
             val rest2 = read(rest.to(List), false, Nil)
-
-            // Fish's `count (commandline --tokenize --cut-at-cursor)` includes the partial token
-            // at the cursor when mid-word, but not the empty token at a trailing-space cursor.
-            // So fish `position` is one less than zsh `$CURRENT` after a trailing space, and
-            // equal to it mid-word. `position0` (fish's `commandline -C -t`) is 0 only when the
-            // cursor is at the start of an empty token; non-zero means mid-word.
-            val focus = focus1 - (shell match
-              case Shell.Zsh                            => 2
-              case Shell.Fish if position0 > 0          => 2
-              case Shell.Fish                           => 1
-              case _                                    => 1)
+            val focus = focus1 - (if shell == Shell.Zsh then 2 else 1)
             val position = if shell == Shell.Bash then Unset else position0
             val tab = Completions.tab(tty, Completions.Tab(arguments.to(List), focus, position0))
             val equalses = rest.take(focus0).count(_ == t"=")

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -260,7 +260,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
         test(m"short flag options on fish"):
           Fish.tmux()(Tmux.completions(t"distribution gentoo -"))
-        . aspire(_ == t"-f  --color  (red, green or blue)")
+        . assert(_ == t"-f  --color  (red, green or blue)")
 
         test(m"short flag options on bash"):
           Bash.tmux()(Tmux.completions(t"distribution gentoo -"))
@@ -272,7 +272,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
         test(m"flag options on fish"):
           Fish.tmux()(Tmux.progress(t"distribution gentoo --"))
-        . aspire(_ == t"distribution gentoo --color ^")
+        . assert(_ == t"distribution gentoo --color ^")
 
         test(m"flag options on bash"):
           Bash.tmux()(Tmux.progress(t"distribution gentoo --"))

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -64,8 +64,10 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           val RedHat = Subcommand("red hat", e"Red Hat Linux")
           val Ubuntu = Subcommand("ubuntu", e"Ubuntu")
           val Gentoo = Subcommand("gentoo", e"Gentoo Linux")
+          val Tree = Subcommand("tree", e"path-segment completion", hidden = true)
 
           class Hue(name: Text)
+          class Segment(name: Text)
 
           cli:
             arguments match
@@ -100,6 +102,15 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                     execute(Exit.Ok)
 
                   case _             => execute(Exit.Ok)
+
+              case Tree() :: _ =>
+                given Segment is Discoverable = _ => List(Suggestion(t"src/", incomplete = true))
+                given Segment is Interpretable =
+                  case argument :: Nil => Segment(argument())
+                  case _               => Segment(t"")
+
+                Flag[Segment]("at", description = t"path segment")()
+                execute(Exit.Ok)
 
               case _ =>
                 execute(Exit.Fail(1))
@@ -371,3 +382,21 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           test(m"completion with fish args returns alpha"):
             sh"$tool '{completions}' fish 1 0 /dev/null -- abcd ''".exec[Text]()
           .check(_.contains(t"alpha"))
+
+          // Regression check for #1086 part (1): mid-word completion in fish. With the
+          // buggy off-by-one focus calculation, `gentoo` is dropped from the suggestions
+          // and the executive falls back to flag-only output (which here is empty,
+          // since `distribution` has no flags). Position arguments mimic fish's
+          // `count (commandline --tokenize --cut-at-cursor)` (3 — includes partial
+          // token at cursor) and `commandline -C -t` (1 — non-zero indicates mid-word).
+          test(m"fish mid-word completion suggests focused subcommand"):
+            sh"$tool '{completions}' fish 3 1 /dev/null -- abcd distribution g".exec[Text]()
+          .aspire(_.contains(t"gentoo"))
+
+          // Regression check for #1086 part (2): `Suggestion.incomplete` on fish branch.
+          // With the bug, output contains `src/` once; with the fix, it appears twice
+          // (the second with a trailing space) to force fish's LCP no-trailing-space
+          // behaviour for progressive completion.
+          test(m"fish incomplete suggestion emits LCP duplicate"):
+            sh"$tool '{completions}' fish 3 0 /dev/null -- abcd tree --at ".exec[Text]()
+          .aspire(_.cut(t"\n").count(_.starts(t"src/")) >= 2)

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -384,19 +384,19 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           .check(_.contains(t"alpha"))
 
           // Regression check for #1086 part (1): mid-word completion in fish. With the
-          // buggy off-by-one focus calculation, `gentoo` is dropped from the suggestions
-          // and the executive falls back to flag-only output (which here is empty,
-          // since `distribution` has no flags). Position arguments mimic fish's
-          // `count (commandline --tokenize --cut-at-cursor)` (3 — includes partial
-          // token at cursor) and `commandline -C -t` (1 — non-zero indicates mid-word).
+          // buggy off-by-one focus calculation, `gentoo` was dropped from the suggestions
+          // and the executive fell back to flag-only output (which here is empty, since
+          // `distribution` has no flags). Position arguments mimic fish's
+          // `count (commandline --tokenize --cut-at-cursor)` (3 — includes partial token
+          // at cursor) and `commandline -C -t` (1 — non-zero indicates mid-word).
           test(m"fish mid-word completion suggests focused subcommand"):
             sh"$tool '{completions}' fish 3 1 /dev/null -- abcd distribution g".exec[Text]()
-          .aspire(_.contains(t"gentoo"))
+          .check(_.contains(t"gentoo"))
 
           // Regression check for #1086 part (2): `Suggestion.incomplete` on fish branch.
-          // With the bug, output contains `src/` once; with the fix, it appears twice
+          // With the bug, output contained `src/` once; with the fix, it appears twice
           // (the second with a trailing space) to force fish's LCP no-trailing-space
           // behaviour for progressive completion.
           test(m"fish incomplete suggestion emits LCP duplicate"):
             sh"$tool '{completions}' fish 3 0 /dev/null -- abcd tree --at ".exec[Text]()
-          .aspire(_.cut(t"\n").count(_.starts(t"src/")) >= 2)
+          .check(_.cut(t"\n").count(_.starts(t"src/")) >= 2)


### PR DESCRIPTION
A second attempt at fixing the fish tab-completion bugs originally reported in #1086. The first fix (`72beecb13`) regressed two existing tests and had to be reverted; this PR reverts it, adds two regression tests at the raw `'{completions}' fish` level to track the bugs, then re-lands a refined fix that resolves both bugs without breaking the rest of the suite (`61 passed, 0 failed, 0 aspire-failed`).

### Commits

1. **Revert** `72beecb13` (fish-completion fix) and `fa5ec79d4` (aspirations marker that masked the regression).
2. **Add regression tests** for both #1086 bugs at the raw executive level, plus a hidden `Tree` subcommand with a `Segment is Discoverable` returning `Suggestion(t"src/", incomplete = true)` to exercise the second bug.
3. **Re-land the fix**, refined so it only triggers in cases that actually need it.

### Part 1 — mid-word focus calculation

Fish's `count (commandline --tokenize --cut-at-cursor)` includes the partial token at the cursor when mid-word but drops the empty token at a trailing-space cursor, so the original `focus = focus1 - 1` for fish pointed `focus` at a phantom empty argument past the real partial. `Completion.suggest`'s `focused(arg)` check dropped the registered suggestions and the executive fell back to flag suggestions — typing `app sub sha` would list `--limit`/`-n` instead of `sha1`/`sha2`.

The previous attempt subtracted `-2` for *all* fish mid-word cases (`position0 > 0`), but that also covered `-`/`--` flag-prefix typing — where the existing fallback path needs focus on the phantom past the prefix so `flagSuggestions` can emit both long and short aliases. The refinement: only apply `-2` when the partial token doesn't start with `-`. Flag-prefix typing keeps the original `-1`.

### Part 2 — `Suggestion.incomplete` on the fish/PowerShell branch

The zsh branch emits a duplicate `compadd -S '' -- core` for incomplete suggestions, telling zsh not to append a trailing space and enabling progressive ("extend by one path segment per TAB") completion. The fish/PowerShell branch destructured `incomplete` but never used it, so a single incomplete candidate got finalised with a trailing space. Fix: emit a sentinel duplicate (`text + " "`) alongside each incomplete candidate to force fish's LCP no-trailing-space behaviour.

### Tests restored / added

- `short flag options on fish` and `flag options on fish` are back to `assert(...)` (no longer aspirations).
- `fish mid-word completion suggests focused subcommand` and `fish incomplete suggestion emits LCP duplicate` are new regression tests at the raw executive level, both passing on this branch and failing on the pre-fix code.

Fixes #1086.