### PR TITLE
ci: run tests locally, verify signed attestations on GitHub

### DIFF
--- a/.ci/allowed_signers
+++ b/.ci/allowed_signers
@@ -1,0 +1,12 @@
+# SSH allowed-signers file for soundness local-CI attestations.
+#
+# Format (one entry per line, OpenSSH `allowed_signers` syntax):
+#     <principal> [options] <key-type> <base64-key> [comment]
+#
+# Where <principal> is the signer's git email (matches `git config user.email`).
+# Add a line below with your existing GitHub SSH key. Example:
+#
+#     jon.pretty@propensive.com ssh-ed25519 AAAAC3Nz... soundness-ci
+#
+# This file is also consumed by .github/workflows/main.yml when verifying
+# attestations on push/PR. Adding a co-signer = a PR that adds a line here.

--- a/.ci/allowed_signers
+++ b/.ci/allowed_signers
@@ -3,10 +3,7 @@
 # Format (one entry per line, OpenSSH `allowed_signers` syntax):
 #     <principal> [options] <key-type> <base64-key> [comment]
 #
-# Where <principal> is the signer's git email (matches `git config user.email`).
-# Add a line below with your existing GitHub SSH key. Example:
-#
-#     jon.pretty@propensive.com ssh-ed25519 AAAAC3Nz... soundness-ci
-#
-# This file is also consumed by .github/workflows/main.yml when verifying
-# attestations on push/PR. Adding a co-signer = a PR that adds a line here.
+# `<principal>` is the signer's git email (must match `git config user.email`).
+# This file is also consumed by .github/workflows/main.yml during verification.
+# Adding a co-signer = a PR that adds a line here.
+jon.pretty@propensive.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDSnmYjoBstsoEdV5yh4z5Bg9XZwz/KzzA5Gk38m6LKz6ED13OnZ8dvGXnUwfoEJltUWwXhTuMTlFnT+jGyWW5kB5KN3vjkAJ6p/EQ985ieB2KhvjhdZ/XUvPbRBtMq5SWqDH1kpubjCv4hngVSABzzz3oymONV9AD1P+BuaO/t2L9iSnCv5web3dQNFwTpxiQjkBszscRQCF9bd27bhD8i9OOeNHgDgLZujsbjF7actOe4gUK/PUrRNzqEMVPTcXfEHdPuhtW6lY43YYcvgVOQ/DHd45BMkD+lGp/p5nMQPkwxtZtGTZLrGalraI144MakwmakojTvOycsirTqVixHkZZvfoQO12vBz7vIbEfntCYaLV6S3sSbwgVSutGU3c35oQro0/Bq14kYzAzBe6xz8gWiyG1JeRLqFNcicn7uKWXSYKcXtcx0F+SBhsvDF7jrCfSdiKl/Ys7mSDUuQLMnHxV/mNWLyJ8wC8YQIRCo67L8ov7tyrXv+IXKC762xcE= jon.pretty@propensive.com

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,6 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Run all tests: `make test`
 - Watch mode for development: `mill -w soundness.all`
 - Run single test: `mill module.test.run` (e.g., `mill abacist.test.run`)
+- Run the full CI test suite in Docker and sign the result: `make attest` (see "CI workflow" below)
 
 ## Code Style
 
@@ -43,10 +44,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Pull requests
 
-- Check that the tests compile and pass before opening a PR
+- Check that the tests compile and pass before opening a PR, by running `make attest` (which builds and runs the suite in Docker and signs the result).
 - Let the user approve the text before the PR is opened.
 - Open as **draft** until ready for review. Set the PR to be auto-mergeable.
-- Immediately before opening the PR, make sure the branch is based upon the current `origin/main` before opening the PR, and rebase if necessary
+- Immediately before opening the PR, make sure the branch is based upon the current `origin/main` before opening the PR, and rebase if necessary.
+- After pushing the branch, push attestation notes with `git push origin refs/notes/ci-attestation` (or use `make push` instead of plain `git push`).
 - Title is a clear one-line description of the work.
 - Body follows `.github/pull_request_template.md`: a single summary paragraph, a blank line, then Markdown release notes for users (with code examples if useful).
 - Whenever a new commit is added to a PR, re-read the PR description and update it if it no longer accurately describes the full set of commits.
