### PR TITLE
escapade: stack traces via StackTrace.Palette + Escritoire

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -473,7 +473,7 @@ object denominative extends Library:
   object test extends Tests(core)
 
 object digression extends Library:
-  object core extends Component(contingency.core)
+  object core extends Component(contingency.core, iridescence.core)
   object test extends Tests(core)
 
 object dissonance extends Library:
@@ -497,7 +497,7 @@ object enigmatic extends Library:
   object test extends Tests(core)
 
 object escapade extends Library:
-  object core extends Component(anticipation.gfx, gossamer.core, turbulence.core, anticipation.url, iridescence.core)
+  object core extends Component(anticipation.gfx, gossamer.core, turbulence.core, anticipation.url, iridescence.core, escritoire.core)
   object test extends Tests(core, yossarian.core)
   object bench extends Benchmarks(core, quantitative.units)
 

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -34,6 +34,8 @@ package digression
 
 import anticipation.*
 import fulminate.*
+import iridescence.*
+import prepositional.*
 import proscenium.*
 import rudiments.*
 import symbolism.*
@@ -47,6 +49,36 @@ object StackTrace:
     lazy val prefix: Text = if pivot >= 0 then className.s.substring(0, pivot).nn.tt else "".tt
 
   case class Frame(method: Method, file: Text, line: Optional[Int], native: Boolean)
+
+  trait Palette extends iridescence.Palette:
+    type Form = Srgb
+    def message:   Color in Srgb
+    def file:      Color in Srgb
+    def method:    Color in Srgb
+    def line:      Color in Srgb
+    def separator: Color in Srgb
+    def accent1:   Color in Srgb
+    def accent2:   Color in Srgb
+    def accent3:   Color in Srgb
+    def accent4:   Color in Srgb
+    def accent5:   Color in Srgb
+
+  private def hex(n: Int): Color in Srgb =
+    Srgb(((n >> 16) & 255)/255.0, ((n >> 8) & 255)/255.0, (n & 255)/255.0)
+
+  given defaultPalette: StackTrace.Palette = new Palette:
+    def background: Color in Srgb = hex(0x000000)
+    def foreground: Color in Srgb = hex(0xffffff)
+    def message:    Color in Srgb = hex(0xffffff)
+    def file:       Color in Srgb = hex(0x5f9e9f)
+    def method:     Color in Srgb = hex(0xabcfdf)
+    def line:       Color in Srgb = hex(0x47d1cc)
+    def separator:  Color in Srgb = hex(0x808080)
+    def accent1:    Color in Srgb = hex(0xf84020)
+    def accent2:    Color in Srgb = hex(0xd88600)
+    def accent3:    Color in Srgb = hex(0xfefe00)
+    def accent4:    Color in Srgb = hex(0xfeae00)
+    def accent5:    Color in Srgb = hex(0xaefe00)
 
   val legend: Map[Text, Text] =
     Map

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -34,9 +34,11 @@ package escapade
 
 import anticipation.*
 import digression.*
+import escritoire.*
 import fulminate.*
 import gossamer.*
 import hieroglyph.*
+import iridescence.*
 import prepositional.*
 import proscenium.*
 import spectacular.*
@@ -82,87 +84,112 @@ object Teletypeable:
 
         append(e"\n")
 
-  given stackTrace: (Text is Measurable) => StackTrace is Teletypeable = stack =>
-    def heat(level: Int): Chroma = Chroma:
-      level match
-        case 0 => 0xf84020
-        case 1 => 0xd88600
-        case 2 => 0xfefe00
-        case 3 => 0xfeae00
-        case _ => 0xaefe00
+  given stackTrace: (Text is Measurable) => (palette: StackTrace.Palette)
+  =>  StackTrace is Teletypeable = stack =>
 
+    def accent(level: Int): Color in Srgb =
+      palette.selectDynamic(s"accent${(level % 5) + 1}")
 
     def dedup[element](todo: List[element], seen: Set[element] = Set(), done: List[element] = Nil)
     :   List[element] =
 
       todo match
-        case Nil => done
+        case Nil          => done.reverse
 
         case head :: tail =>
           if seen.contains(head) then dedup(tail, seen, done)
           else dedup(tail, seen + head, head :: done)
 
-
-    val packages: Map[Text, Chroma] =
+    val packages: Map[Text, Color in Srgb] =
       dedup[Text](stack.frames.map(_.method.prefix), Set(), Nil)
-      . zipWithIndex.map(_ -> heat(_))
+      . zipWithIndex.map: (prefix, index) =>
+          prefix -> accent(index)
+
       . to(Map)
 
