### PR TITLE
profanity/exoskeleton/ethereal: fix off-by-1e6 await timeouts

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -507,7 +507,7 @@ object escritoire extends Library:
     override def enabled = false
 
 object ethereal extends Library:
-  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core):
+  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, quantitative.units):
     val rustTargets: Seq[(String, String, String)] = Seq(
       ("x86_64-pc-windows-gnu",       "windows-x64",   "runner.exe"),
       ("x86_64-unknown-linux-gnu",    "linux-x64",     "runner"),
@@ -588,7 +588,7 @@ object exegesis extends Library:
   object test extends Tests(core)
 
 object exoskeleton extends Library:
-  object args extends Component(escapade.core, profanity.core, ambience.core)
+  object args extends Component(escapade.core, profanity.core, ambience.core, quantitative.units)
   object core extends Component(args, galilei.core)
   object completions extends Component(core)
 
@@ -820,7 +820,7 @@ object probably extends Library:
   object test extends Tests(cli)
 
 object profanity extends Library:
-  object core extends Component(eucalyptus.core, diuretic.core, iridescence.core)
+  object core extends Component(eucalyptus.core, diuretic.core, iridescence.core, quantitative.units)
   object test extends Tests(core, exoskeleton.rig)
 
 object punctuation extends Library:

--- a/lib/ethereal/src/core/ethereal.Client.scala
+++ b/lib/ethereal/src/core/ethereal.Client.scala
@@ -37,17 +37,16 @@ import language.experimental.pureFunctions
 import java.io as ji
 import java.nio.channels as jnc
 
-import anticipation.*
 import contingency.*
 import exoskeleton.*
 import guillotine.*
 import parasite.*
 import prepositional.*
 import proscenium.*
+import quantitative.*
 import rudiments.*
+import symbolism.*
 import turbulence.*
-
-import anticipation.abstractables.durationIsAbstractable
 
 object Client:
   @targetName("make")
@@ -68,4 +67,4 @@ case class Client(pid: Pid) extends Topical:
 
   val socket: Promise[jnc.SocketChannel] = Promise()
 
-  def close(): Unit = safely(socket.await(1000L).close())
+  def close(): Unit = safely(socket.await(1.0*Second).close())

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -62,6 +62,7 @@ import parasite.*
 import prepositional.*
 import profanity.*
 import proscenium.*
+import quantitative.*
 import rudiments.*
 import serpentine.*
 import spectacular.*
@@ -70,7 +71,6 @@ import symbolism.*
 import turbulence.*
 import vacuous.*
 
-import anticipation.abstractables.durationIsAbstractable
 import filesystemOptions.createNonexistent.enabled
 import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.deleteRecursively.enabled
@@ -228,7 +228,7 @@ def cli[bus <: Matchable](using executive: Executive)
   val socketFile: Path on Local = baseDir/name/"socket"
   val clients: scc.TrieMap[Pid, Client of bus] = scc.TrieMap()
   val terminatePid: Promise[Pid] = Promise()
-  val idleTimeout: Long = 6L*60L*60L*1_000_000_000L
+  val idleTimeout = 6.0*Hour
 
   def client(pid: Pid): Client of bus = clients.getOrElseUpdate(pid, Client[bus](pid))
 
@@ -316,7 +316,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
           val response: SignalResponse =
             safely:
-              val invocation = client(pid).invocation.await(250L*1_000_000L)
+              val invocation = client(pid).invocation.await(250.0*Milli(Second))
               invocation.dispatchSignal(signal)
 
             . or(SignalResponse.Reject)

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -41,10 +41,10 @@ import denominative.*
 import gossamer.*
 import parasite.*
 import profanity.*
+import quantitative.*
 import rudiments.*
+import symbolism.*
 import vacuous.*
-
-import abstractables.durationIsAbstractable
 
 object Cli:
   private var messages: List[Text] = Nil
@@ -56,7 +56,7 @@ object Cli:
 
   def done(): Unit = trigger.offer(())
   def log(input: Text): Unit = messages ::= input
-  def await(): List[Text] = safely(trigger.await(10000L)) yet messages.reverse
+  def await(): List[Text] = safely(trigger.await(10.0*Second)) yet messages.reverse
 
 
   def arguments

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -39,10 +39,10 @@ import gossamer.*
 import hypotenuse.*
 import parasite.*
 import proscenium.*
+import quantitative.*
 import spectacular.*
+import symbolism.*
 import vacuous.*
-
-import abstractables.durationIsAbstractable
 
 object Keyboard:
   import Keypress.*
@@ -82,7 +82,7 @@ object Keyboard:
 
     def process(stream: Stream[Char]): Stream[Keypress] = stream match
       case '\u001b' #:: rest =>
-        safely(async(rest.head).await(30L)) match
+        safely(async(rest.head).await(30.0*Milli(Second))) match
           case Unset => Keypress.Escape #:: process(rest)
 
           case _ => rest match

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -37,11 +37,11 @@ import contingency.*
 import gossamer.*
 import iridescence.*
 import parasite.*
+import quantitative.*
 import rudiments.*
+import symbolism.*
 import turbulence.*
 import vacuous.*
-
-import abstractables.durationIsAbstractable
 
 object Terminal:
   def reportBackground: Text = t"\e]11;?\e\\"
@@ -64,8 +64,8 @@ extends Interactivity[TerminalEvent]:
   var rows: Optional[Int] = Unset
   var columns: Optional[Int] = Unset
 
-  def knownColumns: Int = columns.or(safely(columns0.await(50L))).or(80)
-  def knownRows: Int = rows.or(safely(rows0.await(50L))).or(80)
+  def knownColumns: Int = columns.or(safely(columns0.await(50.0*Milli(Second)))).or(80)
+  def knownRows: Int = rows.or(safely(rows0.await(50.0*Milli(Second)))).or(80)
 
   val cap: Termcap = new Termcap:
     def ansi: Boolean = true


### PR DESCRIPTION
Six `await` / `Timeout` call sites in `profanity`, `exoskeleton`, and `ethereal` passed raw `Long` literals where a `Quantity`-typed duration was expected. Because the in-scope `Long is Abstractable across Durations to Long` instance interprets `Long` as nanoseconds, every such site was effectively waiting one million times less than intended (50 ns instead of 50 ms, 10 µs instead of 10 s, etc.). The most visible consequence was that `Terminal.knownColumns` and `knownRows` never observed the CSI 8;rows;cols reply from the terminal, so any consumer reading them on entry to an `interactive:` block saw the 80-column fallback. Each site now uses a `Quantity`-typed literal, routing the conversion through `Quantity`'s `genericDuration` `Abstractable`, which correctly scales seconds to nanoseconds.

### Bug fix

Six timeouts in `profanity`, `exoskeleton`, and `ethereal` were silently waiting nanoseconds where they intended milliseconds (or seconds, or hours):

| Site | Was | Now |
| --- | --- | --- |
| `profanity.Terminal.knownColumns` / `knownRows` | `50L` | `50.0*Milli(Second)` |
| `profanity.Keyboard.Standard.process` (escape disambiguation) | `30L` | `30.0*Milli(Second)` |
| `ethereal.Client.close` | `1000L` | `1.0*Second` |
| `ethereal_core` daemon signal dispatch | `250L*1_000_000L` | `250.0*Milli(Second)` |
| `ethereal_core` daemon `idleTimeout` | `6L*60L*60L*1_000_000_000L` | `6.0*Hour` |
| `exoskeleton.Cli.await` | `10000L` | `10.0*Second` |

The fix replaces each with a `Quantity`-typed literal, matching the convention already used in the parasite tests:

```scala
// before — intended 50 ms, actually 50 ns
columns0.await(50L)

// after — 50 ms, as documented
columns0.await(50.0*Milli(Second))
```

Closes #1112.