### PR TITLE
frontier: enable plugin in Component trait; relocate phase after pickleQuotes

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -129,6 +129,7 @@ extends BaseScalaModule, SonatypeCentralPublishModule:
     settings.scalaOptions
       :+ s"-Xplugin:${decorum.plugin.assembly().path}"
       :+ s"-Xplugin:${beneficence.plugin.assembly().path}"
+      :+ s"-Xplugin:${frontier.plugin.assembly().path}"
 
 trait Tests(dependencies: PublishModule*) extends BaseScalaModule:
   def moduleId: String = moduleDir.last

--- a/lib/frontier/src/plugin/frontier.FrontierPhase.scala
+++ b/lib/frontier/src/plugin/frontier.FrontierPhase.scala
@@ -41,13 +41,15 @@ import dotty.tools.dotc.core.TypeError
 
 class FrontierPhase() extends PluginPhase:
   val phaseName: String                = "frontier"
-  // Run AFTER `inlining`/`splicing` so the macro splice inside the
-  // `internal.explanation` inline def has been fully expanded into a
-  // `Sentinel.missing[T]("...")` call we can recognise. Typer alone leaves
-  // the inline def as an unexpanded `Apply(explanation, ...)`; the splice
-  // doesn't fire until the `splicing` phase.
-  override val runsAfter: Set[String]  = Set("splicing")
-  override val runsBefore: Set[String] = Set("pickleQuotes")
+  // Run AFTER `pickleQuotes` (which comes after `splicing`) so quoted
+  // expression bodies — e.g. the literal `'{Sentinel.missing[T](...)}`
+  // inside the macro's *own source* — are pickled into opaque blobs
+  // before we walk the tree. Without that, the plugin matches the Apply
+  // nodes inside those quotes when compiling `frontier.core` itself and
+  // treats them as real sentinel calls. After pickleQuotes, only
+  // expanded user-site Apply nodes remain.
+  override val runsAfter: Set[String]  = Set("pickleQuotes")
+  override val runsBefore: Set[String] = Set("crossVersionChecks")
 
   // Walk each unit's typed tree for `frontier.Sentinel.missing[T](pretty,
   // tree)` calls emitted by the catch-all macro in place of missing


### PR DESCRIPTION
## Summary

Add `-Xplugin:frontier.plugin.assembly()` to the `Component` trait so
every library module compiles with the plugin loaded. The plugin no-ops
on units that don't have `frontier.Sentinel` on the classpath, so this
is behavior-preserving for modules that don't import the catch-all —
but for any module that does (including downstream user code that
depends on `frontier.core`), failed implicit search now routes through
Frontier's diagnostic without needing per-module scalacOptions
overrides.

This exposed an existing bug: the plugin was running between `splicing`
and `pickleQuotes`, which meant compiling `frontier.core` itself, the
plugin saw the Apply nodes *inside* the macro's own
`'{Sentinel.missing[T](...)}` quote literal and treated them as real
sentinel calls. Move the phase to run after `pickleQuotes` so quoted
bodies have already been pickled into opaque blobs by the time we
walk the tree.

All 4892 soundness tests pass.

## Release notes

The Frontier compiler plugin is now wired into the `Component` trait
alongside `decorum` and `beneficence`, so every soundness Library
module compiles with it loaded by default. Production code that
imports `frontier.context.explainMissingContext` (or the equivalent
`soundness.context.explainMissingContext`) automatically gets the
chain-aware diagnostic; no per-module `-Xplugin` override needed.