-    val methodWidth = stack.frames.map(_.method.method.length).maxOption.getOrElse(0)
-    val classWidth = stack.frames.map(_.method.className.length).maxOption.getOrElse(0)
-    val fileWidth = stack.frames.map(_.file.length).maxOption.getOrElse(0)
     val fullClass = e"$Italic(${stack.component}.$Bold(${stack.className}))"
-    val init = e"${Fg(Chroma(0xffffff))}($fullClass): ${stack.message}"
+    val init = e"${palette.message}($fullClass): ${stack.message}"
 
-    var lastClass: Text = t""
-    var lastFile: Text = t""
+    case class Row(frame: StackTrace.Frame, sameClass: Boolean, sameFile: Boolean)
 
-    val root = stack.frames.foldLeft(init):
-      case (msg, frame) =>
-        val obj = frame.method.cls.starts(t"Ξ")
-        val methodCls = if obj then frame.method.cls.skip(1) else frame.method.cls
-        val file = e"${Fg(Chroma(0x5f9e9f))}(${frame.file.fit(fileWidth, Rtl)})"
-        val dot = if obj then t" . " else t" ⌗ "
+    val rows: List[Row] =
+      stack.frames.foldLeft((List.empty[Row], t"", t"")):
+        case ((acc, lastClass, lastFile), frame) =>
+          val sameClass = frame.method.className == lastClass
+          val sameFile = frame.file == lastFile
+          (Row(frame, sameClass, sameFile) :: acc, frame.method.className, frame.file)
 
-        val sameClass = frame.method.className == lastClass
-        lastClass = frame.method.className
+      . _1.reverse
 
-        val gray = Fg(Chroma(0x808080))
+    def classCell(row: Row): Teletype =
+      val frame = row.frame
+      val obj = frame.method.cls.starts(t"Ξ")
+      val methodCls = if obj then frame.method.cls.skip(1) else frame.method.cls
+      val color = packages(frame.method.prefix)
 
-        val className =
-          val color = packages(frame.method.prefix)
-          if sameClass
-          then
-            e"${Fg(Chroma(0x222222))}(${frame.method.prefix}.$methodCls)"
-            . fit(classWidth, Rtl)
-          else
-            val halfColor = Fg(Chroma(color.underlying/2))
-            e"$halfColor(${frame.method.prefix}.$Bold(${Fg(color)}($methodCls)))"
-            . fit(classWidth, Rtl)
+      if row.sameClass
+      then e"${palette.subdue(color, 0.85)}(${frame.method.prefix}.$methodCls)"
+      else
+        e"${palette.subdue(color, 0.5)}(${frame.method.prefix}.$Bold($color($methodCls)))"
 
-        val method = e"${Fg(Chroma(0xabcfdf))}(${frame.method.method.fit(methodWidth)})"
-        val line = e"${Fg(Chroma(0x47d1cc))}(${frame.line.let(_.show).or(t"")})"
-        val sameFile = frame.file == lastFile
-        lastFile = frame.file
-        val file2 = frame.file.fit(fileWidth, Rtl)
+    def dotCell(row: Row): Teletype =
+      val ch = if row.frame.method.cls.starts(t"Ξ") then t"." else t"⌗"
+      e"${palette.separator}($ch)"
 
-        val foreground = Fg(Chroma(if sameFile then 0x111111 else 0x5faeaf))
-        e"$msg\n  $gray(at) $className$gray($dot)$method $foreground($file2)$gray(:)$line"
+    def methodCell(row: Row): Teletype =
+      e"${palette.method}(${row.frame.method.method})"
+
+    def fileCell(row: Row): Teletype =
+      val color = if row.sameFile then palette.subdue(palette.file, 0.85) else palette.file
+      e"$color(${row.frame.file})"
+
+    def lineCell(row: Row): Teletype =
+      e"${palette.line}(${row.frame.line.let(_.show).or(t"")})"
+
+    val scaffold =
+      Scaffold[Row]
+        ( Column(e"")(_ => e"${palette.separator}(at)"),
+          Column(e"", textAlign = TextAlignment.Right)(classCell),
+          Column(e"")(dotCell),
+          Column(e"")(methodCell),
+          Column(e"", textAlign = TextAlignment.Right)(fileCell),
+          Column(e"")(_ => e"${palette.separator}(:)"),
+          Column(e"", textAlign = TextAlignment.Right)(lineCell) )
+
+    given style: TableStyle =
+      TableStyle
+        ( padding    = 0,
+          topLine    = Unset,
+          bottomLine = Unset,
+          titleLine  = Unset,
+          sideLines  = BoxLine.Blank,
+          innerLines = BoxLine.Blank,
+          charset    = LineCharset.Default )
+
+    given attenuation: Attenuation = columnAttenuation.ignore
+
+    val grid = scaffold.tabulate(rows).grid(200)
+    val dataOnly = grid.copy(sections = grid.sections.tail)
+    val tableLines = dataOnly.render.to(List)
+
+    val root = (init :: tableLines).join(e"\n")
 
     stack.cause.lay(root): cause =>
