### PR TITLE
exoskeleton: fix completion crash when focus argument is missing

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -142,7 +142,8 @@ extends Cli:
         List(Suggestion(Flag.serialize(flag.name), flag.description, aliases =
           flag.aliases.map(Flag.serialize(_))))
 
-  def focusText: Text = arguments.find(_.position == currentArgument).get.value
+  def focusText: Text =
+    arguments.find(_.position == currentArgument).fold(t"")(_.value)
 
   def serialize: List[Text] =
     val items0 =

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -400,3 +400,11 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           test(m"fish incomplete suggestion emits LCP duplicate"):
             sh"$tool '{completions}' fish 3 0 /dev/null -- abcd tree --at ".exec[Text]()
           .check(_.cut(t"\n").count(_.starts(t"src/")) >= 2)
+
+          // Regression check for #1109: with focus0 = 0 and position0 = 0 the
+          // completions executive previously hit a `.get` on an empty Option in
+          // `Completion.focusText` and dumped the stack trace to stdout (which
+          // fish then displayed as completion candidates).
+          test(m"fish focus=0 does not throw NoSuchElementException"):
+            sh"$tool '{completions}' fish 0 0 /dev/null -- abcd".exec[Text]()
+          .check(!_.contains(t"NoSuchElementException"))

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -403,8 +403,12 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
           // Regression check for #1109: with focus0 = 0 and position0 = 0 the
           // completions executive previously hit a `.get` on an empty Option in
-          // `Completion.focusText` and dumped the stack trace to stdout (which
-          // fish then displayed as completion candidates).
-          test(m"fish focus=0 does not throw NoSuchElementException"):
-            sh"$tool '{completions}' fish 0 0 /dev/null -- abcd".exec[Text]()
-          .check(!_.contains(t"NoSuchElementException"))
+          // `Completion.focusText`. With the `stackTrace` backstop in user
+          // deployments that dumped the Java stack trace to stdout (which fish
+          // then displayed as completion candidates); under the test suite's
+          // `silent` backstop the daemon exits non-zero instead. Either way,
+          // the focusText call should not throw, so the daemon should exit
+          // cleanly.
+          test(m"fish focus=0 exits cleanly"):
+            sh"$tool '{completions}' fish 0 0 /dev/null -- abcd".exec[Exit]()
+          .assert(_ == Exit.Ok)


### PR DESCRIPTION
`exoskeleton.Completion.focusText` called `.get` on the `Option` returned by `arguments.find`. When the completions executive ended up with an empty arguments list and `currentArgument = -1` — which fish can produce on real `<TAB>` completions in some setups — this threw `NoSuchElementException`. The exception bubbled up to ethereal's daemon, where the user-configured `stackTrace` backstop printed the formatted Java trace to stdout — exactly the stream fish reads completion candidates from — so users saw a colour-coded stack trace in place of completions. `focusText` is now total, returning an empty `Text` when no argument matches, and a regression test covers the `fish 0 0` invocation path.

### Bug fix

Fish completion requests that resolve to no focused argument no longer crash the daemon. Previously, an unsafe `.get` on `Option` in `Completion.focusText` threw `NoSuchElementException`:

```scala
// before
def focusText: Text = arguments.find(_.position == currentArgument).get.value

// after
def focusText: Text =
  arguments.find(_.position == currentArgument).fold(t"")(_.value)
```

Under the `stackTrace` backstop the exception was rendered to stdout, and fish — which reads stdout as its completion-candidate list — displayed it inline in place of the expected completions.

Closes #1109.