### PR TITLE
stenography: render match types, super, and into annotation

### DIFF
--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -272,8 +272,7 @@ object Syntax:
               Primitive("<unknown>")
 
         case AnnotatedType(tpe, annotation) =>
-          // FIXME: We don't have access to `into` information, so this is a hack
-          if annotation.toString.contains("object annotation),into)")
+          if annotation.tpe.typeSymbol == Symbol.classSymbol("scala.annotation.internal.$into")
           then Prefix("into", apply(tpe))
           else apply(tpe)
 
@@ -408,6 +407,22 @@ object Syntax:
         case RecursiveThis(binder) =>
           Symbolic(bindings.nameFor(binder, candidateName(binder)))
 
+        case MatchType(_, scrutinee, cases) =>
+          def renderCase(case0: TypeRepr): Syntax = case0.absolve match
+            case TypeLambda(_, _, body) => renderCase(body)
+            case other                  => apply(other)
+
+          Syntax.Match(apply(scrutinee), cases.map(renderCase))
+
+        case MatchCase(pattern, rhs) =>
+          Prefix("case", Infix(apply(pattern), "=>", apply(rhs)))
+
+        case SuperType(_, _) =>
+          Symbolic("super")
+
+        case NoPrefix() =>
+          Primitive("")
+
         case repr =>
           if retry then apply(repr.typeSymbol.typeRef, false) else Primitive("<unknown>")
 
@@ -427,12 +442,14 @@ enum Syntax:
   case Declaration(method: Boolean, syntaxes: List[Syntax], result: Syntax)
   case Value(typename: Typename)
   case Compound(syntaxes: List[Syntax])
+  case Match(scrutinee: Syntax, cases: List[Syntax])
 
   def precedence: Int = this match
     case Structural(_, _, _)  => 0
     case Prefix(_, _)         => 0
     case Named(_, _, _)       => 0
     case Suffix(_, _)         => 0
+    case Match(_, _)          => 10
     case Infix(_, "<:", _)    => 10
     case Infix(_, ">:", _)    => 10
     case Projection(_, _)     => 9
@@ -474,6 +491,9 @@ enum Syntax:
     case Sequence('{', elements) => s"{${elements.map(_.text).mkString(", ")}}".tt
     case Value(typename)         => s"${typename.text}.type".tt
     case Compound(syntaxes)      => syntaxes.map(_.text).mkString.tt
+
+    case Match(scrutinee, cases) =>
+      s"${scrutinee.text} match { ${cases.map(_.text).mkString("; ")} }".tt
 
     case Declaration(method, syntaxes, result) =>
       s"${syntaxes.map(_.text).mkString}${if method then ": " else ""}${result.text}".tt

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -108,6 +108,49 @@ object Tests extends Suite(m"Stenography Tests"):
       Syntax.name[4.2F]
     . assert(_ == t"4.2F")
 
+    test(m"Show constant Boolean true type"):
+      Syntax.name[true]
+    . assert(_ == t"true")
+
+    test(m"Show constant Boolean false type"):
+      Syntax.name[false]
+    . assert(_ == t"false")
+
+    test(m"Show constant Char type"):
+      Syntax.name['a']
+    . assert(_ == t"'a'")
+
+    test(m"Show wildcard type argument"):
+      Syntax.name[List[?]]
+    . assert(_ == t"collection.immutable.List[?]")
+
+    test(m"Show upper-bounded wildcard"):
+      Syntax.name[List[? <: AnyRef]]
+    . assert(_ == t"collection.immutable.List[? <: AnyRef]")
+
+    test(m"Show lower-bounded wildcard"):
+      Syntax.name[List[? >: String]]
+    . assert(_ == t"collection.immutable.List[? >: String]")
+
+    test(m"Show wildcard with both bounds"):
+      Syntax.name[List[? >: String <: AnyRef]]
+    . assert(_ == t"collection.immutable.List[? >: String <: AnyRef]")
+
+    test(m"Show into-annotated type"):
+      Syntax.name[Int @scala.annotation.internal.$into]
+    . assert(_ == t"into Int")
+
+    test(m"Show match type"):
+      Syntax.name[[scrutinee] =>> scrutinee match
+        case String => Char
+        case Int    => Boolean]
+    . assert(_ == t"[scrutinee] =>> scrutinee match { case String => Char; case Int => Boolean }")
+
+    test(m"Show match type with parametric case"):
+      Syntax.name[[scrutinee] =>> scrutinee match
+        case List[item] => item]
+    . assert(_ == t"[scrutinee] =>> scrutinee match { case collection.immutable.List[item] => item }")
+
     test(m"Show singleton type"):
       Syntax.name[None.type]
     . assert(_ == t"None.type")


### PR DESCRIPTION
Four `TypeRepr` kinds previously fell into the catch-all in `Syntax.apply` and lost their structure: `MatchType`, `MatchCase`, `SuperType`, and a bare `NoPrefix`. The `AnnotatedType` handling for `into` also relied on a string match against the annotation's `toString`. This commit adds explicit handlers for each, replaces the `toString` hack with a direct symbol comparison, and extends the test suite to cover both the new handlers and several previously-handled-but-untested kinds.

### Match types now render

```scala
Syntax.name[[X] =>> X match
  case String     => Char
  case List[item] => item]
// "[X] =>> X match { case String => Char; case collection.immutable.List[item] => item }"
```

`SuperType` now renders as `super` and combines with the existing `TypeRef` prefix path to produce `super.Foo`. A bare `NoPrefix` renders to the empty string instead of falling into the catch-all.

### `into` detection is no longer a string match

`AnnotatedType` previously detected `scala.annotation.internal.$into` by substring-matching the annotation's `toString`. It now compares the annotation's type symbol against `Symbol.classSymbol(...)` directly.

### New tests

Coverage added for Char and Boolean `ConstantType`s, wildcards with upper, lower, and both bounds, `into`-annotated types, and match types with constant and parametric cases (57 tests total, up from 47).