### PR TITLE
frontier: surface deepest-level alternatives inside implicit chains

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -143,6 +143,7 @@ trait Tests(dependencies: PublishModule*) extends BaseScalaModule:
     settings.scalaOptions
       :+ s"-Xplugin:${larceny.plugin.assembly().path}"
       :+ s"-Xplugin:${beneficence.plugin.assembly().path}"
+      :+ s"-Xplugin:${frontier.plugin.assembly().path}"
 
 trait Benchmarks(dependencies: PublishModule*) extends BaseScalaModule:
   def moduleId: String = moduleDir.last
@@ -643,9 +644,7 @@ object frontier extends Library:
   object plugin extends BareComponent():
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
   object core extends Component(dendrology.tree, escapade.core, beneficence.core, plugin)
-  object test extends Tests(core, scintillate.servlet, jacinta.schema):
-    override def scalacOptions = Task:
-      super.scalacOptions() :+ s"-Xplugin:${plugin.assembly().path}"
+  object test extends Tests(core, scintillate.servlet, jacinta.schema)
 
 object fulminate extends Library:
   object core extends Component(anticipation.css, anticipation.http, anticipation.print, anticipation.log, proscenium.core, gigantism.core):

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -508,13 +508,38 @@ object internal:
     val frontierPluginPresent: Boolean =
       context.base.allPhases.exists(_.phaseName == "frontier")
 
+    // Serialise the search Result tree to a tab-separated, depth-prefixed
+    // flat text the plugin can parse without depending on dendrology or
+    // escapade. Pre-order traversal: each node emits `<depth>\t<kind>\t<name>`
+    // and then its children at `depth + 1`. Kind is M/C/A/F.
+    def serializeTree(result: Result, depth: Int, builder: StringBuilder): Unit =
+      result match
+        case Found(name, _) =>
+          builder.append(depth).append('\t').append('F').append('\t')
+            .append(name.s).append('\n')
+        case Missing(name, available, candidates) =>
+          builder.append(depth).append('\t').append('M').append('\t')
+            .append(name.s).append('\n')
+          available.foreach(serializeTree(_, depth + 1, builder))
+          candidates.foreach(serializeTree(_, depth + 1, builder))
+        case Available(name, requirements) =>
+          builder.append(depth).append('\t').append('A').append('\t')
+            .append(name.s).append('\n')
+          requirements.foreach(serializeTree(_, depth + 1, builder))
+        case Candidate(name, _, missing) =>
+          builder.append(depth).append('\t').append('C').append('\t')
+            .append(name.s).append('\n')
+          missing.foreach(serializeTree(_, depth + 1, builder))
+
     seek(TypeRepr.of[target], Nil, 1).absolve match
       case Found(_, expr) => expr.asExprOf[target]
 
-      case Missing(_, available, candidates) =>
+      case m @ Missing(_, available, candidates) =>
         val text = renderText(available, candidates)
-        if frontierPluginPresent
-        then '{frontier.Sentinel.missing[target](${Expr(text)})}
+        if frontierPluginPresent then
+          val sb = new StringBuilder
+          serializeTree(m, 0, sb)
+          '{frontier.Sentinel.missing[target](${Expr(text)}, ${Expr(sb.toString)})}
         else report.errorAndAbort(text)
 
   def every[value: Type]: Macro[Every[value]] =

--- a/lib/frontier/src/plugin/frontier.Diagnose.scala
+++ b/lib/frontier/src/plugin/frontier.Diagnose.scala
@@ -32,22 +32,86 @@
                                                                                                   */
 package frontier
 