-      e"$root\n${Fg(Chroma(0xffffff))}(caused by:)\n$cause"
+      e"$root\n${palette.message}(caused by:)\n$cause"
 
-  given frame: (Text is Measurable) => StackTrace.Frame is Teletypeable = frame =>
-    val className = e"${Fg(Chroma(0xc61485))}(${frame.method.className.fit(40, Rtl)})"
-    val method = e"${Fg(Chroma(0xdb6f92))}(${frame.method.method.fit(40)})"
-    val file = e"${Fg(Chroma(0x5f9e9f))}(${frame.file.fit(18, Rtl)})"
-    val line = e"${Fg(Chroma(0x47d1cc))}(${frame.line.let(_.show).or(t"?")})"
-    e"$className${Fg(Chroma(0x808080))}( ⌗ )$method $file${Fg(Chroma(0x808080))}(:)$line"
+  given frame: (Text is Measurable) => (palette: StackTrace.Palette)
+  =>  StackTrace.Frame is Teletypeable = frame =>
 
-  given method: StackTrace.Method is Teletypeable = method =>
-    val className = e"${Fg(Chroma(0xc61485))}(${method.className})"
-    val methodName = e"${Fg(Chroma(0xdb6f92))}(${method.method})"
-    e"$className${Fg(Chroma(0x808080))}( ⌗ )$methodName"
+    val className = e"${palette.method}(${frame.method.className.fit(40, Rtl)})"
+    val method = e"${palette.method}(${frame.method.method.fit(40)})"
+    val file = e"${palette.file}(${frame.file.fit(18, Rtl)})"
+    val line = e"${palette.line}(${frame.line.let(_.show).or(t"?")})"
+    e"$className${palette.separator}( ⌗ )$method $file${palette.separator}(:)$line"
+
+  given method: (palette: StackTrace.Palette) => StackTrace.Method is Teletypeable = method =>
+    val className = e"${palette.method}(${method.className})"
+    val methodName = e"${palette.method}(${method.method})"
+    e"$className${palette.separator}( ⌗ )$methodName"
 
   given double: (decimalizer: Decimalizer) => Double is Teletypeable = double =>
     Teletype.styled(decimalizer.decimalize(double))(_.copy(fg = Chroma(0xffd600)))


### PR DESCRIPTION
Stack-trace rendering now goes through a `StackTrace.Palette` typeclass with semantic colour slots, replacing the hardcoded hex cycle and `Int/2` bit-shift dimming. Per-package highlights rotate through five palette accents; faded variants for repeated class names and same-file rows blend perceptually toward the palette background via `palette.subdue(color, ratio)`. The per-frame column layout now uses an Escritoire `Scaffold` with a borderless table style, replacing the hand-rolled `.fit(width, Rtl)` arithmetic.

## Stack-trace palette

Stack traces respond to a `StackTrace.Palette`, a refinement of `iridescence.Palette` with slots for `message`, `file`, `method`, `line`, `separator`, and five rotating `accent` colours used for per-package highlighting. A `defaultPalette` ships in `object StackTrace` and is discoverable wherever `StackTrace.*` types appear, so existing call sites keep working with no source changes.

To customise:

```scala
given StackTrace.Palette = new StackTrace.Palette:
  def background = Srgb(0, 0, 0)
  def foreground = Srgb(1, 1, 1)
  def message    = Srgb(1, 1, 1)
  def file       = Srgb(0.4, 0.6, 0.6)
  // ...accents and remaining slots
```

## Perceptual fades

Repeated class names and same-file rows now fade via `palette.subdue(color, ratio)`, which blends in sRGB space toward `palette.background`. The previous `color.underlying/2` halved each channel independently as a packed `0xRRGGBB` int, which could shift hue when channels were unequal.

## Module deps

`escapade.core` gains a build dep on `escritoire.core`; `digression.core` gains a build dep on `iridescence.core`, since `StackTrace.Palette` lives in the `StackTrace` companion.