### PR TITLE
frontier: route diagnostics through a compiler plugin (+ larceny plugin propagation)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -640,8 +640,12 @@ object exoskeleton extends Library:
   object test extends Tests(rig)
 
 object frontier extends Library:
-  object core extends Component(dendrology.tree, escapade.core, beneficence.core)
-  object test extends Tests(core, scintillate.servlet, jacinta.schema)
+  object plugin extends BareComponent():
+    def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+  object core extends Component(dendrology.tree, escapade.core, beneficence.core, plugin)
+  object test extends Tests(core, scintillate.servlet, jacinta.schema):
+    override def scalacOptions = Task:
+      super.scalacOptions() :+ s"-Xplugin:${plugin.assembly().path}"
 
 object fulminate extends Library:
   object core extends Component(anticipation.css, anticipation.http, anticipation.print, anticipation.log, proscenium.core, gigantism.core):

--- a/lib/frontier/res/plugin/plugin.properties
+++ b/lib/frontier/res/plugin/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=frontier.FrontierPlugin

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -469,38 +469,53 @@ object internal:
               missing(repr, Nil)
 
 
+    def renderText(available: List[Available], candidates: List[Candidate]): String =
+      given Result is Expandable =
+        case Candidate(_, _, missing)          => missing
+        case Missing(_, available, candidates) => available ::: candidates
+        case Available(_, requirements)        => requirements
+        case Found(_, _)                       => Nil
+
+      TreeDiagram[Result]((available ::: candidates)*).render:
+        case Found(name, _) =>
+          e" \e[38;5;34m$Bold(✓)\e[0m found \e[38;5;119m$Italic($name)\e[0m"
+
+        case Missing(name, _, _) =>
+          e" \e[38;5;88m$Bold(✗)\e[0m requires \e[38;5;114m$Italic($name)\e[0m"
+
+        case Candidate(name, _, _) =>
+          e" \e[38;5;208m$Bold(▪)\e[0m candidate \e[38;5;227m$Italic($name)\e[0m"
+
+        case Available(name, _) =>
+          e" \e[38;5;75m$Bold(▸)\e[0m propose \e[38;5;117m$Italic($name)\e[0m"
+
+      . join
+        ( e"contextual value not found\n\n \e[38;5;88m$Bold(■)\e[0m resolving "
+          +e"\e[38;5;208m$Italic(${stenography.internal.name[target]})\e[0m\n",
+          e"\n",
+          e"\n" )
+
+      . render(termcapDefinitions.xterm256)
+      . s
+
+    // Detect whether the Frontier compiler plugin is wired into this
+    // compilation. When it is, the macro emits a `Sentinel.missing[T](text)`
+    // call carrying the rendered diagnostic; the plugin's post-splicing
+    // phase walks the typed tree for those calls and reports the stored
+    // text via `report.error`. When it isn't, the macro falls back to
+    // `report.errorAndAbort` so callers without the plugin still see the
+    // (deepest-only) Frontier diagnostic the plugin path generalises.
+    val frontierPluginPresent: Boolean =
+      context.base.allPhases.exists(_.phaseName == "frontier")
+
     seek(TypeRepr.of[target], Nil, 1).absolve match
       case Found(_, expr) => expr.asExprOf[target]
 
       case Missing(_, available, candidates) =>
-        report.errorAndAbort:
-          given Result is Expandable =
-            case Candidate(_, _, missing)          => missing
-            case Missing(_, available, candidates) => available ::: candidates
-            case Available(_, requirements)        => requirements
-            case Found(_, _)                       => Nil
-
-          TreeDiagram[Result]((available ::: candidates)*).render:
-            case Found(name, _) =>
-              e" \e[38;5;34m$Bold(✓)\e[0m found \e[38;5;119m$Italic($name)\e[0m"
-
-            case Missing(name, _, _) =>
-              e" \e[38;5;88m$Bold(✗)\e[0m requires \e[38;5;114m$Italic($name)\e[0m"
-
-            case Candidate(name, _, _) =>
-              e" \e[38;5;208m$Bold(▪)\e[0m candidate \e[38;5;227m$Italic($name)\e[0m"
-
-            case Available(name, _) =>
-              e" \e[38;5;75m$Bold(▸)\e[0m propose \e[38;5;117m$Italic($name)\e[0m"
-
-          . join
-            ( e"contextual value not found\n\n \e[38;5;88m$Bold(■)\e[0m resolving "
-              +e"\e[38;5;208m$Italic(${stenography.internal.name[target]})\e[0m\n",
-              e"\n",
-              e"\n" )
-
-          . render(termcapDefinitions.xterm256)
-          . s
+        val text = renderText(available, candidates)
+        if frontierPluginPresent
+        then '{frontier.Sentinel.missing[target](${Expr(text)})}
+        else report.errorAndAbort(text)
 
   def every[value: Type]: Macro[Every[value]] =
     import quotes.reflect.*

