### PR TITLE
Replace .contains with .has across downstream modules

### DIFF
--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -123,6 +123,7 @@ statement = {
     "predicateType": "https://soundness.dev/local-ci/v1",
     "predicate": {
         "commands": [
+            "./mill --ticker false --silent soundness.all.compile",
             "./mill --ticker false --silent test.assembly",
             "make ci",
         ],

--- a/img/test
+++ b/img/test
@@ -11,7 +11,7 @@
 # A successful build implies `./mill test.assembly && make ci` passed.
 
 ARG JDK=23
-FROM eclipse-temurin:${JDK}-jdk
+FROM eclipse-temurin:${JDK}-jdk AS base
 
 # Shells and tooling the tests exercise. We need the same userland as the
 # GitHub Actions ubuntu-latest runner image, which preinstalls many of these.
@@ -75,19 +75,39 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 WORKDIR /src
 COPY . /src
 
-# The actual test run. BuildKit cache mounts persist Mill/Coursier/Cargo
-# state across invocations on the same machine, making re-runs fast.
+# The test run is split into three stages so each phase gets a fresh
+# container — the mill build-server JVM from stages 1–2 is torn down
+# before the test runner JVM starts in stage 3, keeping the resident-set
+# ceiling to the worst single phase rather than their sum.
+#
+# All three stages mount the same /src/out BuildKit cache, which is what
+# carries the mill compile state and the assembled test JAR forward.
+# Stages are chained via FROM so BuildKit runs them serially.
 #
 # CLAUDECODE=1 tells `probably`'s reporter to emit the terse, log-friendly
 # format (per-failure source location + stack frames), as opposed to the
 # default human/table mode that assumes an interactive terminal.
+
+# Stage 1: compile every soundness module.
+FROM base AS compile-sources
 RUN --mount=type=cache,target=/root/.cache/coursier \
     --mount=type=cache,target=/root/.cache/mill \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/src/out \
-    CLAUDECODE=1 ./mill --ticker false test.assembly \
- && CLAUDECODE=1 make ci
+    CLAUDECODE=1 ./mill --ticker false soundness.all.compile
 
-# Final image is intentionally not optimised — it exists only as the side
-# effect of a successful test run. We don't push or otherwise use it.
+# Stage 2: compile tests and assemble the fat test JAR. Mill sees the
+# warm compile state from stage 1 via the /src/out cache mount.
+FROM compile-sources AS compile-tests
+RUN --mount=type=cache,target=/root/.cache/coursier \
+    --mount=type=cache,target=/root/.cache/mill \
+    --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/src/out \
+    CLAUDECODE=1 ./mill --ticker false test.assembly
+
+# Stage 3: run the assembled test JAR. No mill JVM in this stage.
+FROM compile-tests AS run-tests
+RUN --mount=type=cache,target=/src/out \
+    CLAUDECODE=1 make ci

--- a/lib/acyclicity/src/core/acyclicity.Dag.scala
+++ b/lib/acyclicity/src/core/acyclicity.Dag.scala
@@ -120,7 +120,7 @@ case class Dag[node] private[acyclicity](edgeMap: Map[node, Set[node]] = Map()):
         case (m, (k, v)) => m.updated(k, m(k) - v)
 
   def reachable(node: node): Set[node] raises DagError =
-    if !edgeMap.contains(node)
+    if !edgeMap.has(node)
     then abort(DagError(DagError.Reason.NodeMissing(node.toString.tt)))
     else reach(node)
 
@@ -162,7 +162,7 @@ case class Dag[node] private[acyclicity](edgeMap: Map[node, Set[node]] = Map()):
       } -- deletions
 
   private def findCycle(start: node): Option[List[node]] raises DagError =
-    if !edgeMap.contains(start)
+    if !edgeMap.has(start)
     then abort(DagError(DagError.Reason.NodeMissing(start.toString.tt)))
 
     @tailrec

--- a/lib/aviation/src/core/aviation.Holidays.scala
+++ b/lib/aviation/src/core/aviation.Holidays.scala
@@ -41,7 +41,7 @@ object Holidays:
   def apply(holidays: Iterable[Holiday]): Holidays = new Holidays:
     private val store: SortedMap[Date, Holiday] = holidays.bi.map(_.date -> _).to(SortedMap)
 
-    def holiday(date: Date): Optional[Holiday] = if store.contains(date) then store(date) else Unset
+    def holiday(date: Date): Optional[Holiday] = if store.has(date) then store(date) else Unset
 
     def between(start: Date, end: Date): List[Holiday] =
       store.iteratorFrom(start).map(_(1)).takeWhile(_.date < end).to(List)

--- a/lib/breviloquence/src/core/breviloquence.CborRelabelling.scala
+++ b/lib/breviloquence/src/core/breviloquence.CborRelabelling.scala
@@ -39,4 +39,4 @@ trait CborRelabelling[+target]:
   def relabelling(): Map[Text, Text]
   private lazy val labels: Map[Text, Text] = relabelling()
 
-  def apply(label: Text): Optional[Text] = if labels.contains(label) then labels(label) else Unset
+  def apply(label: Text): Optional[Text] = if labels.has(label) then labels(label) else Unset

--- a/lib/cellulose/src/core/cellulose.CodlSchema.scala
+++ b/lib/cellulose/src/core/cellulose.CodlSchema.scala
@@ -97,7 +97,7 @@ extends Dynamic:
     else if endlessParams && paramCount > 0 then subschemas(paramCount - 1)
     else Unset
 
-  def has(key: Optional[Text]): Boolean = dictionary.contains(key)
+  def has(key: Optional[Text]): Boolean = dictionary.has(key)
 
   lazy val requiredKeys: List[Text] =
     subschemas.filter(_.required).map(_.key).collect { case text: Text => text }.to(List)

--- a/lib/cellulose/src/core/cellulose.Data.scala
+++ b/lib/cellulose/src/core/cellulose.Data.scala
@@ -72,7 +72,7 @@ extends Indexed:
     case _                                    => key
 
   def promote(n: Int): Atom = copy(layout = layout.copy(params = n))
-  def has(key: Text): Boolean = index.contains(key) || paramIndex.contains(key)
+  def has(key: Text): Boolean = index.has(key) || paramIndex.has(key)
 
   override def equals(that: Any) = that.matchable(using Unsafe) match
     case that: Atom =>

--- a/lib/cellulose/src/core/cellulose.internal.scala
+++ b/lib/cellulose/src/core/cellulose.internal.scala
@@ -386,7 +386,7 @@ object internal extends protointernal:
                         focus.commit(Proto(word, line, col, multiline = block))
 
                       uniqueId.let: uniqueId =>
-                        if peerIds.contains(uniqueId(0)) then
+                        if peerIds.has(uniqueId(0)) then
                           val first = peerIds(uniqueId(0))
                           val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
                           raise
@@ -403,7 +403,7 @@ object internal extends protointernal:
                         focus.commit(Proto(word, line, col, multiline = block))
 
                       uniqueId.let: uniqueId =>
-                        if peerIds.contains(uniqueId(0)) then
+                        if peerIds.has(uniqueId(0)) then
                           val first = peerIds(uniqueId(0))
                           val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
                           raise
@@ -430,7 +430,7 @@ object internal extends protointernal:
                         val (uniqueId, focus2) = focus.commit(peer)
 
                         uniqueId.let: uniqueId =>
-                          if peerIds.contains(uniqueId(0)) then
+                          if peerIds.has(uniqueId(0)) then
                             val first = peerIds(uniqueId(0))
                             val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
                             raise

--- a/lib/charisma/src/core/charisma.Molecule.scala
+++ b/lib/charisma/src/core/charisma.Molecule.scala
@@ -46,13 +46,13 @@ object Molecule:
 
   given showable: Molecule is Showable = molecule =>
     val orderedElements =
-      if !molecule.elements.contains(PeriodicTable.C)
+      if !molecule.elements.has(PeriodicTable.C)
       then molecule.elements.to(List).sortBy(_(0).symbol)
       else
         val carbon = PeriodicTable.C -> molecule.elements(PeriodicTable.C)
 
         val hydrogen =
-          if !molecule.elements.contains(PeriodicTable.H) then Nil else
+          if !molecule.elements.has(PeriodicTable.H) then Nil else
             List(PeriodicTable.H -> molecule.elements(PeriodicTable.H))
 
         val rest =

--- a/lib/escritoire/src/core/escritoire.Grid.scala
+++ b/lib/escritoire/src/core/escritoire.Grid.scala
@@ -103,7 +103,7 @@ case class Grid[text](sections: List[TableSection[text]], style: TableStyle):
       Textual:
         Text.fill(width): index =>
           def vertical(bitSet: sci.BitSet, line: BoxLine): BoxLine =
-            if bitSet.contains(index) then line else BoxLine.Blank
+            if bitSet.has(index) then line else BoxLine.Blank
 
           if index == 0 then
             style.charset

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -85,7 +85,7 @@ extends Topical:
       if key().starts(t"--") then key().skip(2) else if key().starts(t"-")
       then key().at(Sec) else Unset
 
-    flag == name || aliases.contains(flag)
+    flag == name || aliases.has(flag)
 
 
   def apply()

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -85,7 +85,7 @@ extends Topical:
       if key().starts(t"--") then key().skip(2) else if key().starts(t"-")
       then key().at(Sec) else Unset
 
-    flag == name || aliases.has(flag)
+    flag == name || aliases.contains(flag)
 
 
   def apply()

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -146,6 +146,18 @@ extension (shell: Shell)
             sh"""tmux send-keys -t ${tmux.id} "autoload -Uz compinit; compinit -u" C-m"""
             . exec[Unit]()
 
+            // `compinit` walks every completion function and can take seconds
+            // under Docker load; without an explicit ready-marker the test
+            // would start sending keys (including TAB) before the completion
+            // system is initialised, so TAB resolves to nothing.
+            sh"""tmux send-keys -t ${tmux.id} 'echo READY-${tmux.id}' C-m""".exec[Unit]()
+            var zshReady = false
+            var zshAttempts = 0
+            while !zshReady && zshAttempts < 666 do
+              delay(0.03*Second)
+              zshReady = Tmux.screenshot().screen.filter(_.trim == t"READY-${tmux.id}").length > 0
+              zshAttempts += 1
+
             Tmux.attend:
               sh"""tmux send-keys -t ${tmux.id} C-l""".exec[Unit]()
 

--- a/lib/gesticulate/src/core/gesticulate.Media.scala
+++ b/lib/gesticulate/src/core/gesticulate.Media.scala
@@ -113,7 +113,7 @@ object Media:
     parsed.subtype match
       case Subtype.Standard(_) =>
         if !systemMediaTypes.nil then
-          if !systemMediaTypes.contains(parsed.basic) then
+          if !systemMediaTypes.has(parsed.basic) then
             val suggestion = systemMediaTypes.minBy(_.proximity(parsed.basic))
 
             return
@@ -157,7 +157,7 @@ object Media:
 
     def parseSubtype(string: Text): Subtype =
       def notAllowed(char: Char): Boolean =
-        char.isWhitespace || char.isControl || specials.contains(char)
+        char.isWhitespace || char.isControl || specials.has(char)
 
       string.chars.find(notAllowed(_)).map: char =>
         raise(MediaTypeError(string, MediaTypeError.Reason.InvalidChar(char)))

--- a/lib/gossamer/src/core/gossamer.Dictionary.scala
+++ b/lib/gossamer/src/core/gossamer.Dictionary.scala
@@ -127,7 +127,7 @@ enum Dictionary[+element]:
           val next = entry.s.charAt(offset)
 
           val child =
-            if map.contains(next) then map(next).add(entry, value, offset + 1)
+            if map.has(next) then map(next).add(entry, value, offset + 1)
             else Just(entry, offset + 1, value)
 
           Branch(value0, map.updated(next, child))

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -51,7 +51,7 @@ object SourceCode:
     else if token >= 4 && token <= 9 || token == 23 || token == 24 || token == 42 || token == 43
     then Accent.Number
     else if token == 14 then Accent.Ident
-    else if token >= 20 && token <= 62 && Tokens.modifierTokens.contains(token) then Accent.Modifier
+    else if token >= 20 && token <= 62 && Tokens.modifierTokens.has(token) then Accent.Modifier
     else if token >= 20 && token <= 66 then Accent.Keyword
     else if token >= 78 && token <= 99 then Accent.Symbol
     else Accent.Parens

--- a/lib/hellenism/src/core/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/core/hellenism.LocalClasspath.scala
@@ -87,7 +87,7 @@ object LocalClasspath:
           case Directory => ClasspathEntry.Directory(path.encode)
           case _         => ClasspathEntry.Jar(path.encode)
 
-        if classpath.entrySet.contains(entry) then classpath
+        if classpath.entrySet.has(entry) then classpath
         else new LocalClasspath(entry :: classpath.entries, classpath.entrySet + entry)
 
 

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -1201,7 +1201,7 @@ object Html extends Tag.Container
                       reset(mark)
                       close()
                     else if stackContainsAncestor(content) then
-                      if formattingTags.contains(parent.label) then
+                      if formattingTags.has(parent.label) then
                         pendingAtDepth = findAncestorIndex(content)
                         if pendingFormattingSize >= pendingFormattingLabels.length then
                           val newCap = pendingFormattingLabels.length*2
@@ -1217,7 +1217,7 @@ object Html extends Tag.Container
                         pendingFormattingSize += 1
                       reset(mark)
                       close()
-                    else if formattingTags.contains(content) then
+                    else if formattingTags.has(content) then
                       advance()
                       level = Level.Skip
                     else

--- a/lib/honeycomb/src/core/honeycomb.Html4.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html4.scala
@@ -352,7 +352,7 @@ class Html4Transitional() extends Dom:
 
   def infer(parent: Tag, child: Tag): Optional[Tag] =
     def recur(parent: Tag): Boolean =
-      parent.admissible.contains(child.label) || insertable(parent).exists(recur(_))
+      parent.admissible.has(child.label) || insertable(parent).exists(recur(_))
 
     insertable(parent).find(recur(_)).optional
 

--- a/lib/honeycomb/src/core/honeycomb.Whatwg.scala
+++ b/lib/honeycomb/src/core/honeycomb.Whatwg.scala
@@ -396,7 +396,7 @@ class Whatwg() extends Dom:
 
   def infer(parent: Tag, child: Tag): Optional[Tag] =
     def recur(parent: Tag): Boolean =
-      parent.admissible.contains(child.label) || insertable(parent).exists(recur(_))
+      parent.admissible.has(child.label) || insertable(parent).exists(recur(_))
 
     insertable(parent).find(recur(_)).optional
 

--- a/lib/metamorphose/src/core/metamorphose.Permutation.scala
+++ b/lib/metamorphose/src/core/metamorphose.Permutation.scala
@@ -58,7 +58,7 @@ object Permutation:
         raise
           ( PermutationError(PermutationError.Reason.InvalidIndex(element, sequence.length - 1)) )
 
-      if seen.contains(element)
+      if seen.has(element)
       then raise(PermutationError(PermutationError.Reason.DuplicateIndex(element, index)))
 
       seen(element) = true

--- a/lib/nomenclature/src/core/nomenclature.MustContain.scala
+++ b/lib/nomenclature/src/core/nomenclature.MustContain.scala
@@ -37,6 +37,6 @@ import fulminate.*
 import gossamer.*
 import proscenium.*
 
-object MustContain extends Rule({ text => m"must contain $text" }, _.contains(_))
+object MustContain extends Rule({ text => m"must contain $text" }, _.has(_))
 
 sealed trait MustContain[text <: Label] extends Check[text]

--- a/lib/nomenclature/src/core/nomenclature.MustNotContain.scala
+++ b/lib/nomenclature/src/core/nomenclature.MustNotContain.scala
@@ -37,6 +37,6 @@ import fulminate.*
 import gossamer.*
 import proscenium.*
 
-object MustNotContain extends Rule({ text => m"must not contain $text"}, !_.contains(_))
+object MustNotContain extends Rule({ text => m"must not contain $text"}, !_.has(_))
 
 sealed trait MustNotContain[text <: Label] extends Check[text]

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -666,7 +666,7 @@ object Tests extends Suite(m"Octogenarian Tests"):
         worktree.makeBranch(GitBranch(t"oldname"))
         worktree.repo.renameBranch(GitBranch(t"oldname"), GitBranch(t"newname"))
         val names = worktree.branches().map(_.show).to(Set)
-        names.contains(t"newname") && !names.contains(t"oldname")
+        names.has(t"newname") && !names.has(t"oldname")
       .assert(_ == true)
 
       test(m"tags() returns an empty list for a tagless repo"):

--- a/lib/orthodoxy/src/core/orthodoxy.Scope.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Scope.scala
@@ -42,7 +42,7 @@ case class Scope(names: Text*):
   :   Authorization of this.type raises OAuthError =
 
     names.each: name =>
-      if !authorization.scopes.contains(name)
+      if !authorization.scopes.has(name)
       then raise(OAuthError(OAuthError.Reason.InsufficientPrivileges(name)))
 
     authorization.of[this.type]

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -510,7 +510,7 @@ object Tests extends Suite(m"Parasite tests"):
           val tasks = (1 to 5).map: i =>
             async(i)
           val result = async(tasks.race()).await()
-          (1 to 5).contains(result)
+          (1 to 5).has(result)
         . assert(_ == true)
 
       suite(m"Retry / Tenacity"):

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -287,7 +287,7 @@ class Report(using Environment)(using palette: TestPalette):
     val failureStatuses: Set[Status] =
       Set(Status.Fail, Status.Throws, Status.CheckThrows, Status.Mixed)
 
-    val failures = summaryLines.filter{ s => failureStatuses.contains(s.status) }
+    val failures = summaryLines.filter{ s => failureStatuses.has(s.status) }
 
     if failures.nonEmpty then
       Out.println(t"")
@@ -401,10 +401,10 @@ class Report(using Environment)(using palette: TestPalette):
 
       val data = coverage.spec.groupBy(_.path).to(List).map: (path, branches) =>
         val hitCount: Int =
-          branches.to(List).map(_.id).map(coverage.hits.contains).count(identity(_))
+          branches.to(List).map(_.id).map(coverage.hits.has).count(identity(_))
 
         val oldHitCount: Int =
-          branches.to(List).map(_.id).map(coverage.oldHits.contains).count(identity(_))
+          branches.to(List).map(_.id).map(coverage.oldHits.has).count(identity(_))
 
         CoverageData(path, branches.size, hitCount, oldHitCount)
 
@@ -433,8 +433,8 @@ class Report(using Environment)(using palette: TestPalette):
             if row(0).juncture.branch then e"⎇" else e"",
 
           Column(e""): row =>
-            if coverage.hits.contains(row(0).juncture.id) then e"${Bg(palette.detail)}(  )"
-            else if coverage.oldHits.contains(row(0).juncture.id) then e"${Bg(palette.detail)}(  )"
+            if coverage.hits.has(row(0).juncture.id) then e"${Bg(palette.detail)}(  )"
+            else if coverage.oldHits.has(row(0).juncture.id) then e"${Bg(palette.detail)}(  )"
             else e"${Bg(palette.highlight)}(  )",
 
           Column(e"Juncture")(_(1)),

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -102,7 +102,7 @@ class Report(using Environment)(using palette: TestPalette):
       tests = tests.updated(testId, reportLine)
 
     def getOrElseUpdate(testId: TestId, reportLine: => ReportLine): ReportLine = synchronized:
-      if !tests.contains(testId) then tests = tests.updated(testId, reportLine)
+      if !tests.has(testId) then tests = tests.updated(testId, reportLine)
       tests(testId)
 
   enum ReportLine:

--- a/lib/probably/src/coverage/probably.Surface.scala
+++ b/lib/probably/src/coverage/probably.Surface.scala
@@ -44,7 +44,7 @@ object Surface:
 
 case class Surface(juncture: Juncture, children: List[Surface]):
   def covered(hits: Set[Int]): Boolean =
-    hits.contains(juncture.id) && children.all(_.covered(hits))
+    hits.has(juncture.id) && children.all(_.covered(hits))
 
   def uncovered(hits: Set[Int]): Surface =
     Surface(juncture, children.filter(!_.covered(hits)).map(_.uncovered(hits)))

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -495,8 +495,8 @@ object Tests extends Suite(m"Quantitative Tests"):
         val ops = Set(t"negate", t"add", t"subtract", t"multiply", t"divide", t"root", t"op")
         bytecode.instructions.exists: instruction =>
           instruction.opcode match
-            case Bytecode.Opcode.Invokevirtual(_, name, _)      => ops.contains(name)
-            case Bytecode.Opcode.Invokeinterface(_, name, _, _) => ops.contains(name)
+            case Bytecode.Opcode.Invokevirtual(_, name, _)      => ops.has(name)
+            case Bytecode.Opcode.Invokeinterface(_, name, _, _) => ops.has(name)
             case _                                              => false
 
       def hasBoxing(bytecode: Bytecode): Boolean =

--- a/lib/revolution/src/core/revolution.Manifest.scala
+++ b/lib/revolution/src/core/revolution.Manifest.scala
@@ -76,7 +76,7 @@ case class Manifest(entries: Map[Text, Text]):
   def apply[key <: Label: DecodableManifest](attribute: ManifestAttribute[key])
   :   Optional[key.Topic] =
 
-    if entries.contains(attribute.key) then key.decoded(entries(attribute.key)) else Unset
+    if entries.has(attribute.key) then key.decoded(entries(attribute.key)) else Unset
 
 
   def serialize: Data =

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -138,10 +138,6 @@ extension [value <: Matchable](iterable: Iterable[value])
   transparent inline def weave(right: Iterable[value]): Iterable[value] =
     iterable.zip(right).flatMap(Iterable(_, _))
 
-extension [value <: Matchable](set: Set[value])
-  @targetName("hasSet")
-  inline def has(value: value): Boolean = set.contains(value)
-
 extension [element <: Matchable](iarray: IArray[element])
   @targetName("hasIArray")
   inline def has(value: element): Boolean = iarray.exists(_ == value)

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -138,6 +138,18 @@ extension [value <: Matchable](iterable: Iterable[value])
   transparent inline def weave(right: Iterable[value]): Iterable[value] =
     iterable.zip(right).flatMap(Iterable(_, _))
 
+extension [value <: Matchable](set: Set[value])
+  @targetName("hasSet")
+  inline def has(value: value): Boolean = set.contains(value)
+
+extension [element <: Matchable](iarray: IArray[element])
+  @targetName("hasIArray")
+  inline def has(value: element): Boolean = iarray.exists(_ == value)
+
+extension [element <: Matchable](array: Array[element])
+  @targetName("hasArray")
+  inline def has(value: element): Boolean = array.exists(_ == value)
+
 extension [value](iterator: Iterator[value])
   transparent inline def each(predicate: Ordinal aka "ordinal" ?=> value => Unit): Unit =
     var ordinal: Ordinal = Prim
@@ -317,7 +329,7 @@ extension [key, value](map: sc.Map[key, value])
 
 extension [key, value](map: Map[key, value])
   def upsert(key: key, optional: Optional[value] => value): Map[key, value] =
-    map.updated(key, optional(if map.contains(key) then map(key) else Unset))
+    map.updated(key, optional(if map.has(key) then map(key) else Unset))
 
   def collate(right: Map[key, value])(merge: (value, value) => value): Map[key, value] =
     right.fuse(map)(state.updated(next(0), state.get(next(0)).fold(next(1))(merge(_, next(1)))))
@@ -353,9 +365,6 @@ extension [element](sequence: Seq[element])
 
     if sequence.nil then Nil
     else recur(lambda(sequence.head), sequence.tail, List(sequence.head), Nil)
-
-extension [element](sequence: IndexedSeq[element])
-  transparent inline def has(index: Int): Boolean = index >= 0 && index < sequence.length
 
 extension (bytes: Data)
   def javaInputStream: ji.InputStream = new ji.ByteArrayInputStream(bytes.mutable(using Unsafe))

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -51,6 +51,55 @@ object Tests extends Suite(m"Rudiments Tests"):
         case _                    => ('X', 'X')
     . assert(_ == ('I', 'J'))
 
+    suite(m"has tests"):
+      test(m"List membership via has"):
+        List(1, 2, 3).has(2)
+      . assert(_ == true)
+
+      test(m"List non-membership via has"):
+        List(1, 2, 3).has(4)
+      . assert(_ == false)
+
+      test(m"Vector[Int] has is membership, not index validity"):
+        Vector(10, 20, 30).has(2)
+      . assert(_ == false)
+
+      test(m"Range has is membership, not index validity"):
+        (100 to 110).has(5)
+      . assert(_ == false)
+
+      test(m"Range has positive membership"):
+        (100 to 110).has(105)
+      . assert(_ == true)
+
+      test(m"Set has element"):
+        Set(1, 2, 3).has(2)
+      . assert(_ == true)
+
+      test(m"Set has missing element"):
+        Set(1, 2, 3).has(4)
+      . assert(_ == false)
+
+      test(m"IArray element membership"):
+        IArray(1, 2, 3).has(2)
+      . assert(_ == true)
+
+      test(m"IArray missing element"):
+        IArray(1, 2, 3).has(4)
+      . assert(_ == false)
+
+      test(m"Array element membership"):
+        Array(1, 2, 3).has(2)
+      . assert(_ == true)
+
+      test(m"Map key membership"):
+        Map(t"a" -> 1, t"b" -> 2).has(t"a")
+      . assert(_ == true)
+
+      test(m"Map missing key"):
+        Map(t"a" -> 1, t"b" -> 2).has(t"c")
+      . assert(_ == false)
+
     // test(m"Display a PID"):
     //   Pid(2999).toString
     // .assert(_ == "↯2999")

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -217,7 +217,7 @@ object Syntax:
               if isPackage(name2) then simple else Simple(Typename.Type(typename, name2))
 
             case refined@Structural(base, members, defs) =>
-              if members.contains(name) then members(name.tt) else Projection(refined, name.tt)
+              if members.has(name) then members(name.tt) else Projection(refined, name.tt)
 
             case symbolic@Symbolic(_) =>
               Selection(symbolic, name)
@@ -244,7 +244,7 @@ object Syntax:
               if isPackage(name) then simple else Value(Typename.Term(typename, name))
 
             case refined@Structural(base, members, defs) =>
-              if members.contains(name) then members(name.tt) else Projection(refined, name.tt)
+              if members.has(name) then members(name.tt) else Projection(refined, name.tt)
 
             case symbolic@Symbolic(_) =>
               Selection(symbolic, name)

--- a/lib/ypsiloid/src/core/ypsiloid.YamlParser.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlParser.scala
@@ -2325,7 +2325,7 @@ private[ypsiloid] final class YamlParser:
       val secondBang = s.indexOf('!', 1)
       if secondBang > 1 then
         val handle = s.substring(0, secondBang + 1).nn
-        if handle != "!!" && !tagHandles.contains(handle) then
+        if handle != "!!" && !tagHandles.has(handle) then
           errorAt(Issue.UndefinedTagHandle(handle.tt))
 
   private def applyTag(tag: Text, value: Yaml.Ast)(using Tactic[ParseError])

--- a/lib/ypsiloid/src/core/ypsiloid.internal.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.internal.scala
@@ -262,7 +262,7 @@ object internal:
           (elem, idx) =>
             elem.asMatchable match
               case s: String if s == MarkerString =>
-                if spreads.contains(holeIndex) then
+                if spreads.has(holeIndex) then
                   if idx != n - 1 then halt:
                     m"a `*`-spread is only allowed as the last element of a sequence"
                   encodeArraySpread(consumeHole())
@@ -318,7 +318,7 @@ object internal:
 
       def serialize(node: Any): Expr[Yaml.Ast] = node.asMatchable match
         case s: String if s == MarkerString =>
-          if spreads.contains(holeIndex) then halt:
+          if spreads.has(holeIndex) then halt:
             m"a `*`-spread is only allowed as the last element of a sequence"
           encodeValue(consumeHole())
 
@@ -382,7 +382,7 @@ object internal:
         pattern.asMatchable match
           case s: String if s == MarkerString =>
             val idx = nextHole
-            if spreads.contains(idx) then halt:
+            if spreads.has(idx) then halt:
               m"a `*`-spread is only allowed as the last element of a sequence"
             nextHole += 1
             types ::= TypeRepr.of[Yaml]
@@ -441,7 +441,7 @@ object internal:
         val tailSpread: Boolean =
           n > 0 && (elements(n - 1).asMatchable match
             case s: String if s == MarkerString =>
-              spreads.contains(nextHole + countHolesInPrefix(elements, n - 1))
+              spreads.has(nextHole + countHolesInPrefix(elements, n - 1))
 
             case _ => false)
 
@@ -593,7 +593,7 @@ object internal:
                     var j = 0
                     while j < n do
                       val key = $scrutinee.objectKey(j)
-                      if !keep.contains(key) then
+                      if !keep.has(key) then
                         keysBuf += key
                         valsBuf += $scrutinee.objectValue(j)
                       j += 1


### PR DESCRIPTION
Replaces the Scala stdlib `.contains` with Soundness's `.has` extension
across modules downstream of `rudiments.core`. Adds new element-membership
extensions for `IArray` and `Array` in `rudiments.core`, and removes the
`IndexedSeq.has(Int)` overload (which silently shadowed `Iterable.has`
membership for `Vector[Int]` and `Range`). Also splits the CI Docker
image into three sequential build stages so the mill build-server JVM
is torn down before the test runner starts, and adds a missing
ready-marker to the zsh test fixture so `compinit` finishes before
keystrokes are sent.

### Release notes

`has` is now a more reliable alternative to `contains` for membership
checks across all the standard collection types:

\`\`\`scala
import rudiments.*

Set(1, 2, 3).has(2)              // true   (via Iterable.has)
IArray(1, 2, 3).has(2)           // true
Array(1, 2, 3).has(2)            // true
Vector(10, 20, 30).has(2)        // false  (was true under the old footgun)
(100 to 110).has(5)              // false  (was true under the old footgun)
Map(t"a" -> 1).has(t"a")         // true
\`\`\`

The previous `IndexedSeq.has(Int)` overload, which meant "is this a
valid index", has been removed. Use `at(ordinal)` from the `Indexable`
typeclass for index-checked access instead.