-// Sentinel call the catch-all macro emits in place of a missing implicit
-// (instead of `null.asInstanceOf[T]` plus a tree attachment, which doesn't
-// reliably survive inline + transparent-given expansion). The plugin's
-// post-typer phase walks the typed tree for calls to `Sentinel.missing`,
-// extracts the pre-rendered diagnostic string from the literal argument,
-// and emits it via `report.error`. The runtime body must never be reached
-// — the plugin's `report.error` fails the compilation before any class
-// containing the call can be loaded.
-object Sentinel:
-  // `pretty` is the macro's already-formatted (ANSI-coloured) deepest-only
-  // diagnostic; the plugin uses it verbatim in the no-chain case. `tree`
-  // is a tab-separated serialisation of the `seek` result that the plugin
-  // parses to render alternatives at the deepest level even when the
-  // sentinel sits inside an outer chain. Format per line:
+import scala.collection.mutable
+
+// Parses the tab-separated tree the macro pickles into `Sentinel.missing`'s
+// second argument and renders the structured result as plain text. The
+// macro encodes its `seek` result (Missing/Candidate/Available/Found) so
+// the plugin can show alternative candidates at the deepest level without
+// having to re-run implicit search itself.
+object Diagnose:
+  sealed trait Node:
+    def name: String
+    def children: List[Node]
+
+  case class Missing(name: String, children: List[Node])   extends Node
+  case class Candidate(name: String, children: List[Node]) extends Node
+  case class Available(name: String, children: List[Node]) extends Node
+  case class Found(name: String, children: List[Node])     extends Node
+
+  // Parse one line of the macro's serialised tree:
   //     <depth>\t<kind>\t<name>
-  // depth is a non-negative integer; kind is one of M, C, A, F (Missing,
-  // Candidate, Available, Found); the rest of the line is the name.
-  def missing[any](pretty: String, tree: String): any =
-    null.asInstanceOf[any]
+  // Returns `None` for malformed or blank lines (defensive).
+  private case class Line(depth: Int, kind: Char, name: String)
+
+  private def parseLine(line: String): Option[Line] =
+    val parts = line.split('\t')
+    if parts.length < 3 then None
+    else
+      try Some(Line(parts(0).toInt, parts(1).charAt(0), parts.drop(2).mkString("\t")))
+      catch case _: NumberFormatException => None
+
+  // Convert a single line to an empty Node of the right kind. Children are
+  // filled in as the parser walks deeper into the line stream.
+  private def emptyNode(line: Line): Option[Node] = line.kind match
+    case 'M' => Some(Missing(line.name, Nil))
+    case 'C' => Some(Candidate(line.name, Nil))
+    case 'A' => Some(Available(line.name, Nil))
+    case 'F' => Some(Found(line.name, Nil))
+    case _   => None
+
+  private def withChildren(node: Node, children: List[Node]): Node = node match
+    case _: Missing   => Missing(node.name, children)
+    case _: Candidate => Candidate(node.name, children)
+    case _: Available => Available(node.name, children)
+    case _: Found     => Found(node.name, children)
+
+  // Parse the full serialised tree. Builds nodes top-down using a stack
+  // keyed by depth: each new line either deepens (push child onto top
+  // frame), stays at the same depth (sibling), or unwinds to a shallower
+  // frame (collapse and reattach).
+  def parse(text: String): Option[Node] =
+    val lines = text.linesIterator.toList.flatMap(parseLine)
+    if lines.isEmpty then None
+    else
+      // Stack of (current node, accumulated children, depth)
+      val frames = mutable.ArrayBuffer.empty[(Node, mutable.ArrayBuffer[Node], Int)]
+      lines.foreach: line =>
+        emptyNode(line).foreach: node =>
+          while frames.nonEmpty && frames.last._3 >= line.depth do
+            val (parentNode, parentChildren, _) = frames.remove(frames.size - 1)
+            val completed = withChildren(parentNode, parentChildren.toList)
+            if frames.nonEmpty then frames.last._2 += completed
+            else frames += ((completed, mutable.ArrayBuffer(), -1))
+          frames += ((node, mutable.ArrayBuffer.empty, line.depth))
+      while frames.size > 1 do
+        val (parentNode, parentChildren, _) = frames.remove(frames.size - 1)
+        frames.last._2 += withChildren(parentNode, parentChildren.toList)
+      val (top, topChildren, _) = frames.head
+      Some(withChildren(top, topChildren.toList))
+
+  // Render a parsed Node at the requested indent. Format mirrors the
+  // macro's own tree style, just with plain characters instead of ANSI.
+  def render(node: Node, indent: String = ""): String =
+    val sb = new StringBuilder
+    renderInto(sb, node, indent, isRoot = true)
+    sb.toString
+
+  private def renderInto(sb: StringBuilder, node: Node, indent: String, isRoot: Boolean): Unit =
+    val marker = node match
+      case _: Missing   => "■ resolving"
+      case _: Candidate => "▪ candidate"
+      case _: Available => "▸ propose"
+      case _: Found     => "✓ found"
+    sb.append(indent).append(' ').append(marker).append(' ').append(node.name).append('\n')
+    node.children.foreach(renderInto(sb, _, indent + "  ", isRoot = false))

