### PR TITLE
stenography: fix stack overflow on recursive types

### DIFF
--- a/lib/stenography/src/core/stenography.Bindings.scala
+++ b/lib/stenography/src/core/stenography.Bindings.scala
@@ -32,87 +32,27 @@
                                                                                                   */
 package stenography
 
-import scala.quoted.*
+import java.util.IdentityHashMap
+
+import scala.collection.mutable as scm
 
 import anticipation.*
-import gigantism.*
-import proscenium.*
 
-object internal:
-  import dotty.tools.dotc.*
+final class Bindings:
+  private val names = IdentityHashMap[AnyRef, Text]()
+  private val counters = scm.HashMap[Text, Int]()
+  private[stenography] val cache = scm.HashMap[Any, Syntax]()
 
-  def typename[typename <: AnyKind: Type]: Macro[Text] = Expr(name[typename])
+  def nameFor(binder: Matchable, candidate: => Text): Text =
+    val key = binder.asInstanceOf[AnyRef]
+    val existing = names.get(key)
 
-  def name(using Quotes)(typeRepr: quotes.reflect.TypeRepr): Text =
-    typeRepr.asType.absolve match case '[tpe] => name[tpe]
+    if existing != null then existing
+    else
+      val base = candidate
+      val n = counters.getOrElse(base, 0)
+      counters(base) = n + 1
+      val fresh = if n == 0 then base else s"$base${n + 1}".tt
+      names.put(key, fresh)
 
-  def name[typename <: AnyKind: Type](using Quotes): Text =
-    import quotes.reflect.*
-
-    given Bindings = Bindings()
-
-    val outer: List[Typename] = quotes.absolve match
-      case quotes: runtime.impl.QuotesImpl =>
-        given context: core.Contexts.Context = quotes.ctx
-
-        context.compilationUnit.tpdTree.absolve match
-          case ast.tpd.PackageDef(root, statements) =>
-            Typename(root.show) :: statements.collect:
-              case ast.tpd.Import(name, _) => Typename(name.show)
-
-          case _ =>
-            Nil
-
-      case _ => Nil
-
-    val imports: Set[Typename] = metaprogramming.imports.map(_.term).map(Syntax.term(_)).to(Set)
-
-    // Build the `direct` set by drilling into every wildcard import that's in
-    // scope (including REPL-accumulated imports across earlier lines, captured
-    // by `metaprogramming.imports`) and collecting type aliases carrying the
-    // `Exported` flag. Those aliases' *target* types are reachable via just
-    // their leaf in the current scope, so we render them that way.
-    val direct: Set[Typename] = quotes.absolve match
-      case quotes: runtime.impl.QuotesImpl =>
-        given context: core.Contexts.Context = quotes.ctx
-
-        metaprogramming.imports.filter(_.wildcard).flatMap: imp =>
-          val rootSym = imp.term.asInstanceOf[core.Types.Type].termSymbol(using context)
-
-          if !rootSym.exists then Nil
-          else exportedTargets(rootSym)
-
-        .toSet
-
-      case _ => Set.empty[Typename]
-
-    given Imports =
-      Imports(Set(Typename("scala"), Typename("scala.Predef")) ++ imports ++ outer, direct)
-
-    Syntax(TypeRepr.of[typename]).text
-
-  private def exportedTargets(using Quotes, dotty.tools.dotc.core.Contexts.Context)
-    ( rootSym: dotty.tools.dotc.core.Symbols.Symbol )
-  :   List[Typename] =
-
-    import dotty.tools.dotc.core.{Flags, Types}
-    import quotes.reflect.TypeRepr
-
-    // Top-level definitions in a package are stored inside synthetic
-    // `<filename>$package` classes; export forwarders for types live there.
-    val directDecls = rootSym.info.decls.toList
-    val packageClasses = directDecls.filter(_.name.toString.endsWith("$package"))
-    val nestedDecls = packageClasses.flatMap(_.info.decls.toList)
-
-    (directDecls ++ nestedDecls).filter(_.is(Flags.Exported)).flatMap: decl =>
-      decl.info match
-        case alias: Types.TypeAlias =>
-          Syntax(alias.alias.asInstanceOf[TypeRepr]) match
-            // Add both forms so the same import path can shorten references
-            // to either the type itself or its companion (e.g. `Textual` and
-            // `Textual.foo` both resolve via `import soundness.*`).
-            case Syntax.Simple(typename) => List(typename, typename.companionObject)
-            case _                       => Nil
-
-        case _ =>
-          Nil
+      fresh

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -33,7 +33,6 @@
 package stenography
 
 import scala.collection.immutable.ListMap
-import scala.collection.mutable as scm
 import scala.quoted.*
 
 import anticipation.*
@@ -56,15 +55,27 @@ object Syntax:
   val CloseType: Symbolic = Symbolic("]")
   val Plus: Symbolic = Symbolic("+")
   val Minus: Symbolic = Symbolic("-")
