### PR TITLE
caesura: quote DSV cells containing delimiter or newline

### DIFF
--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -73,7 +73,12 @@ object Dsv:
 
   given showable: (format: DsvFormat) => Dsv is Showable =
     _.data.map: cell =>
-      if !cell.contains(format.Quote) then cell else
+      if !cell.contains(format.Quote)
+         && !cell.contains(format.Delimiter)
+         && !cell.contains('\n')
+         && !cell.contains('\r')
+      then cell
+      else
         Text.build:
           append(format.quote)
 

--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -73,12 +73,10 @@ object Dsv:
 
   given showable: (format: DsvFormat) => Dsv is Showable =
     _.data.map: cell =>
-      if !cell.contains(format.Quote)
-         && !cell.contains(format.Delimiter)
-         && !cell.contains('\n')
-         && !cell.contains('\r')
-      then cell
-      else
+      val safe = !cell.contains(format.Quote) && !cell.contains(format.Delimiter)
+        && !cell.contains('\n') && !cell.contains('\r')
+
+      if safe then cell else
         Text.build:
           append(format.quote)
 

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -196,6 +196,21 @@ object Tests extends Suite(m"Caesura tests"):
       Sheet(Stream(Dsv(t"hello\"world"))).show
     . assert(_ == t""""hello""world"""")
 
+    test(m"convert row with delimiter in cell"):
+      import dsvFormats.csv
+      Sheet(Stream(Dsv(t"hello, world", t"test"))).show
+    . assert(_ == t""""hello, world",test""")
+
+    test(m"convert row with newline in cell"):
+      import dsvFormats.csv
+      Sheet(Stream(Dsv(t"line1\nline2", t"test"))).show
+    . assert(_ == t""""line1\nline2",test""")
+
+    test(m"convert row with carriage return in cell"):
+      import dsvFormats.csv
+      Sheet(Stream(Dsv(t"line1\rline2", t"test"))).show
+    . assert(_ == t""""line1\rline2",test""")
+
     test(m"simple parse TSV"):
       import dsvFormats.tsv
       t"hello\tworld".read[Sheet]


### PR DESCRIPTION
caesura's DSV/CSV serialiser now quotes cells when they contain the format's delimiter or a `\n` / `\r` byte, in addition to the existing case of containing the quote character itself. The previous behaviour emitted such cells verbatim, producing output that re-parsed into the wrong number of cells or split a row across multiple lines, contrary to RFC 4180. Fixes #1050.

### Quoting predicate widened to match RFC 4180

`Dsv is Showable` previously quoted a cell only if it contained the
configured quote character. A cell containing the delimiter or a line
break was emitted as-is, which corrupted the surrounding row structure.

```scala
import dsvFormats.csv
Sheet(Stream(Dsv(t"hello, world", t"test"))).show
// before: hello, world,test          (re-parses as three cells)
// after:  "hello, world",test
```

The same now holds for cells containing `\n` or `\r`:

```scala
Sheet(Stream(Dsv(t"line1\nline2", t"test"))).show
// before: line1<LF>line2,test         (splits the row)
// after:  "line1<LF>line2",test
```

No other behaviour changes: the quote-doubling logic inside the
quoted-cell branch is untouched, and cells that need no quoting at all
are still emitted verbatim.