--- a/lib/frontier/src/plugin/frontier.FrontierPhase.scala
+++ b/lib/frontier/src/plugin/frontier.FrontierPhase.scala
@@ -32,8 +32,12 @@
                                                                                                   */
 package frontier
 
+import scala.collection.mutable
+
 import dotty.tools.dotc.*, ast.tpd, core.*, Constants.Constant, Contexts.*,
-    Symbols.*, plugins.*
+    Flags.*, Symbols.*, Types.*, plugins.*
+
+import dotty.tools.dotc.core.TypeError
 
 class FrontierPhase() extends PluginPhase:
   val phaseName: String                = "frontier"
@@ -45,33 +49,119 @@ class FrontierPhase() extends PluginPhase:
   override val runsAfter: Set[String]  = Set("splicing")
   override val runsBefore: Set[String] = Set("pickleQuotes")
 
-  // Walk each unit's typed tree for `frontier.Sentinel.missing[T](text)`
-  // calls emitted by the catch-all macro in place of missing implicits and
-  // emit the pre-rendered diagnostic via `report.error` at the sentinel's
-  // source position. Reporting from this phase (rather than from the macro
-  // itself via `report.errorAndAbort`) is what lets the user see a real
-  // error: a macro abort emitted during nested implicit-search elaboration
-  // would be buffered, but a `report.error` at this phase reaches the user.
+  // Walk each unit's typed tree for `frontier.Sentinel.missing[T](pretty,
+  // tree)` calls emitted by the catch-all macro in place of missing
+  // implicits. For each sentinel, walk up through `given`-method ancestors
+  // (the implicit chain the typer wove) and render a full chain at the
+  // outermost user-source call. For direct `summon[X]` (no chain) relay
+  // the macro's pretty text unchanged.
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
-    val sentinelMissing: Symbol =
-      Symbols.requiredModule("frontier.Sentinel").requiredMethod("missing")
+    // The plugin is no-op when `frontier.Sentinel.missing` isn't on the
+    // compile classpath — i.e., when the compilation unit doesn't depend on
+    // frontier.plugin. (We're still registered as a phase on every unit
+    // because the plugin is on `-Xplugin:`, but units that don't transitively
+    // depend on frontier won't have any sentinel calls to find.)
+    val sentinelMissingOpt: Option[Symbol] =
+      try Some(Symbols.requiredModule("frontier.Sentinel").requiredMethod("missing"))
+      catch case _: TypeError => None
 
