### PR TITLE
gossamer: fix levenshteinDistance with empty left string

### DIFF
--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -453,7 +453,7 @@ package proximities:
 
         for j <- 0 to n do old(j) = dist(j)
 
-      dist(n)
+      if m == 0 then n else dist(n)
 
 
   given normalizedLevenshteinDistance: CaseSensitivity => Proximity by Double =

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -79,6 +79,21 @@ object Tests extends Suite(m"Gossamer Tests"):
 
       . assert(_ == 4)
 
+      test(m"empty left string has edit distance equal to right length"):
+        t"".proximity(t"abc").toLong
+
+      . assert(_ == 3)
+
+      test(m"empty right string has edit distance equal to left length"):
+        t"abc".proximity(t"").toLong
+
+      . assert(_ == 3)
+
+      test(m"two empty strings have zero edit distance"):
+        t"".proximity(t"").toLong
+
+      . assert(_ == 0)
+
     suite(m"String functions"):
       test(m"punycode test"):
         t"www.äpfel.com".punycode


### PR DESCRIPTION
Fixes #1046. `proximities.levenshteinDistance` returned `0` whenever the left
string was empty because the outer `for i <- 1 to m do` loop never executed
when `m == 0`, leaving the `dist` array at its zero-initialised default.
The seeded `old` array (`[0, 1, …, n]`) was never copied into `dist`.
Return `n` directly when `m == 0` — the algorithm is already correct for
`m >= 1`. Adds tests for empty-left, empty-right and both-empty inputs.

`proximities.levenshteinDistance` now correctly returns the length of the
non-empty string when one input is empty, matching the standard definition
of Levenshtein distance:

```scala
import gossamer.*, proximities.levenshteinDistance, caseSensitivity.sensitive

t"".proximity(t"abc")    // 3 (was 0)
t"abc".proximity(t"")    // 3
t"".proximity(t"")       // 0
```