-  private val cache: scm.HashMap[Any, Syntax] = scm.HashMap()
-
-  def clear(): Unit = cache.clear()
 
   def symbolic(name: Text): Symbolic =
     Symbolic(if name.s.startsWith("_$") then name.s.drop(2).tt else name)
 
 
-  def typeBounds(using Quotes)
+  private def candidateName(using Quotes)(rt: quotes.reflect.RecursiveType): Text =
+    import quotes.reflect.*
+
+    def base(repr: TypeRepr): String = repr.absolve match
+      case Refinement(parent, _, _) => base(parent)
+      case AppliedType(tycon, _)    => base(tycon)
+      case TypeRef(_, name)         => name
+      case other                    => other.typeSymbol.name
+
+    val raw = base(rt.underlying)
+
+    if raw.isEmpty then "self".tt
+    else (raw.head.toLower.toString + raw.drop(1)).tt
+
+
+  def typeBounds(using Quotes, Bindings)
     ( sub: Syntax, lower: quotes.reflect.TypeRepr, upper: quotes.reflect.TypeRepr )
   :   Syntax =
 
@@ -78,7 +89,9 @@ object Syntax:
     else Infix(Infix(sub, ">:", apply(lower)), "<:", apply(upper))
 
 
-  def contextBounds(using Quotes)(clauses: List[quotes.reflect.ParamClause]): Map[Text, Syntax] =
+  def contextBounds(using Quotes, Bindings)(clauses: List[quotes.reflect.ParamClause])
+  :   Map[Text, Syntax] =
+
     import quotes.reflect.*
 
     clauses.flatMap:
@@ -105,7 +118,7 @@ object Syntax:
     . to(Map)
 
 
-  def clause(using Quotes)
+  def clause(using Quotes, Bindings)
     ( clause: quotes.reflect.ParamClause, showUsing: Boolean, context: Map[Text, Syntax] )
   :   Syntax =
 
@@ -157,7 +170,7 @@ object Syntax:
         Sequence('[', items)
 
 
-  def signature(using Quotes)(name: Text, repr: quotes.reflect.TypeRepr): Declaration =
+  def signature(using Quotes, Bindings)(name: Text, repr: quotes.reflect.TypeRepr): Declaration =
     import quotes.reflect.*
 
     repr.absolve match
@@ -182,13 +195,16 @@ object Syntax:
       case other =>
         Declaration(true, List(), apply(other))
 
-  def term(using Quotes)(repr: quotes.reflect.TermRef): Typename = apply(repr) match
+  def term(using Quotes, Bindings)(repr: quotes.reflect.TermRef): Typename = apply(repr) match
     case Value(value) => value
     case _            => panic(m"expected a Value")
 
 
-  def apply(using Quotes)(repr: quotes.reflect.TypeRepr, retry: Boolean = true): Syntax =
-    cache.establish(repr):
+  def apply(using Quotes)(using bindings: Bindings = Bindings())
+    ( repr: quotes.reflect.TypeRepr, retry: Boolean = true )
+  :   Syntax =
+
+    bindings.cache.establish(repr):
       import quotes.reflect.*
 
       def isPackage(name: String): Boolean = name.endsWith("$package") || name == "package"
@@ -385,11 +401,12 @@ object Syntax:
             case PolyType(params, _, _)   => symbolic(params(n))
             case other                    => Primitive("ParamRef")
 
-        case RecursiveType(tpe) =>
-          apply(tpe)
+        case rt@RecursiveType(body) =>
+          bindings.nameFor(rt, candidateName(rt))
+          apply(body)
 
-        case RecursiveThis(tpe) =>
-          apply(tpe)
+        case RecursiveThis(binder) =>
+          Symbolic(bindings.nameFor(binder, candidateName(binder)))
 
         case repr =>
           if retry then apply(repr.typeSymbol.typeRef, false) else Primitive("<unknown>")


### PR DESCRIPTION
Rendering a TASTy type that contained a `RecursiveType` (a self-referential structural type, with `RecursiveThis` back-edges in its body) would loop endlessly in `Syntax.apply` until the JVM ran out of stack. The fix names each recursive binder once, on identity, and emits that name where the body references it; the cache moves into a per-call `Bindings` so cached subtrees cannot leak names from another traversal.

### Recursive type rendering no longer stack-overflows

`Syntax.name[T]` and `Syntax(typeRepr)` now terminate on types that, in TASTy, are encoded as `RecursiveType` — typically structural refinements whose member signatures back-reference the parent's `this.type`. Each recursive binder receives a deterministic, readable name derived from the underlying type (lower-cased first letter, with a numeric suffix when the same base appears more than once in a single rendering).

### Internal API change

The helpers in `stenography.Syntax` (`apply`, `signature`, `typeBounds`, `term`, `clause`, `contextBounds`) now take an additional contextual `Bindings` parameter. A default `Bindings = Bindings()` on `apply` keeps existing call sites source-compatible.