+- PRs from external contributors do not have valid attestations. To merge them, pull the branch locally, run `make attest`, and merge locally with `make push`.
+
+### CI workflow
+
+This repository runs CI locally and verifies signed attestations on GitHub Actions. The slow build/test work happens in Docker on the developer's machine; the GitHub `Build` check only verifies the attestation note.
+
+- The CI input set is the Docker build context of `img/test`, controlled by `.dockerignore`. Anything inside it changes the input digest.
+- `make attest` builds and runs the test suite in `img/test`. On success, it computes the input digest, signs it with SSH (`ssh-keygen -Y sign`), and attaches a JSON envelope (in-toto Statement v1 + signature) as a git note in `refs/notes/ci-attestation` on HEAD.
+- If only files outside the input set changed (docs, `.github/`, `.claude/`, etc.), `make attest` re-uses the existing attestation rather than rebuilding.
+- `make verify-attest` is the local dry-run of what GitHub Actions does. It does not invoke Docker.
+- `make push` pushes commits and the attestation notes ref together. Plain `git push` works too but you must also `git push origin refs/notes/ci-attestation`, otherwise the `Build` check will fail with "no attestation note".
+- Required tooling locally: Docker (Desktop / Colima / dockerd), Python 3, `ssh-keygen`. The signing key defaults to `~/.ssh/id_ed25519`; override with `SOUNDNESS_CI_KEY=…`.
+- The signer's email (from `git config user.email`) must appear in `.ci/allowed_signers` with their SSH public key. Adding a co-signer = a PR that adds a line.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# soundness local-CI input set
+#
+# Everything *not* excluded here is part of the Docker build context for
+# `img/test`, which means it is also part of the CI input digest.
+# Keep this list as the single source of truth for "what counts as a CI input".
+
+# Git metadata
+.git
+.gitignore
+.gitattributes
+
+# CI / repo metadata that has no effect on test outcomes.
+# `.dockerignore` itself is *not* listed: it defines the input set, so changes
+# to it must invalidate prior attestations.
+.github
+.claude
+
+# Editor / IDE
+.bsp
+.bloop
+.metals
+.vscode
+
+# Build outputs (also in .gitignore, but exclude here for clean Docker context)
+out
+boot
+bin
+**/target
+lib/ethereal/target
+
+# Bootstrap docker image build path — not used by `mill test.assembly && make ci`.
+# But keep `img/test` itself as an input: changes to the test Dockerfile must
+# invalidate the attestation, since they change *how* tests run.
+img
+!img/test
+etc/build1
+etc/build2
+etc/build3
+etc/build4
+etc/header.txt
+etc/headers
+etc/oldbranches
+
+# Docs / samples / images (top-level and per-module)
+doc
+sample
+**/doc
+**/images
+**/*.md
+LICENSE
+
+# Per-module metadata files that aren't test inputs
+**/.gitignore
+**/.github
+
+# Test fixtures we don't track in git
+tests/JSONTestSuite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Fetch CI attestation notes
-        run: git fetch origin 'refs/notes/ci-attestation:refs/notes/ci-attestation'
+        # The notes ref may not exist on origin yet (e.g. immediately after this
+        # workflow is first introduced). Tolerate that so the verify step can
+        # produce a user-friendly "no attestation note" error instead.
+        run: git fetch origin 'refs/notes/ci-attestation:refs/notes/ci-attestation' || true
       - name: Verify local-CI attestation
         run: ./etc/ci/verify-attest.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,54 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install shells
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y bash zsh fish
-        touch ~/.zshrc
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-    - name: Install tmux
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y tmux
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin' # See 'Supported distributions' for available options
-        java-version: '23'
-    - name: Cache Coursier and Mill
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/coursier
-          ~/.cache/mill
-        key: ${{ runner.os }}-coursier-${{ hashFiles('.mill-version', 'build.mill', 'web/build.mill') }}
-        restore-keys: |
-          ${{ runner.os }}-coursier-
-    - name: Cache Cargo registry
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-${{ hashFiles('lib/ethereal/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-    - name: Setup Zig
-      uses: mlugg/setup-zig@v1
-      with:
-        version: 0.13.0
-    - name: Setup Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        targets: x86_64-pc-windows-gnu,x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,x86_64-apple-darwin,aarch64-apple-darwin
-    - name: Install cargo-zigbuild
-      uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-zigbuild
-    - name: Mill Build
-      run: ./mill --ticker false --silent test.assembly && make ci
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch CI attestation notes
+        run: git fetch origin 'refs/notes/ci-attestation:refs/notes/ci-attestation'
+      - name: Verify local-CI attestation
+        run: ./etc/ci/verify-attest.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # For pull_request events, default checkout points at the synthesised
+          # merge commit between base and head. Our attestation notes are
+          # attached to the head commit, so check that out instead. (For push
+          # events, github.sha already equals the pushed commit, so the same
+          # expression works.)
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
       - name: Fetch CI attestation notes
         # The notes ref may not exist on origin yet (e.g. immediately after this

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,16 @@ dev:
 ci:
 	java -cp out/test/assembly.dest/out.jar soundness.Tests
 
+attest:
+	./etc/ci/attest.sh
+
+verify-attest:
+	./etc/ci/verify-attest.sh
+
+push:
+	git push
+	git push origin refs/notes/ci-attestation
+
 scala/%:
 	TAG=$(word 1, $(subst :, ,$*)); \
 	JDK=$(word 2, $(subst :, ,$*)); \
@@ -48,4 +58,4 @@ matrix:
 	    $(foreach scala,3.6.1 3.6.2 3.6.3 3.6.4 3.7.0 3.7.1 3.7.1 main, \
 			    $(MAKE) bootstrap/$(scala):$(jdk);))
 
-.PHONY: publishLocal build dev ci test matrix
+.PHONY: publishLocal build dev ci test matrix attest verify-attest push

--- a/etc/ci/_lib.py
+++ b/etc/ci/_lib.py
@@ -161,17 +161,40 @@ def _ls_tree(commit: str = "HEAD") -> Iterable[tuple[str, str]]:
 
 def _batch_sha256(blob_shas: list[str]) -> list[str]:
     """Pass `blob_shas` through a single `git cat-file --batch` process and
-    return the SHA-256 of each blob's content. Order is preserved."""
+    return the SHA-256 of each blob's content. Order is preserved.
+
+    Writing all SHAs up front and then reading every response is unsafe:
+    for a tree of any real size, git's blob output (many MB) fills its
+    stdout pipe and blocks git, while the parent is still writing to git's
+    stdin (also pipe-bounded), so neither side makes progress. We feed
+    stdin from a background thread so the main thread can drain stdout
+    concurrently."""
     if not blob_shas:
         return []
+    import threading
+
     proc = subprocess.Popen(
         ["git", "cat-file", "--batch"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
     assert proc.stdin is not None and proc.stdout is not None
-    proc.stdin.write(("\n".join(blob_shas) + "\n").encode("ascii"))
-    proc.stdin.close()
+
+    write_error: list[BaseException] = []
+
+    def write_input() -> None:
+        try:
+            for sha in blob_shas:
+                proc.stdin.write((sha + "\n").encode("ascii"))
+            proc.stdin.close()
+        except BrokenPipeError:
+            pass
+        except BaseException as e:  # noqa: BLE001
+            write_error.append(e)
+
+    writer = threading.Thread(target=write_input, daemon=True)
+    writer.start()
+
     out: list[str] = []
     for _ in blob_shas:
         header = proc.stdout.readline().decode().rstrip("\n")
@@ -184,6 +207,10 @@ def _batch_sha256(blob_shas: list[str]) -> list[str]:
         # Consume the trailing newline emitted after content.
         proc.stdout.read(1)
         out.append(hashlib.sha256(content).hexdigest())
+
+    writer.join()
+    if write_error:
+        raise write_error[0]
     proc.wait()
     if proc.returncode != 0:
         raise RuntimeError(f"git cat-file exited with status {proc.returncode}")

--- a/etc/ci/_lib.py
+++ b/etc/ci/_lib.py
@@ -1,0 +1,261 @@
+"""Shared helpers for soundness local-CI attestation tooling.
+
+Two responsibilities:
+
+  1. Parse `.dockerignore` and decide which tracked files are part of the
+     CI input set, then compute a deterministic SHA-256 digest over them.
+     The algorithm is intentionally independent of `docker` so that
+     GitHub Actions can verify without a docker daemon.
+
+  2. Canonicalise the in-toto statement JSON for signing/verification.
+
+This module is imported by the bash entry points in the same directory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+# ---- .dockerignore parsing ----------------------------------------------------
+
+def _parse_dockerignore(path: Path) -> list[tuple[bool, str]]:
+    if not path.exists():
+        return []
+    out: list[tuple[bool, str]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        negate = line.startswith("!")
+        if negate:
+            line = line[1:].lstrip()
+        if line.startswith("./"):
+            line = line[2:]
+        elif line.startswith("/"):
+            line = line[1:]
+        # Strip trailing slash (docker treats `foo/` like `foo` for our purposes:
+        # both exclude the directory and everything underneath).
+        if line.endswith("/"):
+            line = line[:-1]
+        if not line:
+            continue
+        out.append((negate, line))
+    return out
+
+
+def _pattern_to_regex(pat: str) -> re.Pattern[str]:
+    r"""Translate a docker-style ignore pattern to a regex matching the full path.
+
+    Supported:
+      *      matches any sequence of non-slash characters
+      ?      matches a single non-slash character
+      **/    matches zero or more leading directory components (".*/")
+      /**    matches zero or more trailing path components
+      **     in other positions matches any sequence including slashes
+      All other characters are literal.
+    """
+    chars: list[str] = ["^"]
+    i = 0
+    n = len(pat)
+    while i < n:
+        # Three-char lookahead for `**/`
+        if pat[i:i + 3] == "**/":
+            chars.append("(?:.*/)?")
+            i += 3
+            continue
+        # Two-char lookahead for `/**`
+        if pat[i:i + 3] == "/**" and (i + 3 == n or pat[i + 3] == "/"):
+            # `foo/**` matches `foo`, `foo/x`, `foo/x/y` …
+            chars.append("(?:/.*)?")
+            i += 3
+            continue
+        if pat[i:i + 2] == "**":
+            chars.append(".*")
+            i += 2
+            continue
+        c = pat[i]
+        if c == "*":
+            chars.append("[^/]*")
+            i += 1
+        elif c == "?":
+            chars.append("[^/]")
+            i += 1
+        else:
+            chars.append(re.escape(c))
+            i += 1
+    chars.append("$")
+    return re.compile("".join(chars))
+
+
+def _matches(path: str, regex: re.Pattern[str]) -> bool:
+    """A pattern matches `path` if it matches the path itself or any ancestor
+    directory of it (so excluding a directory excludes its contents)."""
+    if regex.match(path):
+        return True
+    parts = path.split("/")
+    for i in range(1, len(parts)):
+        if regex.match("/".join(parts[:i])):
+            return True
+    return False
+
+
+def is_excluded(path: str, patterns: list[tuple[bool, str]]) -> bool:
+    excluded = False
+    for negate, pat in patterns:
+        regex = _pattern_to_regex(pat)
+        if _matches(path, regex):
+            excluded = not negate
+    return excluded
+
+
+# ---- git plumbing -------------------------------------------------------------
+
+def _load_dockerignore(root: Path, commit: str) -> list[tuple[bool, str]]:
+    """Read `.dockerignore` from `commit` (preferred) or fall back to the
+    working tree if the file is not yet tracked there. The latter is needed
+    only when bootstrapping — once `.dockerignore` is committed, every digest
+    computation is a pure function of the commit."""
+    try:
+        data = subprocess.check_output(
+            ["git", "show", f"{commit}:.dockerignore"],
+            stderr=subprocess.DEVNULL,
+        )
+        tmp = root / ".soundness-ci-dockerignore.tmp"
+        tmp.write_bytes(data)
+        patterns = _parse_dockerignore(tmp)
+        tmp.unlink()
+        return patterns
+    except subprocess.CalledProcessError:
+        fallback = root / ".dockerignore"
+        if fallback.exists():
+            return _parse_dockerignore(fallback)
+        return []
+
+
+def _repo_root() -> Path:
+    return Path(
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode().strip()
+    )
+
+
+def _ls_tree(commit: str = "HEAD") -> Iterable[tuple[str, str]]:
+    """Yield (blob_sha, path) for every tracked file at `commit`. NUL-separated
+    so paths with spaces or special chars are safe."""
+    raw = subprocess.check_output(["git", "ls-tree", "-r", "-z", commit])
+    for entry in raw.split(b"\0"):
+        if not entry:
+            continue
+        header, path_bytes = entry.split(b"\t", 1)
+        mode, type_, sha = header.split(b" ")
+        if type_ != b"blob":
+            continue
+        yield sha.decode("ascii"), path_bytes.decode("utf-8")
+
+
+def _batch_sha256(blob_shas: list[str]) -> list[str]:
+    """Pass `blob_shas` through a single `git cat-file --batch` process and
+    return the SHA-256 of each blob's content. Order is preserved."""
+    if not blob_shas:
+        return []
+    proc = subprocess.Popen(
+        ["git", "cat-file", "--batch"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdin is not None and proc.stdout is not None
+    proc.stdin.write(("\n".join(blob_shas) + "\n").encode("ascii"))
+    proc.stdin.close()
+    out: list[str] = []
+    for _ in blob_shas:
+        header = proc.stdout.readline().decode().rstrip("\n")
+        # Format: "<sha> <type> <size>" — type must be "blob".
+        parts = header.split()
+        if len(parts) != 3 or parts[1] != "blob":
+            raise RuntimeError(f"unexpected git cat-file output: {header!r}")
+        size = int(parts[2])
+        content = proc.stdout.read(size)
+        # Consume the trailing newline emitted after content.
+        proc.stdout.read(1)
+        out.append(hashlib.sha256(content).hexdigest())
+    proc.wait()
+    if proc.returncode != 0:
+        raise RuntimeError(f"git cat-file exited with status {proc.returncode}")
+    return out
+
+
+# ---- public API ---------------------------------------------------------------
+
+def compute_input_digest(commit: str = "HEAD") -> str:
+    """Return a hex SHA-256 over the CI input set at `commit`.
+
+    Algorithm:
+      1. `git ls-tree -r <commit>` → tracked paths + blob SHAs.
+      2. Filter through `.dockerignore` (loaded from `<commit>` *not* working tree).
+      3. Sort surviving paths lexicographically (LC_ALL=C / Python default).
+      4. For each, emit "<sha256-of-blob-content>  <path>\\n" (two-space separator).
+      5. SHA-256 the concatenation. Return hex.
+    """
+    root = _repo_root()
+    patterns = _load_dockerignore(root, commit)
+
+    entries: list[tuple[str, str]] = []  # (path, blob_sha)
+    for blob_sha, path in _ls_tree(commit):
+        if is_excluded(path, patterns):
+            continue
+        entries.append((path, blob_sha))
+    entries.sort(key=lambda x: x[0])
+
+    content_shas = _batch_sha256([blob_sha for _, blob_sha in entries])
+    h = hashlib.sha256()
+    for (path, _), content_sha in zip(entries, content_shas):
+        h.update(f"{content_sha}  {path}\n".encode("utf-8"))
+    return h.hexdigest()
+
+
+def canonical_json(obj) -> bytes:
+    """Stable JSON encoding for signing/verification.
+
+    Sorted keys, no insignificant whitespace, UTF-8, ensure_ascii=False so the
+    encoding is well-defined for non-ASCII content."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+# ---- CLI dispatch (used by bash wrappers) -------------------------------------
+
+def _cli() -> int:
+    if len(sys.argv) < 2:
+        print("usage: _lib.py {input-digest|canonicalize}", file=sys.stderr)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "input-digest":
+        commit = sys.argv[2] if len(sys.argv) > 2 else "HEAD"
+        print(compute_input_digest(commit))
+        return 0
+    if cmd == "canonicalize":
+        obj = json.load(sys.stdin)
+        sys.stdout.buffer.write(canonical_json(obj))
+        return 0
+    if cmd == "list-inputs":
+        # Diagnostic: print the surviving input paths (for tuning .dockerignore).
+        commit = sys.argv[2] if len(sys.argv) > 2 else "HEAD"
+        root = _repo_root()
+        patterns = _load_dockerignore(root, commit)
+        for _, path in _ls_tree(commit):
+            if not is_excluded(path, patterns):
+                print(path)
+        return 0
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -22,16 +22,27 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 NOTES_REF="refs/notes/ci-attestation"
-KEY="${SOUNDNESS_CI_KEY:-$HOME/.ssh/id_ed25519}"
 HEAD_SHA=$(git rev-parse HEAD)
 SIGNER=$(git config user.email)
+
+# Pick a signing key: $SOUNDNESS_CI_KEY if set, otherwise the first existing
+# default (ed25519 preferred, then rsa).
+if [[ -n "${SOUNDNESS_CI_KEY:-}" ]]; then
+  KEY="$SOUNDNESS_CI_KEY"
+elif [[ -f "$HOME/.ssh/id_ed25519" ]]; then
+  KEY="$HOME/.ssh/id_ed25519"
+elif [[ -f "$HOME/.ssh/id_rsa" ]]; then
+  KEY="$HOME/.ssh/id_rsa"
+else
+  KEY=""
+fi
 
 if [[ -z "$SIGNER" ]]; then
   echo "fatal: git config user.email is empty" >&2
   exit 1
 fi
-if [[ ! -f "$KEY" ]]; then
-  echo "fatal: signing key not found at $KEY (set SOUNDNESS_CI_KEY)" >&2
+if [[ -z "$KEY" || ! -f "$KEY" ]]; then
+  echo "fatal: no signing key found (tried \$SOUNDNESS_CI_KEY, ~/.ssh/id_ed25519, ~/.ssh/id_rsa)" >&2
   exit 1
 fi
 if ! grep -q "^$SIGNER " .ci/allowed_signers 2>/dev/null; then

--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -85,10 +85,25 @@ for ancestor in $(git log --format='%H' -n 50 HEAD --skip=1 2>/dev/null); do
   fi
 done
 
-# Slow path: run the test suite in Docker.
+# Slow path: run the test suite in Docker. Tee the BuildKit output to a log
+# file because Docker's UI truncates long step output, which makes diagnosing
+# real test failures painful.
 if [[ "${SOUNDNESS_CI_SKIP_DOCKER:-0}" != "1" ]]; then
-  echo "Running test suite in Docker (img/test)..." >&2
-  DOCKER_BUILDKIT=1 docker build -f img/test --progress=plain .
+  mkdir -p out
+  LOG="out/attest-$(date -u +%Y%m%dT%H%M%SZ).log"
+  echo "Running test suite in Docker (img/test); full output → $LOG" >&2
+  set +e
+  DOCKER_BUILDKIT=1 docker build -f img/test --progress=plain . 2>&1 | tee "$LOG"
+  rc=${PIPESTATUS[0]}
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    echo >&2
+    echo "docker build exited with $rc. Full log at $LOG" >&2
+    echo "Last 80 lines of the log:" >&2
+    echo "----" >&2
+    tail -n 80 "$LOG" >&2
+    exit $rc
+  fi
 fi
 
 # Build the in-toto statement and sign it.

--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Run the test suite in Docker. On success, sign an attestation over the
+# CI input digest and attach it as a git note on HEAD.
+#
+# Environment:
+#   SOUNDNESS_CI_KEY  path to the private SSH key used for signing
+#                     (default: ~/.ssh/id_ed25519)
+#   SOUNDNESS_CI_SKIP_DOCKER=1
+#                     skip the docker build step (use only when you know
+#                     the inputs are unchanged from an existing attestation)
+#
+# Exit codes:
+#   0  attestation written to refs/notes/ci-attestation for HEAD
+#   1  tests failed, prerequisites missing, or signing error
+#
+# After success, run `make push` (or `git push && git push origin
+# refs/notes/ci-attestation`) to publish the attestation alongside commits.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+NOTES_REF="refs/notes/ci-attestation"
+KEY="${SOUNDNESS_CI_KEY:-$HOME/.ssh/id_ed25519}"
+HEAD_SHA=$(git rev-parse HEAD)
+SIGNER=$(git config user.email)
+
+if [[ -z "$SIGNER" ]]; then
+  echo "fatal: git config user.email is empty" >&2
+  exit 1
+fi
+if [[ ! -f "$KEY" ]]; then
+  echo "fatal: signing key not found at $KEY (set SOUNDNESS_CI_KEY)" >&2
+  exit 1
+fi
+if ! grep -q "^$SIGNER " .ci/allowed_signers 2>/dev/null; then
+  echo "fatal: $SIGNER is not listed in .ci/allowed_signers" >&2
+  exit 1
+fi
+
+DIGEST=$(etc/ci/compute-input-digest.sh)
+echo "input digest: $DIGEST" >&2
+echo "commit:       $HEAD_SHA" >&2
+echo "signer:       $SIGNER" >&2
+
+# Fast path 1: HEAD already has a valid attestation for this digest.
+if git notes --ref="$NOTES_REF" show HEAD >/dev/null 2>&1; then
+  EXISTING_DIGEST=$(git notes --ref="$NOTES_REF" show HEAD \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["statement"]["subject"][0]["digest"]["sha256"])' \
+    2>/dev/null || true)
+  if [[ "$EXISTING_DIGEST" == "$DIGEST" ]]; then
+    if etc/ci/verify-attest.sh >/dev/null 2>&1; then
+      echo "HEAD already has a valid attestation for this input digest." >&2
+      exit 0
+    fi
+  fi
+fi
+
+# Fast path 2: a recent ancestor has an attestation with the same digest
+# (i.e. only docs/CI-metadata changed). Re-use the existing signed note.
+for ancestor in $(git log --format='%H' -n 50 HEAD --skip=1 2>/dev/null); do
+  if ! git notes --ref="$NOTES_REF" show "$ancestor" >/dev/null 2>&1; then
+    continue
+  fi
+  NOTE=$(git notes --ref="$NOTES_REF" show "$ancestor")
+  AD=$(echo "$NOTE" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["statement"]["subject"][0]["digest"]["sha256"])' \
+    2>/dev/null || true)
+  if [[ "$AD" == "$DIGEST" ]]; then
+    echo "$NOTE" | git notes --ref="$NOTES_REF" add -f -F - HEAD
+    echo "Re-used attestation from $ancestor (input digest unchanged)." >&2
+    exit 0
+  fi
+done
+
+# Slow path: run the test suite in Docker.
+if [[ "${SOUNDNESS_CI_SKIP_DOCKER:-0}" != "1" ]]; then
+  echo "Running test suite in Docker (img/test)..." >&2
+  DOCKER_BUILDKIT=1 docker build -f img/test --progress=plain .
+fi
+
+# Build the in-toto statement and sign it.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+STMT="$TMP/statement.json"
+ENV_FILE="$TMP/envelope.json"
+
+python3 - "$DIGEST" "$SIGNER" "$HEAD_SHA" > "$STMT" <<'PY'
+import datetime, json, sys
+digest, signer, commit = sys.argv[1], sys.argv[2], sys.argv[3]
+mill_version = open(".mill-version").read().strip()
+now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+statement = {
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [{"name": "soundness-ci-inputs", "digest": {"sha256": digest}}],
+    "predicateType": "https://soundness.dev/local-ci/v1",
+    "predicate": {
+        "commands": [
+            "./mill --ticker false --silent test.assembly",
+            "make ci",
+        ],
+        "ranAt": now,
+        "ranBy": signer,
+        "commit": commit,
+        "tooling": {"mill": mill_version},
+        "result": "pass",
+    },
+}
+# Canonical encoding is used for signing.
+import sys
+sys.stdout.buffer.write(
+    json.dumps(statement, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+)
+PY
+
+# `ssh-keygen -Y sign` writes the signature to <file>.sig
+ssh-keygen -Y sign -f "$KEY" -n soundness-ci "$STMT" >/dev/null 2>&1
+
+# Build the envelope: { "statement": <statement>, "signature": <pem> }
+python3 - "$STMT" "$STMT.sig" > "$ENV_FILE" <<'PY'
+import json, sys
+with open(sys.argv[1], "rb") as f:
+    statement = json.loads(f.read())
+with open(sys.argv[2]) as f:
+    signature = f.read()
+envelope = {"statement": statement, "signature": signature}
+print(json.dumps(envelope, indent=2, sort_keys=True, ensure_ascii=False))
+PY
+
+git notes --ref="$NOTES_REF" add -f -F "$ENV_FILE" HEAD
+
+echo >&2
+echo "Attestation written to $NOTES_REF for $HEAD_SHA." >&2
+echo "Run \`make push\` to publish commits and the attestation note." >&2

--- a/etc/ci/canonicalize-statement.sh
+++ b/etc/ci/canonicalize-statement.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Read a JSON document on stdin, write its canonical encoding to stdout.
+# Canonical = sorted keys, no insignificant whitespace, UTF-8.
+
+set -euo pipefail
+exec python3 "$(dirname "$0")/_lib.py" canonicalize

--- a/etc/ci/compute-input-digest.sh
+++ b/etc/ci/compute-input-digest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Emit the SHA-256 input digest for the soundness CI input set at HEAD
+# (or another commit if passed as the first argument).
+#
+# Algorithm: tracked files at <commit>, filtered through .dockerignore,
+# hashed via a deterministic manifest. See etc/ci/_lib.py for details.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+exec python3 etc/ci/_lib.py input-digest "${1:-HEAD}"

--- a/etc/ci/pre-push.sample
+++ b/etc/ci/pre-push.sample
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Sample pre-push hook for soundness local-CI.
+#
+# Install:
+#     ln -s ../../etc/ci/pre-push.sample .git/hooks/pre-push
+#
+# Refuses the push if any ref being pushed lacks a valid attestation note,
+# and ensures the attestation notes ref is part of the push.
+
+set -euo pipefail
+
+remote="$1"
+url="$2"
+
+failed=0
+push_notes=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$local_sha" == "0000000000000000000000000000000000000000" ]]; then
+    continue  # ref deletion
+  fi
+  if [[ "$local_ref" == refs/notes/* ]]; then
+    push_notes=1
+    continue
+  fi
+  if ! etc/ci/verify-attest.sh "$local_sha" >/dev/null 2>&1; then
+    echo "pre-push: missing or invalid attestation for $local_ref ($local_sha)" >&2
+    echo "  run \`make attest\` first." >&2
+    failed=1
+  fi
+done
+
+if [[ $failed -eq 1 ]]; then
+  exit 1
+fi
+
+# Best-effort: push the attestation notes ref alongside the regular push if the
+# user didn't include it explicitly.
+if [[ $push_notes -eq 0 ]]; then
+  echo "pre-push: also pushing refs/notes/ci-attestation to $remote" >&2
+  git push "$remote" refs/notes/ci-attestation || true
+fi

--- a/etc/ci/verify-attest.sh
+++ b/etc/ci/verify-attest.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Verify the local-CI attestation note attached to HEAD (or a given commit).
+# Used by `make verify-attest` locally AND by GitHub Actions.
+#
+# Exit codes:
+#   0  attestation present, signature valid, input digest matches
+#   1  no attestation, bad signature, or digest mismatch
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+COMMIT="${1:-HEAD}"
+COMMIT_SHA=$(git rev-parse "$COMMIT")
+NOTES_REF="refs/notes/ci-attestation"
+ALLOWED="$PWD/.ci/allowed_signers"
+
+if [[ ! -f "$ALLOWED" ]]; then
+  echo "verify-attest: .ci/allowed_signers is missing" >&2
+  exit 1
+fi
+
+if ! git notes --ref="$NOTES_REF" show "$COMMIT_SHA" >/dev/null 2>&1; then
+  echo "verify-attest: no attestation note for $COMMIT_SHA on $NOTES_REF" >&2
+  echo "  (did you forget to push notes with \`make push\`, or run \`make attest\`?)" >&2
+  exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+ENV_FILE="$TMP/envelope.json"
+STMT="$TMP/statement.canonical"
+SIG="$TMP/signature.pem"
+
+git notes --ref="$NOTES_REF" show "$COMMIT_SHA" > "$ENV_FILE"
+
+# Split the envelope into a canonical statement (for verification),
+# the detached signature, the signer principal, and the claimed digest.
+read -r SIGNER CLAIMED_DIGEST < <(python3 - "$ENV_FILE" "$STMT" "$SIG" <<'PY'
+import json, sys
+env_path, stmt_path, sig_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(env_path) as f:
+    env = json.load(f)
+statement = env["statement"]
+signature = env["signature"]
+with open(stmt_path, "wb") as out:
+    out.write(json.dumps(
+        statement, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8"))
+with open(sig_path, "w") as out:
+    out.write(signature)
+print(statement["predicate"]["ranBy"], statement["subject"][0]["digest"]["sha256"])
+PY
+)
+
+# Verify the signature against allowed_signers under namespace `soundness-ci`.
+if ! ssh-keygen -Y verify \
+      -f "$ALLOWED" \
+      -I "$SIGNER" \
+      -n soundness-ci \
+      -s "$SIG" < "$STMT" >/dev/null 2>&1; then
+  echo "verify-attest: signature INVALID (signer=$SIGNER)" >&2
+  exit 1
+fi
+
+# Recompute the input digest at the verified commit and compare.
+ACTUAL_DIGEST=$(etc/ci/compute-input-digest.sh "$COMMIT_SHA")
+if [[ "$ACTUAL_DIGEST" != "$CLAIMED_DIGEST" ]]; then
+  echo "verify-attest: input digest MISMATCH" >&2
+  echo "  claimed: $CLAIMED_DIGEST" >&2
+  echo "  actual:  $ACTUAL_DIGEST" >&2
+  exit 1
+fi
+
+echo "verify-attest: OK (commit=$COMMIT_SHA signer=$SIGNER digest=$ACTUAL_DIGEST)" >&2

--- a/img/test
+++ b/img/test
@@ -23,6 +23,8 @@ RUN apt-get update \
       curl ca-certificates xz-utils git \
       build-essential pkg-config \
       psmisc \
+      libssl3 libicu74 libgssapi-krb5-2 libstdc++6 zlib1g \
+      ncurses-term \
  && rm -rf /var/lib/apt/lists/* \
  && touch /root/.zshrc
 
@@ -33,7 +35,8 @@ RUN mkdir -p /opt/powershell \
  && curl -fsSL "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-x64.tar.gz" \
       | tar -xz -C /opt/powershell \
  && chmod +x /opt/powershell/pwsh \
- && ln -s /opt/powershell/pwsh /usr/local/bin/pwsh
+ && ln -s /opt/powershell/pwsh /usr/local/bin/pwsh \
+ && pwsh -NoProfile -Command 'Write-Host "PowerShell:" $PSVersionTable.PSVersion'
 
 # Zig (matches main.yml: 0.13.0)
 ARG ZIG_VERSION=0.13.0

--- a/img/test
+++ b/img/test
@@ -46,13 +46,17 @@ COPY . /src
 
 # The actual test run. BuildKit cache mounts persist Mill/Coursier/Cargo
 # state across invocations on the same machine, making re-runs fast.
+#
+# CLAUDECODE=1 tells `probably`'s reporter to emit the terse, log-friendly
+# format (per-failure source location + stack frames), as opposed to the
+# default human/table mode that assumes an interactive terminal.
 RUN --mount=type=cache,target=/root/.cache/coursier \
     --mount=type=cache,target=/root/.cache/mill \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/src/out \
-    ./mill --ticker false test.assembly \
- && make ci
+    CLAUDECODE=1 ./mill --ticker false test.assembly \
+ && CLAUDECODE=1 make ci
 
 # Final image is intentionally not optimised — it exists only as the side
 # effect of a successful test run. We don't push or otherwise use it.

--- a/img/test
+++ b/img/test
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.7
+#
+# Test-running image for soundness CI.
+#
+# The build context (controlled by `.dockerignore`) is the canonical "CI input set":
+# any file inside this context is part of the input digest that `make attest` signs.
+#
+# Usage:
+#   DOCKER_BUILDKIT=1 docker build -f img/test --progress=plain .
+#
+# A successful build implies `./mill test.assembly && make ci` passed.
+
+ARG JDK=23
+FROM eclipse-temurin:${JDK}-jdk
+
+# Shells and tooling the tests exercise (matches `.github/workflows/main.yml`).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      bash zsh fish tmux \
+      curl ca-certificates xz-utils git \
+      build-essential pkg-config \
+ && rm -rf /var/lib/apt/lists/* \
+ && touch /root/.zshrc
+
+# Zig (matches main.yml: 0.13.0)
+ARG ZIG_VERSION=0.13.0
+RUN curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
+      | tar -xJ -C /opt \
+ && ln -s "/opt/zig-linux-x86_64-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
+# Rust with the cross-targets main.yml installs, plus cargo-zigbuild.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable \
+          --target x86_64-pc-windows-gnu \
+          --target x86_64-unknown-linux-gnu \
+          --target aarch64-unknown-linux-gnu \
+          --target x86_64-apple-darwin \
+          --target aarch64-apple-darwin
+ENV PATH=/root/.cargo/bin:${PATH}
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    cargo install --locked cargo-zigbuild
+
+WORKDIR /src
+COPY . /src
+
+# The actual test run. BuildKit cache mounts persist Mill/Coursier/Cargo
+# state across invocations on the same machine, making re-runs fast.
+RUN --mount=type=cache,target=/root/.cache/coursier \
+    --mount=type=cache,target=/root/.cache/mill \
+    --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/src/out \
+    ./mill --ticker false --silent test.assembly \
+ && make ci
+
+# Final image is intentionally not optimised — it exists only as the side
+# effect of a successful test run. We don't push or otherwise use it.

--- a/img/test
+++ b/img/test
@@ -13,14 +13,27 @@
 ARG JDK=23
 FROM eclipse-temurin:${JDK}-jdk
 
-# Shells and tooling the tests exercise (matches `.github/workflows/main.yml`).
+# Shells and tooling the tests exercise. We need the same userland as the
+# GitHub Actions ubuntu-latest runner image, which preinstalls many of these.
+# Notably: `psmisc` provides `killall` (used by ethereal tests), and PowerShell
+# (installed below) is required by the exoskeleton powershell test suite.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       bash zsh fish tmux \
       curl ca-certificates xz-utils git \
       build-essential pkg-config \
+      psmisc \
  && rm -rf /var/lib/apt/lists/* \
  && touch /root/.zshrc
+
+# PowerShell, installed from the official tarball release — works on any Linux
+# x86_64 distribution, independent of Microsoft's apt repo per-distro support.
+ARG PWSH_VERSION=7.4.6
+RUN mkdir -p /opt/powershell \
+ && curl -fsSL "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-x64.tar.gz" \
+      | tar -xz -C /opt/powershell \
+ && chmod +x /opt/powershell/pwsh \
+ && ln -s /opt/powershell/pwsh /usr/local/bin/pwsh
 
 # Zig (matches main.yml: 0.13.0)
 ARG ZIG_VERSION=0.13.0

--- a/img/test
+++ b/img/test
@@ -28,11 +28,21 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && touch /root/.zshrc
 
-# PowerShell, installed from the official tarball release — works on any Linux
-# x86_64 distribution, independent of Microsoft's apt repo per-distro support.
+# BuildKit auto-populates $TARGETARCH (amd64 / arm64 / ...) — we use it to
+# fetch native binaries on whatever host runs this build. Building x86_64-only
+# binaries on an Apple Silicon host forces Rosetta emulation, which fails for
+# binaries that do heavy native I/O at startup (notably pwsh).
+ARG TARGETARCH
+
+# PowerShell, installed from the official tarball release.
 ARG PWSH_VERSION=7.4.6
-RUN mkdir -p /opt/powershell \
- && curl -fsSL "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-x64.tar.gz" \
+RUN case "${TARGETARCH}" in \
+      amd64) PWSH_ARCH=linux-x64 ;; \
+      arm64) PWSH_ARCH=linux-arm64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 ; exit 1 ;; \
+    esac \
+ && mkdir -p /opt/powershell \
+ && curl -fsSL "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-${PWSH_ARCH}.tar.gz" \
       | tar -xz -C /opt/powershell \
  && chmod +x /opt/powershell/pwsh \
  && ln -s /opt/powershell/pwsh /usr/local/bin/pwsh \
@@ -40,9 +50,14 @@ RUN mkdir -p /opt/powershell \
 
 # Zig (matches main.yml: 0.13.0)
 ARG ZIG_VERSION=0.13.0
-RUN curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" \
+RUN case "${TARGETARCH}" in \
+      amd64) ZIG_ARCH=x86_64 ;; \
+      arm64) ZIG_ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2 ; exit 1 ;; \
+    esac \
+ && curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}.tar.xz" \
       | tar -xJ -C /opt \
- && ln -s "/opt/zig-linux-x86_64-${ZIG_VERSION}/zig" /usr/local/bin/zig
+ && ln -s "/opt/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
 
 # Rust with the cross-targets main.yml installs, plus cargo-zigbuild.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/img/test
+++ b/img/test
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/root/.cache/coursier \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/src/out \
-    ./mill --ticker false --silent test.assembly \
+    ./mill --ticker false test.assembly \
  && make ci
 
 # Final image is intentionally not optimised — it exists only as the side


### PR DESCRIPTION
CI now runs locally on the maintainer's machine in a dedicated `img/test` Docker image; the GitHub Actions `Build` workflow is reduced to a fast signature-and-digest verification of an attestation that the maintainer attaches to each commit as a git note. There are no user-facing changes.

### For contributors

The `Build` GitHub Actions check no longer compiles or runs tests on CI; instead it verifies a signed attestation. Producing one:

```bash
make attest    # builds and runs tests in img/test (requires Docker)
make push      # pushes commits AND refs/notes/ci-attestation
```

See the new "CI workflow" section of `CLAUDE.md` for full details. PRs from external contributors will be merged locally by the maintainer after re-running tests and signing.