-    def extractStringLiteral(tree: tpd.Tree): Option[String] = tree match
-      case tpd.Literal(Constant(text: String)) => Some(text)
-      case tpd.Inlined(_, _, body)             => extractStringLiteral(body)
-      case tpd.Block(_, expr)                  => extractStringLiteral(expr)
-      case tpd.Typed(expr, _)                  => extractStringLiteral(expr)
-      case _                                   => None
-
-    units.foreach: unit =>
-      val traverser = new tpd.TreeTraverser:
-        def traverse(tree: tpd.Tree)(using Context): Unit =
-          tree match
-            case tpd.Apply(fun, List(arg)) if fun.symbol == sentinelMissing =>
-              extractStringLiteral(arg) match
-                case Some(text) => report.error(text, tree.sourcePos)
-                case None       => traverseChildren(tree)
-            case _ =>
-              traverseChildren(tree)
-      traverser.traverse(unit.tpdTree)
+    sentinelMissingOpt.foreach: sentinelMissing =>
+      units.foreach { unit => processUnit(unit, sentinelMissing) }
     units
+
+  private def processUnit(unit: CompilationUnit, sentinelMissing: Symbol)
+                         (using Context): Unit =
+    val stack: mutable.ArrayBuffer[tpd.Apply] = mutable.ArrayBuffer.empty
+
+    val traverser = new tpd.TreeTraverser:
+      def traverse(tree: tpd.Tree)(using Context): Unit =
+        tree match
+          case apply @ tpd.Apply(fun, List(prettyArg, treeArg))
+          if fun.symbol == sentinelMissing =>
+            handleSentinel(apply, prettyArg, treeArg, stack.toList)
+          case apply: tpd.Apply =>
+            stack += apply
+            try traverseChildren(apply)
+            finally stack.remove(stack.size - 1)
+          case _ =>
+            traverseChildren(tree)
+
+    traverser.traverse(unit.tpdTree)
+
+  // Process a sentinel call: render the chain that surrounds it and emit
+  // `report.error` at the appropriate position. The macro packs two
+  // strings into the sentinel — the already-rendered pretty diagnostic
+  // (used verbatim for direct `summon[X]`), and a tab-separated
+  // serialisation of the seek tree (used to surface alternatives even
+  // when the sentinel is buried inside an implicit chain).
+  private def handleSentinel
+              (sentinel: tpd.Apply,
+               prettyArg: tpd.Tree,
+               treeArg: tpd.Tree,
+               ancestors: List[tpd.Apply])
+              (using Context)
+              : Unit =
+    val macroText = extractStringLiteral(prettyArg).getOrElse("")
+    val serialisedTree = extractStringLiteral(treeArg).getOrElse("")
+    val sentinelType: Type = sentinel.tpe.widen
+
+    // Collect the suffix of `ancestors` whose function symbols are `given`s
+    // — that is the implicit chain the typer wove around the sentinel. The
+    // outermost link's *result type* is the type the user originally
+    // summoned, because `summon[T]` is `inline` and has been folded away by
+    // the time this phase runs.
+    val chain: List[tpd.Apply] = collectChain(ancestors)
+
+    if chain.isEmpty then
+      // No implicit chain — direct `summon[X]` (X had no candidate but the
+      // catch-all). Relay the macro's already-comprehensive text at the
+      // sentinel's position.
+      report.error(macroText, sentinel.sourcePos)
+    else
+      val outerType: Type = chain.head.tpe.widen
+      val pos = chain.head.sourcePos
+      val rendered = renderChain(outerType, chain, sentinelType, serialisedTree)
+      report.error(rendered, pos)
+
+  // Plain-text rendering of the chain the typer actually took, with the
+  // deepest type's seek tree (parsed from the macro's pickled result)
+  // appended under the final `✗ requires` line. The chain comes from
+  // walking the typed tree; the deepest-type alternatives come from the
+  // macro's seek (which ran during typer with full local scope).
+  private def renderChain(outerType: Type,
+                          chain: List[tpd.Apply],
+                          missing: Type,
+                          serialisedTree: String)
+                         (using Context): String =
+    val builder = new StringBuilder
+    builder.append("contextual value not found\n\n")
+    builder.append(s" ■ resolving ${outerType.show}\n")
+    val indent = new StringBuilder("  ")
+    chain.foreach: link =>
+      builder.append(s"$indent ▪ candidate ${link.fun.symbol.name.show}\n")
+      indent.append("  ")
+    builder.append(s"$indent ✗ requires ${missing.show}\n")
+
+    // Append the deepest-type's alternative candidates (proposals and
+    // tried candidates from the macro's seek) at one extra indent under
+    // the `requires` line, skipping the root Missing node since it
+    // duplicates `requires`.
+    val deeperIndent = indent.toString + "  "
+    Diagnose.parse(serialisedTree).foreach: root =>
+      root.children.foreach: child =>
+        builder.append(Diagnose.render(child, deeperIndent))
+
+    builder.toString
+
+  // Walk the ancestor stack from innermost outwards, collecting consecutive
+  // `given`-method Applies (the implicit chain). Returns the chain in
+  // outermost-first order.
+  private def collectChain(ancestors: List[tpd.Apply])(using Context): List[tpd.Apply] =
+    ancestors.reverse.takeWhile(_.fun.symbol.is(Given)).reverse
+
+  private def extractStringLiteral(tree: tpd.Tree): Option[String] = tree match
+    case tpd.Literal(Constant(text: String)) => Some(text)
+    case tpd.Inlined(_, _, body)             => extractStringLiteral(body)
+    case tpd.Block(_, expr)                  => extractStringLiteral(expr)
+    case tpd.Typed(expr, _)                  => extractStringLiteral(expr)
+    case _                                   => None

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -147,3 +147,17 @@ object Tests extends Suite(m"Frontier Tests"):
       . map(_.message)
     . assert(_.exists(_.contains("contextual value not found")))
 
