### PR TITLE
frontier: handle bare Candidate/Available in outer match (#1031)

### DIFF
--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -531,16 +531,34 @@ object internal:
             .append(name.s).append('\n')
           missing.foreach(serializeTree(_, depth + 1, builder))
 
-    seek(TypeRepr.of[target], Nil, 1).absolve match
-      case Found(_, expr) => expr.asExprOf[target]
+    // Funnel any non-Found seek result through the same render/emit
+    // pipeline. `seek` is declared to return any of `Found`, `Missing`,
+    // `Candidate`, or `Available`; a bare `Candidate` escapes via the
+    // SafeInlined+TypeApply branch (#1031). Wrap such bare nodes in a
+    // synthetic `Missing` using the user's target type so the renderer
+    // and serialiser get the outer "■ resolving <target>" framing they
+    // need. `Available` doesn't escape today but the wrapping is cheap
+    // defence against future drift in `seek`.
+    def emit(m: Missing): Expr[target] =
+      val text = renderText(m.available, m.candidates)
+      if frontierPluginPresent then
+        val sb = new StringBuilder
+        serializeTree(m, 0, sb)
+        '{frontier.Sentinel.missing[target](${Expr(text)}, ${Expr(sb.toString)})}
+      else report.errorAndAbort(text)
 
-      case m @ Missing(_, available, candidates) =>
-        val text = renderText(available, candidates)
-        if frontierPluginPresent then
-          val sb = new StringBuilder
-          serializeTree(m, 0, sb)
-          '{frontier.Sentinel.missing[target](${Expr(text)}, ${Expr(sb.toString)})}
-        else report.errorAndAbort(text)
+    seek(TypeRepr.of[target], Nil, 1).absolve match
+      case Found(_, expr) =>
+        expr.asExprOf[target]
+
+      case m: Missing =>
+        emit(m)
+
+      case c: Candidate =>
+        emit(Missing(stenography.internal.name[target], Nil, List(c)))
+
+      case a: Available =>
+        emit(Missing(stenography.internal.name[target], List(a), Nil))
 
   def every[value: Type]: Macro[Every[value]] =
     import quotes.reflect.*


### PR DESCRIPTION
## Summary

\`seek\` can return any of \`Found\`, \`Missing\`, \`Candidate\`, or
\`Available\`, but the outer \`seek(...).absolve match\` in
\`frontier.internal.explain\` only handled the first two. When the
implicit-search failure tree is an \`Inlined\` wrapping a
non-\`explainMissingContext\` \`TypeApply\` (typical when the failing
search happens inside an expanded inline method), \`seek\` returns a
bare \`Candidate(...)\` from the \`SafeInlined\` branch and the
non-exhaustive match crashes the compiler with
\`scala.MatchError: Candidate(???, ...)\`.

Introduce a small \`emit(m: Missing)\` helper that holds the existing
render/serialise/Sentinel-or-errorAndAbort plumbing, then add arms
that wrap bare \`Candidate\`/\`Available\` into a synthetic \`Missing\`
using the user's target type name. \`renderText\` and \`serializeTree\`
already know how to walk all four kinds; the wrapping just gives the
\`■ resolving <target>\` framing they need at the root.

\`Available\` doesn't escape from \`seek\` today (it's only constructed
inside \`Missing.available\`), but the wrapping is cheap defence
against future drift.

The narrow reproducer in #1031 (turbulence's \`read[Text]\` inside a
\`path.open\` lambda with a path-dependent target type) didn't reduce
to a small synthetic test in a few attempts; fix correctness is
verified by inspection (exhaustive over the sealed \`Result\` trait).

All 4892 soundness tests pass.

Fixes #1031.

## Release notes

Fixes a \`scala.MatchError\` crash in
\`frontier.context.explainMissingContext\`'s macro expansion when the
failing implicit search occurs inside an expanded inline method.