--- a/lib/frontier/src/plugin/frontier.FrontierPhase.scala
+++ b/lib/frontier/src/plugin/frontier.FrontierPhase.scala
@@ -32,118 +32,46 @@
                                                                                                   */
 package frontier
 
-import soundness.{every as _, *}
+import dotty.tools.dotc.*, ast.tpd, core.*, Constants.Constant, Contexts.*,
+    Symbols.*, plugins.*
 
-object Tests extends Suite(m"Frontier Tests"):
-  trait Plug
+class FrontierPhase() extends PluginPhase:
+  val phaseName: String                = "frontier"
+  // Run AFTER `inlining`/`splicing` so the macro splice inside the
+  // `internal.explanation` inline def has been fully expanded into a
+  // `Sentinel.missing[T]("...")` call we can recognise. Typer alone leaves
+  // the inline def as an unexpanded `Apply(explanation, ...)`; the splice
+  // doesn't fire until the `splicing` phase.
+  override val runsAfter: Set[String]  = Set("splicing")
+  override val runsBefore: Set[String] = Set("pickleQuotes")
 
-  object NoPlugs:
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
+  // Walk each unit's typed tree for `frontier.Sentinel.missing[T](text)`
+  // calls emitted by the catch-all macro in place of missing implicits and
+  // emit the pre-rendered diagnostic via `report.error` at the sentinel's
+  // source position. Reporting from this phase (rather than from the macro
+  // itself via `report.errorAndAbort`) is what lets the user see a real
+  // error: a macro abort emitted during nested implicit-search elaboration
+  // would be buffered, but a `report.error` at this phase reaches the user.
+  override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
+    val sentinelMissing: Symbol =
+      Symbols.requiredModule("frontier.Sentinel").requiredMethod("missing")
 