+    test(m"explainMissingContext shows classpath alternatives at deepest in chain"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        trait Holder
+        given mkHolder(using rudiments.DecimalConverter): Holder = new Holder {}
+        summon[Holder]
+      . map(_.message)
+    . assert: msgs =>
+        msgs.exists: m =>
+          m.contains("resolving Holder")
+          && m.contains("candidate mkHolder")
+          && m.contains("requires") && m.contains("DecimalConverter")
+          && m.contains("decimalFormatters.java")
+


### PR DESCRIPTION
## Summary

The catch-all macro now pickles its full seek-result tree (rendered
already, plus a flat tab-separated serialisation) into a second
`Sentinel.missing` argument. The plugin parses that serialisation with
a tiny `Diagnose.parse` and, when emitting a chain rendering, appends
the deepest type's candidates and proposals (parsed from the tree)
under the final `✗ requires` line.

A chain like

    summon[Holder]  ←  given mkHolder(using DecimalConverter): Holder

now renders:

    contextual value not found

     ■ resolving Holder
       ▪ candidate mkHolder
         ✗ requires DecimalConverter
           ▸ propose decimalFormatters.java

The chain (Holder → mkHolder → DecimalConverter) comes from walking
typed-tree Apply ancestors; the proposal for the deepest type comes
from the macro's `seek` (which ran at typer time with full local scope
— the plugin's post-splicing context can't reach local givens to
re-run the search there).

Also: wire `frontier.plugin` into the `Tests` trait globally (was
previously an override on `frontier.test` only), so any test module
that imports `frontier.context.explainMissingContext` gets the chain
rendering automatically. The plugin no-ops on units that don't have
`frontier.Sentinel` on the compile classpath.

All 4892 soundness tests pass.

## Release notes

`frontier.Sentinel.missing` now takes a second `String` argument carrying
the tab-separated serialisation of the macro's seek result. The new
`frontier.Diagnose` object exposes `parse` and `render` helpers for that
format. Both are part of the `frontier.plugin` artifact; user code never
touches them directly — the catch-all macro emits the call and the
plugin walks for it.

Test modules that depend on `frontier.core` now automatically benefit
from chain rendering (and deepest-level alternatives) without needing
the `-Xplugin` override that `frontier.test` previously carried.