### PR TITLE
jacinta: emit RFC 6901-compliant JSON pointers in errors

### DIFF
--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -51,6 +51,7 @@ import panopticon.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
+import serpentine.*
 import spectacular.*
 import symbolism.*
 import turbulence.*
@@ -111,7 +112,13 @@ trait Json2:
 
             build: [field] =>
               context =>
-                focus(prior.or(JsonPointer()) / label):
+                focus({
+                  val base = prior.or(JsonPointer())
+                  JsonPointer
+                    ( base.url,
+                      Path[JsonPointer, JsonPointer.type, Tuple]
+                        ( base.path.root, base.path.descent :+ label ) )
+                }):
                   values.get(label.s) match
                     case Some(value) => context.decoded(new Json(value))
                     case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
@@ -138,11 +145,18 @@ trait Json2:
           val values: scm.ArrayBuffer[Json.Ast] = scm.ArrayBuffer()
 
           fields(value): [field] =>
-            field => focus(prior.or(JsonPointer()) / label):
-              contextual.encode(field).root.tap: encoded =>
-                if !encoded.isAbsent then
-                  labels += label.s
-                  values += encoded
+            field =>
+              focus({
+                val base = prior.or(JsonPointer())
+                JsonPointer
+                  ( base.url,
+                    Path[JsonPointer, JsonPointer.type, Tuple]
+                      ( base.path.root, base.path.descent :+ label ) )
+              }):
+                contextual.encode(field).root.tap: encoded =>
+                  if !encoded.isAbsent then
+                    labels += label.s
+                    values += encoded
 
           Json.ast
             ( Json.Ast.obj
@@ -469,7 +483,13 @@ object Json extends Json2, Dynamic:
       val builder = factory.newBuilder
 
       value.root.array.each: json =>
-        focus(prior.or(JsonPointer()) / ordinal):
+        focus({
+          val base = prior.or(JsonPointer())
+          JsonPointer
+            ( base.url,
+              Path[JsonPointer, JsonPointer.type, Tuple]
+                ( base.path.root, base.path.descent :+ ordinal.n0.toString.tt ) )
+        }):
           builder += decodable.decoded(Json.ast(json))
 
       builder.result()

--- a/lib/jacinta/src/core/jacinta.JsonPointer.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPointer.scala
@@ -71,7 +71,9 @@ object JsonPointer extends Root(""):
     val separator: Text = "/"
 
   given JsonPointer is Encodable in Text = pointer =>
-    t"${pointer.url.let(_.encode).or(t"")}#${pointer.path}"
+    val url = pointer.url.let(_.encode).or(t"")
+    if pointer.path.descent.length == 0 then t"$url#"
+    else t"$url#/${pointer.path}"
 
   given divisible: JsonPointer is Divisible by Text to JsonPointer =
     (pointer, segment) => JsonPointer(pointer.url, pointer.path / segment)

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -82,7 +82,7 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
       test(m"Pointers identify the missing fields"):
         val json = t"""{"name": "Alice"}""".read[Json]
         validateJson(json)(_.as[VPerson]).items.map(_(0).s).to(Set)
-      . assert(_ == Set("#age", "#email"))
+      . assert(_ == Set("#/age", "#/email"))
 
       test(m"Each missing-field error has reason Absent"):
         val json = t"""{"name": "Alice"}""".read[Json]
@@ -104,7 +104,7 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
       test(m"Pointers identify the wrong-type fields"):
         val json = t"""{"name": 42, "age": "thirty", "email": "x@y"}""".read[Json]
         validateJson(json)(_.as[VPerson]).items.map(_(0).s).to(Set)
-      . assert(_ == Set("#name", "#age"))
+      . assert(_ == Set("#/name", "#/age"))
 
       test(m"Wrong-type errors have reason NotType"):
         val json = t"""{"name": 42, "age": "thirty", "email": "x@y"}""".read[Json]
@@ -123,35 +123,26 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
       test(m"One wrong-type + two missing: three errors at the right pointers"):
         val json = t"""{"name": 42}""".read[Json]
         validateJson(json)(_.as[VPerson]).items.map(_(0).s).to(Set)
-      . assert(_ == Set("#name", "#age", "#email"))
+      . assert(_ == Set("#/name", "#/age", "#/email"))
 
-    // The encoder for a nested JsonPointer currently emits the segments
-    // leaf-first rather than root-first (e.g. "#city/address" rather than
-    // "#address/city"). This appears to be a pre-existing pre-encoding bug
-    // in jacinta's DecodableDerivation: nested `focus(prior / label)`
-    // supplements run leaf-first, and `prior / "outer"` appends "outer"
-    // at the leaf instead of prepending it. The tracking machinery itself
-    // works — every nested error is accrued with a pointer; the segment
-    // order is just reversed. The assertions below match the current
-    // behaviour.
     suite(m"Nested case-class errors"):
       test(m"Nested object's missing field reports both segments"):
         val json = t"""{"person": {"name": "X", "age": 1, "email": "y@z"},
                         "address": {"street": "S"}}""".read[Json]
         validateJson(json)(_.as[VContact]).items.map(_(0).s).to(Set)
-      . assert(_ == Set("#city/address", "#zip/address"))
+      . assert(_ == Set("#/address/city", "#/address/zip"))
 
       test(m"Nested wrong-type field reports both segments"):
         val json = t"""{"person": {"name": "C", "age": 25, "email": "c@x"},
                         "address": {"street": "X", "city": 999, "zip": "Z"}}""".read[Json]
         validateJson(json)(_.as[VContact]).items.map(_(0).s).to(Set)
-      . assert(_ == Set("#city/address"))
+      . assert(_ == Set("#/address/city"))
 
       test(m"Mixed errors at different depths accrue together"):
         val json = t"""{"person": {"name": "D"},
                         "address": {"street": "X", "city": "Y", "zip": "Z"}}""".read[Json]
         validateJson(json)(_.as[VContact]).items.map(_(0).s).to(Set)
-      . assert(_ == Set("#age/person", "#email/person"))
+      . assert(_ == Set("#/person/age", "#/person/email"))
 
       test(m"Errors accumulate across both nested objects"):
         val json = t"""{"person": {"name": 1, "age": "x", "email": false},


### PR DESCRIPTION
Closes #1104 and #1105. `JsonPointer.encode` now produces the leading `/`
required by RFC 6901, and `DecodableDerivation` no longer reverses the
segment order of nested-field error pointers — together the two bugs
were turning a `/address/city` pointer into `#city/address`.

## JSON Pointers

`JsonPointer.encode` now returns RFC 6901-compliant text:

```scala
JsonPointer() / t"address" / t"city"  // before: "#city/address"
                                       // after:  "#/address/city"
```

Validation errors accrued by `case-class is Decodable in Json` derivation
now identify the failing field with the correct, root-first pointer:

```scala
case class Address(street: Text, city: Text, zip: Text)
case class Contact(person: Person, address: Address)

// decoding {"person": ..., "address": {"street": "S"}} now reports
// the missing fields at #/address/city and #/address/zip (previously
// #city/address and #zip/address).
```