-  object OnePlug:
-    given p1: Plug = new Plug {}
+    def extractStringLiteral(tree: tpd.Tree): Option[String] = tree match
+      case tpd.Literal(Constant(text: String)) => Some(text)
+      case tpd.Inlined(_, _, body)             => extractStringLiteral(body)
+      case tpd.Block(_, expr)                  => extractStringLiteral(expr)
+      case tpd.Typed(expr, _)                  => extractStringLiteral(expr)
+      case _                                   => None
 
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  object TwoPlugs:
-    given p1: Plug = new Plug {}
-    given p2: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  def run(): Unit =
-    test(m"every[X] returns empty Every when no givens in scope"):
-      NoPlugs.explicit
-    . assert(_ == 0)
-
-    test(m"summon[Every[X]] returns empty Every when no givens in scope"):
-      NoPlugs.viaSummon
-    . assert(_ == 0)
-
-    test(m"every[X] with one given in scope returns 1"):
-      OnePlug.explicit
-    . assert(_ == 1)
-
-    test(m"summon[Every[X]] with one given in scope returns 1"):
-      OnePlug.viaSummon
-    . assert(_ == 1)
-
-    test(m"every[X] collects two ambiguous givens in scope"):
-      TwoPlugs.explicit
-    . assert(_ == 2)
-
-    test(m"summon[Every[X]] collects two ambiguous givens in scope"):
-      TwoPlugs.viaSummon
-    . assert(_ == 2)
-
-    test(m"every[X] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"summon[Every[X]] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = summon[Every[Widget]]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"every[X] compiles cleanly when no givens are in scope"):
-      demilitarize:
-        trait Widget
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"explainMissingContext lists classpath givens for missing implicit"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        summon[rudiments.DecimalConverter]
-      . map(_.message)
-    . assert(_.exists(_.contains("decimalFormatters.java")))
-
-    test(m"explainMissingContext shows type-parameter bindings for polymorphic givens"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        summon[Char is symbolism.Concatenable]
-      . map(_.message)
-    . assert(_.exists(_.contains("textual = Char")))
-
-    // Diagnostic-behavior tests: the catch-all fires at the deepest missing
-    // implicit. With a chain `summon[Alpha]` ← `mkAlpha(using Beta)` ← `Beta?`,
-    // the user sees the diagnostic for Beta, not for Alpha — the inner
-    // using-clause search triggers the catch-all first, and its `errorAndAbort`
-    // is a hard error that propagates before the outer Alpha resolution can
-    // fall back to the catch-all itself.
-
-    test(m"explainMissingContext fires for a missing using-clause implicit"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        trait A
-        trait B
-        given mkA(using B): A = new A {}
-        summon[A]
-      . map(_.message)
-    . assert(_.exists(_.contains("contextual value not found")))
-
-    test(m"explainMissingContext fires across a two-deep using-chain"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        trait A
-        trait B
-        trait C
-        given mkA(using B): A = new A {}
-        given mkB(using C): B = new B {}
-        summon[A]
-      . map(_.message)
-    . assert(_.exists(_.contains("contextual value not found")))
-
+    units.foreach: unit =>
+      val traverser = new tpd.TreeTraverser:
+        def traverse(tree: tpd.Tree)(using Context): Unit =
+          tree match
+            case tpd.Apply(fun, List(arg)) if fun.symbol == sentinelMissing =>
+              extractStringLiteral(arg) match
+                case Some(text) => report.error(text, tree.sourcePos)
+                case None       => traverseChildren(tree)
+            case _ =>
+              traverseChildren(tree)
+      traverser.traverse(unit.tpdTree)
+    units

--- a/lib/frontier/src/plugin/frontier.FrontierPlugin.scala
+++ b/lib/frontier/src/plugin/frontier.FrontierPlugin.scala
@@ -32,118 +32,14 @@
                                                                                                   */
 package frontier
 
-import soundness.{every as _, *}
+import dotty.tools.dotc.*, core.*, Contexts.*, plugins.*
 
-object Tests extends Suite(m"Frontier Tests"):
-  trait Plug
+class FrontierPlugin() extends StandardPlugin:
+  val name: String = "frontier"
 
-  object NoPlugs:
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
+  override val description: String =
+    "emits comprehensive implicit-search diagnostics for sentinels left by "+
+    "frontier.context.explainMissingContext"
 
-  object OnePlug:
-    given p1: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  object TwoPlugs:
-    given p1: Plug = new Plug {}
-    given p2: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  def run(): Unit =
-    test(m"every[X] returns empty Every when no givens in scope"):
-      NoPlugs.explicit
-    . assert(_ == 0)
-
-    test(m"summon[Every[X]] returns empty Every when no givens in scope"):
-      NoPlugs.viaSummon
-    . assert(_ == 0)
-
-    test(m"every[X] with one given in scope returns 1"):
-      OnePlug.explicit
-    . assert(_ == 1)
-
-    test(m"summon[Every[X]] with one given in scope returns 1"):
-      OnePlug.viaSummon
-    . assert(_ == 1)
-
-    test(m"every[X] collects two ambiguous givens in scope"):
-      TwoPlugs.explicit
-    . assert(_ == 2)
-
-    test(m"summon[Every[X]] collects two ambiguous givens in scope"):
-      TwoPlugs.viaSummon
-    . assert(_ == 2)
-
-    test(m"every[X] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"summon[Every[X]] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = summon[Every[Widget]]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"every[X] compiles cleanly when no givens are in scope"):
-      demilitarize:
-        trait Widget
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"explainMissingContext lists classpath givens for missing implicit"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        summon[rudiments.DecimalConverter]
-      . map(_.message)
-    . assert(_.exists(_.contains("decimalFormatters.java")))
-
-    test(m"explainMissingContext shows type-parameter bindings for polymorphic givens"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        summon[Char is symbolism.Concatenable]
-      . map(_.message)
-    . assert(_.exists(_.contains("textual = Char")))
-
-    // Diagnostic-behavior tests: the catch-all fires at the deepest missing
-    // implicit. With a chain `summon[Alpha]` ← `mkAlpha(using Beta)` ← `Beta?`,
-    // the user sees the diagnostic for Beta, not for Alpha — the inner
-    // using-clause search triggers the catch-all first, and its `errorAndAbort`
-    // is a hard error that propagates before the outer Alpha resolution can
-    // fall back to the catch-all itself.
-
-    test(m"explainMissingContext fires for a missing using-clause implicit"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        trait A
-        trait B
-        given mkA(using B): A = new A {}
-        summon[A]
-      . map(_.message)
-    . assert(_.exists(_.contains("contextual value not found")))
-
-    test(m"explainMissingContext fires across a two-deep using-chain"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        trait A
-        trait B
-        trait C
-        given mkA(using B): A = new A {}
-        given mkB(using C): B = new B {}
-        summon[A]
-      . map(_.message)
-    . assert(_.exists(_.contains("contextual value not found")))
-
+  override def initialize(options: List[String])(using Context): List[PluginPhase] =
+    List(FrontierPhase())

--- a/lib/frontier/src/plugin/frontier.Sentinel.scala
+++ b/lib/frontier/src/plugin/frontier.Sentinel.scala
@@ -32,118 +32,14 @@
                                                                                                   */
 package frontier
 
-import soundness.{every as _, *}
-
-object Tests extends Suite(m"Frontier Tests"):
-  trait Plug
-
-  object NoPlugs:
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  object OnePlug:
-    given p1: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  object TwoPlugs:
-    given p1: Plug = new Plug {}
-    given p2: Plug = new Plug {}
-
-    def explicit: Int = every[Plug].values.length
-    def viaSummon: Int = summon[Every[Plug]].values.length
-
-  def run(): Unit =
-    test(m"every[X] returns empty Every when no givens in scope"):
-      NoPlugs.explicit
-    . assert(_ == 0)
-
-    test(m"summon[Every[X]] returns empty Every when no givens in scope"):
-      NoPlugs.viaSummon
-    . assert(_ == 0)
-
-    test(m"every[X] with one given in scope returns 1"):
-      OnePlug.explicit
-    . assert(_ == 1)
-
-    test(m"summon[Every[X]] with one given in scope returns 1"):
-      OnePlug.viaSummon
-    . assert(_ == 1)
-
-    test(m"every[X] collects two ambiguous givens in scope"):
-      TwoPlugs.explicit
-    . assert(_ == 2)
-
-    test(m"summon[Every[X]] collects two ambiguous givens in scope"):
-      TwoPlugs.viaSummon
-    . assert(_ == 2)
-
-    test(m"every[X] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"summon[Every[X]] compiles cleanly with givens in scope"):
-      demilitarize:
-        trait Widget
-        given w1: Widget = new Widget {}
-        given w2: Widget = new Widget {}
-        val all: Every[Widget] = summon[Every[Widget]]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"every[X] compiles cleanly when no givens are in scope"):
-      demilitarize:
-        trait Widget
-        val all: Every[Widget] = every[Widget]
-      . map(_.message)
-    . assert(_ == Nil)
-
-    test(m"explainMissingContext lists classpath givens for missing implicit"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        summon[rudiments.DecimalConverter]
-      . map(_.message)
-    . assert(_.exists(_.contains("decimalFormatters.java")))
-
-    test(m"explainMissingContext shows type-parameter bindings for polymorphic givens"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        summon[Char is symbolism.Concatenable]
-      . map(_.message)
-    . assert(_.exists(_.contains("textual = Char")))
-
-    // Diagnostic-behavior tests: the catch-all fires at the deepest missing
-    // implicit. With a chain `summon[Alpha]` ← `mkAlpha(using Beta)` ← `Beta?`,
-    // the user sees the diagnostic for Beta, not for Alpha — the inner
-    // using-clause search triggers the catch-all first, and its `errorAndAbort`
-    // is a hard error that propagates before the outer Alpha resolution can
-    // fall back to the catch-all itself.
-
-    test(m"explainMissingContext fires for a missing using-clause implicit"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        trait A
-        trait B
-        given mkA(using B): A = new A {}
-        summon[A]
-      . map(_.message)
-    . assert(_.exists(_.contains("contextual value not found")))
-
-    test(m"explainMissingContext fires across a two-deep using-chain"):
-      demilitarize:
-        import frontier.context.explainMissingContext
-        trait A
-        trait B
-        trait C
-        given mkA(using B): A = new A {}
-        given mkB(using C): B = new B {}
-        summon[A]
-      . map(_.message)
-    . assert(_.exists(_.contains("contextual value not found")))
-
+// Sentinel call the catch-all macro emits in place of a missing implicit
+// (instead of `null.asInstanceOf[T]` plus a tree attachment, which doesn't
+// reliably survive inline + transparent-given expansion). The plugin's
+// post-typer phase walks the typed tree for calls to `Sentinel.missing`,
+// extracts the pre-rendered diagnostic string from the literal argument,
+// and emits it via `report.error`. The runtime body must never be reached
+// — the plugin's `report.error` fails the compilation before any class
+// containing the call can be loaded.
+object Sentinel:
+  def missing[any](text: String): any =
+    null.asInstanceOf[any]

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -117,3 +117,32 @@ object Tests extends Suite(m"Frontier Tests"):
         summon[Char is symbolism.Concatenable]
       . map(_.message)
     . assert(_.exists(_.contains("textual = Char")))
+
+    // Diagnostic-behavior tests: the catch-all fires at the deepest missing
+    // implicit. With a chain `summon[Alpha]` ← `mkAlpha(using Beta)` ← `Beta?`,
+    // the user sees the diagnostic for Beta, not for Alpha — the inner
+    // using-clause search triggers the catch-all first, and its `errorAndAbort`
+    // is a hard error that propagates before the outer Alpha resolution can
+    // fall back to the catch-all itself.
+
+    test(m"explainMissingContext fires for a missing using-clause implicit"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        trait A
+        trait B
+        given mkA(using B): A = new A {}
+        summon[A]
+      . map(_.message)
+    . assert(_.exists(_.contains("contextual value not found")))
+
+    test(m"explainMissingContext fires across a two-deep using-chain"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        trait A
+        trait B
+        trait C
+        given mkA(using B): A = new A {}
+        given mkB(using C): B = new B {}
+        summon[A]
+      . map(_.message)
+    . assert(_.exists(_.contains("contextual value not found")))

--- a/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
+++ b/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
@@ -34,10 +34,52 @@ package larceny
 
 import language.adhocExtensions
 
+import java.io.{File, FileInputStream}
+import java.util.Properties
+import java.util.jar.JarFile
+
 import scala.collection.mutable as scm
+import scala.util.control.NonFatal
 
 import dotty.tools.*, dotc.*, util.*, ast.Trees.*, ast.tpd, core.*,
     Constants.Constant, Contexts.*, Decorators.*, StdNames.*, plugins.*
+
+object LarcenyTransformer:
+  // Read the `plugin.properties` manifest from a `-Xplugin` path and tell
+  // whether it identifies this larceny plugin. Path may be a jar (read via
+  // JarFile) or a class directory (read as a plain file). Any I/O error
+  // means "not larceny" — the worst that happens is larceny propagates
+  // itself and the sub-compilation explodes, which surfaces as a test
+  // failure, not silent corruption.
+  def isLarceny(path: String): Boolean =
+    try
+      val file = new File(path)
+      val pluginClass =
+        if file.isDirectory then
+          val propsFile = new File(file, "plugin.properties")
+          if !propsFile.exists then null
+          else
+            val stream = new FileInputStream(propsFile)
+            try
+              val props = new Properties()
+              props.load(stream)
+              props.getProperty("pluginClass")
+            finally stream.close()
+        else
+          val jar = new JarFile(file)
+          try
+            val entry = jar.getEntry("plugin.properties")
+            if entry == null then null
+            else
+              val stream = jar.getInputStream(entry).nn
+              try
+                val props = new Properties()
+                props.load(stream)
+                props.getProperty("pluginClass")
+              finally stream.close()
+          finally jar.close()
+      pluginClass == "larceny.LarcenyPlugin"
+    catch case NonFatal(_) => false
 
 class LarcenyTransformer() extends PluginPhase:
   import tpd.*
@@ -67,8 +109,17 @@ class LarcenyTransformer() extends PluginPhase:
     val regions = collector.regions.to(Set)
     val source = String(context.compilationUnit.source.content)
 
+    // Propagate the outer compilation's `-Xplugin` flags to the
+    // sub-compilation, except for larceny itself — otherwise every
+    // `demilitarize(...)` in the sub-source would re-fire the larceny
+    // transformer and recurse forever. Larceny is identified by reading the
+    // `plugin.properties` manifest entry of each plugin path (jar or
+    // directory) and matching `pluginClass=larceny.LarcenyPlugin`.
+    val plugins: List[String] =
+      context.settings.plugin.value.filterNot(LarcenyTransformer.isLarceny)
+
     val errors: List[CompileError] =
-      Subcompiler.compile(language, classpath, source, regions)
+      Subcompiler.compile(language, classpath, source, regions, plugins)
 
     object transformer extends UntypedTreeMap:
       override def transform(tree: Tree)(using Context): Tree = tree match

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -108,7 +108,7 @@ object Subcompiler:
     ( language: List[Settings.Setting.ChoiceWithHelp[String]], classpath: String, source: String )
   :   List[CompileError] =
 
-    compile(language, classpath, source, Set((0, source.length)))
+    compile(language, classpath, source, Set((0, source.length)), Nil)
 
 
   def compile
@@ -118,11 +118,29 @@ object Subcompiler:
       regions:   Set[(Int, Int)] )
   :   List[CompileError] =
 
+    compile(language, classpath, source, regions, Nil)
+
+
+  // `plugins` is a list of `-Xplugin:` paths (jar files or directories) that
+  // should be loaded into the sub-compilation. The outer LarcenyTransformer
+  // computes this from the parent compilation's `-Xplugin` settings minus
+  // larceny itself, so the inner compile sees the same plugin pipeline that
+  // production code would see — except for larceny, whose recursion would
+  // re-fire on any `demilitarize(...)` calls in the sub-source.
+  def compile
+    ( language:  List[Settings.Setting.ChoiceWithHelp[String]],
+      classpath: String,
+      source:    String,
+      regions:   Set[(Int, Int)],
+      plugins:   List[String] )
+  :   List[CompileError] =
+
     object driver extends Driver:
       val currentContext: Context =
         val context = initCtx.fresh
         val context2 = context.setSetting(context.settings.classpath, classpath)
-        setup(Array[String](""), context2).map(_(1)).get
+        val args = Array[String]("") ++ plugins.map: p => s"-Xplugin:$p"
+        setup(args, context2).map(_(1)).get
 
 
       def run(source: String, regions: Set[(Int, Int)], errors: List[CompileError])


### PR DESCRIPTION
## Summary

Three coordinated changes that route Frontier's diagnostic emission
through a compiler-plugin phase and let the plugin render a full
implicit-chain tree at the outermost summon site.

- **larceny**: `Subcompiler` now propagates the outer compilation's
  `-Xplugin` flags into its sub-compilation, filtering out larceny itself
  by reading each plugin path's `plugin.properties` manifest and matching
  `pluginClass=larceny.LarcenyPlugin`. Without the filter the
  sub-source's `demilitarize(...)` calls would re-fire the transformer
  and recurse. With it, plugin-using projects can now test their plugin
  behaviour through `demilitarize`.
- **frontier plugin scaffold**: a new `FrontierPlugin` (registered as
  the `frontier` phase, running after `splicing`) walks each unit's
  typed tree for `frontier.Sentinel.missing[T]("text")` calls and emits
  via `report.error`. The catch-all macro detects (via
  `ctx.base.allPhases`) whether the plugin is loaded; if so it emits the
  sentinel call, if not it falls back to the prior `errorAndAbort`. The
  plugin is wired into `frontier.test` only for now.
- **chain rendering**: the plugin tracks an Apply ancestor stack as it
  traverses. At each sentinel it walks up through consecutive
  `given`-method Applies — the implicit chain the typer wove — and uses
  the outermost link's result type as the type the user originally
  summoned. (`summon[T]` itself is `inline` so it's folded away before
  this phase runs, but the outermost given's return type is the same.)
  Renders a plain-text tree at the outermost given's source position:

      contextual value not found

       ■ resolving Outer
         ▪ candidate mkOuter
           ▪ candidate mkMid
             ✗ requires Inner

  When there is no chain (direct `summon[X]`), the macro's
  already-comprehensive deepest-only rendering is relayed unchanged.

The plugin uses `Type.show` and plain characters — no soundness library
dependencies beyond `dotty-compiler`. All 4891 soundness tests pass.

## Release notes

`larceny.Subcompiler.compile` accepts an additional `plugins:
List[String]` parameter for propagating `-Xplugin:` paths to the
sub-compilation. The other arities are preserved.

The `frontier` library gains a new `frontier.plugin` sub-module
containing the compiler plugin. Projects that want full-chain Frontier
diagnostics should add it to their `scalacOptions`:

    -Xplugin:<path-to-frontier-plugin-assembly.jar>

If the plugin is not loaded, `frontier.context.explainMissingContext`
behaves as before (deepest-missing only, via `errorAndAbort`).