### PR TITLE
exoskeleton: fix fish completion off-by-one for mid-word args

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -125,23 +125,7 @@ package executives:
 
             val rest2 = read(rest.to(List), false, Nil)
 
-            // Fish's `count (commandline --tokenize --cut-at-cursor)` includes the
-            // partial token at the cursor when mid-word, but drops the empty token
-            // at a trailing-space cursor. `position0` (fish's `commandline -C -t`)
-            // is 0 only when the cursor is at the start of an empty token, non-zero
-            // mid-word. For mid-word completion of a *value* (not a flag prefix),
-            // we need `-2` like zsh to point `focus` at the partial. For mid-word
-            // typing of a flag prefix (`-` or `--`) we keep the original `-1` so
-            // the existing flag-completion fallback (which expects focus on the
-            // phantom past the prefix) continues to emit both long and short
-            // aliases.
-            val fishMidWordValue =
-              shell == Shell.Fish && position0 > 0
-              && rest.lastOption.exists(!_.starts(t"-"))
-
-            val focus = focus1 - (
-              if shell == Shell.Zsh || fishMidWordValue then 2 else 1
-            )
+            val focus = focus1 - (if shell == Shell.Zsh then 2 else 1)
 
             val position = if shell == Shell.Bash then Unset else position0
             val tab = Completions.tab(tty, Completions.Tab(arguments.to(List), focus, position0))

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -383,14 +383,12 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             sh"$tool '{completions}' fish 1 0 /dev/null -- abcd ''".exec[Text]()
           .check(_.contains(t"alpha"))
 
-          // Regression check for #1086 part (1): mid-word completion in fish. With the
-          // buggy off-by-one focus calculation, `gentoo` was dropped from the suggestions
-          // and the executive fell back to flag-only output (which here is empty, since
-          // `distribution` has no flags). Position arguments mimic fish's
-          // `count (commandline --tokenize --cut-at-cursor)` (3 — includes partial token
-          // at cursor) and `commandline -C -t` (1 — non-zero indicates mid-word).
+          // Regression check for #1086 / #1116: mid-word completion in fish. Position
+          // arguments match what fish 4.6 actually sends: `count (commandline --tokenize
+          // --cut-at-cursor)` returns 2 (fish cuts *before* the partial — the partial is
+          // not counted) and `commandline -C -t` returns 1 (non-zero indicates mid-word).
           test(m"fish mid-word completion suggests focused subcommand"):
-            sh"$tool '{completions}' fish 3 1 /dev/null -- abcd distribution g".exec[Text]()
+            sh"$tool '{completions}' fish 2 1 /dev/null -- abcd distribution g".exec[Text]()
           .check(_.contains(t"gentoo"))
 
           // Regression check for #1086 part (2): `Suggestion.incomplete` on fish branch.


### PR DESCRIPTION
The fish-completion focus calculation introduced by #1086 was premised on fish's `count (commandline --tokenize --cut-at-cursor)` including the partial token at the cursor when typing mid-word. Empirically (fish 4.6) it does not — fish always cuts *before* the partial, so `count` returns N when typing the (N+1)-th token whether mid-word or trailing-space. The `fishMidWordValue` branch that subtracted 2 from `focus1` therefore shifted positional completions by one slot, producing the symptom that `<cmd> a<TAB>` returned nothing while `<cmd> foo a<TAB>` wrongly suggested completions for the previous slot. Restoring the pre-#1086 formula (`focus = focus0 - 1` for fish, `-2` for zsh only) lands `focus` on the right slot in both cases, and the regression test from #1086 is updated to use the arg shape real fish 4.6 actually sends.

### Bug fix

Fish completion for positional arguments mid-word is no longer shifted by one slot. Previously, completing `amok a<TAB>` returned no candidates while `amok foo a<TAB>` returned candidates intended for the previous slot:

```
$ fish -c "complete -C 'amok a'"
                                  # (no output) — should match "about"
$ fish -c "complete -C 'amok foo a'"
about	find out about Amok        # wrong — should be empty
```

The fix collapses the focus calculation in the fish branch to match real fish 4.6 tokenisation:

```scala
// before
val fishMidWordValue =
  shell == Shell.Fish && position0 > 0
  && rest.lastOption.exists(!_.starts(t"-"))

val focus = focus1 - (if shell == Shell.Zsh || fishMidWordValue then 2 else 1)

// after
val focus = focus1 - (if shell == Shell.Zsh then 2 else 1)
```

Flag-prefix mid-word completion (`--to<TAB>`, `-<TAB>`) is unaffected since the calculation is the same regardless of partial content. The independent LCP-duplicate fix from #1086 in `Completion.serialize` is untouched.

Closes #1116.